### PR TITLE
Test: normalize whitespace for purge-cache assertions

### DIFF
--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -247,9 +247,17 @@ cache:
             )
             # Should fail because --purge-cache is not a valid option for lint
             assert result.exit_code == 2
-            # Strip ANSI color codes for assertion
+            # Strip ANSI color codes for assertion and collapse whitespace
+            # so that Rich panel line wrapping (which can split the message
+            # across lines when the terminal width is narrow on CI) doesn't
+            # break the substring match. Different Click versions also
+            # format the option name with or without surrounding single
+            # quotes, so check for the error prefix and the option name
+            # independently.
             clean_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
-            assert "No such option: --purge-cache" in clean_output
+            normalized_output = re.sub(r"\s+", " ", clean_output)
+            assert "No such option" in normalized_output
+            assert "--purge-cache" in normalized_output
 
         finally:
             Path(config_file).unlink()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,9 +256,16 @@ class TestCLICommands:
 
         # Should fail because --purge-cache is not a valid option for lint
         assert result.exit_code == 2
-        # Strip ANSI color codes for assertion
+        # Strip ANSI color codes for assertion and collapse whitespace so
+        # that Rich panel line wrapping (which can split the message across
+        # lines when the terminal width is narrow on CI) doesn't break the
+        # substring match. Different Click versions also format the option
+        # name with or without surrounding single quotes, so check for the
+        # error prefix and the option name independently.
         clean_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
-        assert "No such option: --purge-cache" in clean_output
+        normalized_output = re.sub(r"\s+", " ", clean_output)
+        assert "No such option" in normalized_output
+        assert "--purge-cache" in normalized_output
 
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.WorkflowScanner")

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -934,9 +934,17 @@ class TestCLIIntegration:
 
             # Should fail because --purge-cache is not a valid option for lint
             assert result.exit_code == 2
-            # Strip ANSI color codes for assertion
+            # Strip ANSI color codes for assertion and collapse whitespace
+            # so that Rich panel line wrapping (which can split the message
+            # across lines when the terminal width is narrow on CI) doesn't
+            # break the substring match. Different Click versions also
+            # format the option name with or without surrounding single
+            # quotes, so check for the error prefix and the option name
+            # independently.
             clean_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
-            assert "No such option: --purge-cache" in clean_output
+            normalized_output = re.sub(r"\s+", " ", clean_output)
+            assert "No such option" in normalized_output
+            assert "--purge-cache" in normalized_output
 
     def test_lint_command_nonexistent_path(self) -> None:
         """Test lint command with nonexistent path."""


### PR DESCRIPTION
## Problem

Three CLI tests that verify the now-removed `--purge-cache` flag is rejected
have started failing on CI (see the dependabot PRs #208 / #209 and
[this run](https://github.com/lfreleng-actions/gha-workflow-linter/actions/runs/26250454952/job/77260147206?pr=209)):

- `tests/test_cache_integration.py::TestCacheIntegration::test_main_command_purge_cache_flag`
- `tests/test_cli.py::TestCLICommands::test_lint_purge_cache`
- `tests/test_cli_comprehensive.py::TestCLIIntegration::test_lint_command_purge_cache`

Each test asserts that the literal string `No such option: --purge-cache`
appears in the CLI output. Click renders that error inside a Rich panel and,
when the terminal width on the CI runner is narrower than the local dev
environment, Rich wraps the message across multiple lines:

```
│ No such option: --purge-cache. Did you mean    │
│ '--no-cache'?                                  │
```

The wrapped output breaks the substring match, even though the error is
emitted correctly.

## Fix

Collapse all whitespace in the captured (ANSI-stripped) output before doing
the substring check, so the assertions are insensitive to where Rich
decides to wrap the panel content. Verified locally by re-running the
three tests under `COLUMNS=40` to force narrow-panel wrapping.

## Test Plan

```
COLUMNS=40 uv run pytest \
  tests/test_cli.py::TestCLICommands::test_lint_purge_cache \
  tests/test_cache_integration.py::TestCacheIntegration::test_main_command_purge_cache_flag \
  tests/test_cli_comprehensive.py::TestCLIIntegration::test_lint_command_purge_cache
```

All three pass.
