### PR TITLE
Fix: mitigate script injection in action + pin Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:f9fa7f851e38bfb19c9de3afbc4b86ae7176ea7aaf94535c31df5458d5849457 # python:3.11-slim
 
 # Set labels for container metadata
 LABEL org.opencontainers.image.title="gha-workflow-linter"

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,11 @@ author: "The Linux Foundation"
 
 inputs:
   path:
-    description: "Path to scan for workflows (default: current directory)"
+    description: >
+      Path to scan for workflows (default: current directory).
+      Input values are passed to the linter as literal strings (they are not
+      subject to shell-variable expansion); use GitHub expression contexts
+      (such as the github.workspace context) for dynamic values.
     required: false
     default: "."
   config-file:
@@ -93,6 +97,18 @@ runs:
     - name: "Run gha-workflow-linter"
       id: gha-workflow-linter
       shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_CONFIG_FILE: ${{ inputs.config-file }}
+        INPUT_LOG_LEVEL: ${{ inputs.log-level }}
+        INPUT_OUTPUT_FORMAT: ${{ inputs.output-format }}
+        INPUT_FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        INPUT_PARALLEL: ${{ inputs.parallel }}
+        INPUT_WORKERS: ${{ inputs.workers }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_REQUIRE_PINNED_SHA: ${{ inputs.require-pinned-sha }}
+        INPUT_SKIP_ACTIONS: ${{ inputs.skip-actions }}
+        INPUT_VALIDATION_METHOD: ${{ inputs.validation-method }}
       run: |
         # Determine command prefix (uvx for PyPI, direct for local)
         if [[ "$USE_UVX" == "true" ]]; then
@@ -102,53 +118,53 @@ runs:
         fi
 
         # Build command arguments
-        args=("${{ inputs.path }}")
+        args=("$INPUT_PATH")
 
-        if [[ -n "${{ inputs.config-file }}" ]]; then
-          args+=(--config "${{ inputs.config-file }}")
+        if [[ -n "$INPUT_CONFIG_FILE" ]]; then
+          args+=(--config "$INPUT_CONFIG_FILE")
         fi
 
-        if [[ -n "${{ inputs.log-level }}" ]]; then
-          args+=(--log-level "${{ inputs.log-level }}")
+        if [[ -n "$INPUT_LOG_LEVEL" ]]; then
+          args+=(--log-level "$INPUT_LOG_LEVEL")
         fi
 
-        if [[ -n "${{ inputs.output-format }}" ]]; then
-          args+=(--format "${{ inputs.output-format }}")
+        if [[ -n "$INPUT_OUTPUT_FORMAT" ]]; then
+          args+=(--format "$INPUT_OUTPUT_FORMAT")
         fi
 
-        if [[ "${{ inputs.fail-on-error }}" == "false" ]]; then
+        if [[ "$INPUT_FAIL_ON_ERROR" == "false" ]]; then
           args+=(--no-fail-on-error)
         fi
 
-        if [[ "${{ inputs.parallel }}" == "false" ]]; then
+        if [[ "$INPUT_PARALLEL" == "false" ]]; then
           args+=(--no-parallel)
         fi
 
-        if [[ -n "${{ inputs.workers }}" ]]; then
-          args+=(--workers "${{ inputs.workers }}")
+        if [[ -n "$INPUT_WORKERS" ]]; then
+          args+=(--workers "$INPUT_WORKERS")
         fi
 
-        if [[ -n "${{ inputs.exclude }}" ]]; then
-          IFS=',' read -ra EXCLUDES <<< "${{ inputs.exclude }}"
+        if [[ -n "$INPUT_EXCLUDE" ]]; then
+          IFS=',' read -ra EXCLUDES <<< "$INPUT_EXCLUDE"
           for exclude in "${EXCLUDES[@]}"; do
             args+=(--exclude "$exclude")
           done
         fi
 
-        if [[ "${{ inputs.require-pinned-sha }}" == "false" ]]; then
+        if [[ "$INPUT_REQUIRE_PINNED_SHA" == "false" ]]; then
           args+=(--no-require-pinned-sha)
         fi
 
-        if [[ "${{ inputs.skip-actions }}" == "true" ]]; then
+        if [[ "$INPUT_SKIP_ACTIONS" == "true" ]]; then
           args+=(--skip-actions)
         fi
 
-        if [[ -n "${{ inputs.validation-method }}" ]]; then
-          args+=(--validation-method "${{ inputs.validation-method }}")
+        if [[ -n "$INPUT_VALIDATION_METHOD" ]]; then
+          args+=(--validation-method "$INPUT_VALIDATION_METHOD")
         fi
 
         # Run gha-workflow-linter and capture output
-        if [[ "${{ inputs.output-format }}" == "json" ]]; then
+        if [[ "$INPUT_OUTPUT_FORMAT" == "json" ]]; then
           output=$($cmd_prefix lint "${args[@]}" --no-cache)
           echo "scan-summary<<EOF" >> "$GITHUB_OUTPUT"
           echo "$output" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Security Findings: #19 (MEDIUM), #20 (LOW), #21 (MEDIUM)

Vulnerability Details:
- Finding #19 (MEDIUM, line 105): inputs.path was template-substituted
  into a bash array assignment:
    args=("${{ inputs.path }}")
  Double quotes prevent word-splitting but NOT command substitution
  from ${{ }} expansion. A path value of '$(id)' causes bash to
  evaluate the command at template-expansion time.

- Finding #20 (LOW, lines 107-146): Multiple inputs were template-
  substituted in [[ ]] comparisons and array additions:
    if [[ -n "${{ inputs.config-file }}" ]]; then
      args+=(--config "${{ inputs.config-file }}")
  Same command substitution risk as #19. While values go into array
  slots (safer than unquoted expansion), the $(cmd) evaluation occurs
  before bash sees the double-quoting.

- Finding #21 (MEDIUM, Dockerfile line 4): FROM without digest:
    FROM python:3.11-slim
  The python:3.11-slim tag is mutable — Docker Hub can update it at
  any time. A compromised or updated base image could inject malicious
  code into builds. The http-api-tool-docker/docker/Containerfile
  correctly pins with @sha256:... — the same pattern applies here.

Remediation Applied:
- All inputs in the 'Run gha-workflow-linter' step now pass through
  the step's 'env:' block (INPUT_PATH, INPUT_CONFIG_FILE, etc.),
  eliminating template-substitution injection entirely.
- Shell code references $INPUT_PATH, $INPUT_CONFIG_FILE, etc.
  instead of ${{ inputs.* }} template expressions.
- Dockerfile FROM now pins to sha256 digest for reproducible,
  tamper-proof builds.

Impact:
- No behavioral change for legitimate callers.
- Dockerfile builds are now deterministic until the digest is
  explicitly updated.

Reference: lfreleng-actions composite action security audit (2025-06)

Signed-off-by: Anil Belur <askb23@gmail.com>
Signed-off-by: Anil Belur <abelur@linuxfoundation.org>
