### PR TITLE
Fix(coverage): Repair coverage measurement under python-test-action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,13 +185,11 @@ markers = [
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
-source = ["src/gha_workflow_linter"]
+source = ["gha_workflow_linter"]
 omit = [
     "*/tests/*",
     "*/test_*",
     "*/__pycache__/*",
-    "*/venv/*",
-    "*/.venv/*",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

Two related bugs in `[tool.coverage.run]` cause `No data was collected` / 0% coverage when this project is tested via `lfreleng-actions/python-test-action` v1.1.x (which installs the package **non-editably** into `.venv` by default):

1. **`source = ["src/gha_workflow_linter"]`** is a filesystem path, not a package name. coverage.py treats `source` entries with a path separator as path filters; the installed package lives at `.venv/lib/pythonX.Y/site-packages/gha_workflow_linter/...`, which the filter never matched.

2. **`omit` included `*/venv/*` and `*/.venv/*`**. Those globs match the very directory where the non-editable install lives — so even after fixing `source`, the `omit` list would have excluded every measured file.

This is the same class of bug that broke `markdown-table-fixer` on PR [#129](https://github.com/lfreleng-actions/markdown-table-fixer/pull/129). The workflow here is currently pinned to `python-test-action@v1.0.1`, so the regression is latent — it will surface as soon as Dependabot bumps the action to v1.1.x.

## Fix

```diff
 [tool.coverage.run]
-source = ["src/gha_workflow_linter"]
+source = ["gha_workflow_linter"]
 omit = [
     "*/tests/*",
     "*/test_*",
     "*/__pycache__/*",
-    "*/venv/*",
-    "*/.venv/*",
 ]
```

`coverage.py` instruments the package by import name wherever it is loaded from (including `site-packages`).

## Verification

Reproduced the failure pattern with `markdown-table-fixer` (same shape of bug) and verified the fix locally for that project. The same pattern applies here.