### PR TITLE
Feat: add Dependabot cooldown for action updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,44 @@ Example output (default behavior, test actions skipped):
   + - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
 ```
 
+### Update Cooldown
+
+To guard against supply-chain attacks and retracted releases, the linter
+can refuse to update an action call to a release until that release has
+been public for a set number of days. This mirrors the
+[Dependabot `cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-)
+policy.
+
+```bash
+# Update to releases at least 7 days old
+gha-workflow-linter lint --auto-fix --auto-latest --cooldown 7
+
+# Disable the cooldown (the default behaviour)
+gha-workflow-linter lint --auto-fix --auto-latest --cooldown 0
+```
+
+When `--cooldown` is not supplied, the linter walks up from the scanned
+path to find a `.github/dependabot.yml` (or `.yaml`) file and reuses its
+`cooldown.default-days` value, preferring the `github-actions` ecosystem.
+The linter reports that value once:
+
+```text
+Using cooldown timer/value [7] from dependabot configuration 🤖
+```
+
+When the linter finds no Dependabot configuration (and no flag sets a
+value) the cooldown defaults to `0`, preserving the original behaviour.
+The linter picks the newest release that satisfies the cooldown window,
+so it still updates an action to an older-but-eligible release when the
+latest release remains inside the window.
+
+> Note: the cooldown relies on a verifiable publication timestamp for
+> each candidate: the release publish date (GitHub API GraphQL/REST) or
+> an annotated tag's tagger date. Lightweight tags carry no creation
+> timestamp of their own, and the Git validation method cannot expose
+> release dates, so the linter skips candidates it cannot date while a
+> cooldown applies.
+
 ### As a Pre-commit Hook
 
 Add to your `.pre-commit-config.yaml`:
@@ -699,6 +737,9 @@ Options:
   --skip-actions             Skip scanning action.yaml/action.yml files
   --no-skip-actions          Scan action.yaml/action.yml files (default)
   --fix-test-calls           Fix actions with 'test' in comments
+  --cooldown INTEGER         Days a release must be public before updating
+                             (defaults to the Dependabot cooldown setting,
+                             then 0)
   --version                  Show version and exit
   --help                     Show this message and exit
 

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
 import logging
 from pathlib import Path
 import re
@@ -130,6 +131,78 @@ def _find_most_specific_version_tag(
     )
 
     return sorted_by_specificity[0]
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp into a timezone-aware ``datetime``.
+
+    GitHub returns timestamps such as ``2026-01-02T03:04:05Z``. The
+    trailing ``Z`` is normalised to ``+00:00`` so ``fromisoformat`` can
+    parse it on all supported Python versions.
+
+    Args:
+        value: An ISO-8601 timestamp string, or ``None``.
+
+    Returns:
+        A timezone-aware ``datetime`` (UTC if no offset was provided), or
+        ``None`` if the value is missing or cannot be parsed.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _select_version_with_cooldown(
+    candidates: list[tuple[str, str, datetime | None]],
+    cooldown_days: int,
+    now: datetime | None = None,
+) -> tuple[str, str] | None:
+    """Pick the newest eligible ``(tag, sha)`` honouring a cooldown window.
+
+    The cooldown enforces a Dependabot-style policy: a release must have
+    been available for at least ``cooldown_days`` days before it is
+    eligible to be selected. This protects against deploying actions that
+    were recently retracted, superseded, or compromised by a supply-chain
+    attack.
+
+    Args:
+        candidates: ``(tag, sha, published)`` tuples ordered newest-first.
+            ``published`` may be ``None`` when a release date is unknown.
+        cooldown_days: Minimum age in days. Values ``<= 0`` disable the
+            cooldown and simply return the newest candidate.
+        now: Reference time (defaults to the current UTC time); primarily
+            an injection point for tests.
+
+    Returns:
+        The first eligible ``(tag, sha)`` tuple, or ``None`` when no
+        candidate satisfies the cooldown. When the cooldown is active and
+        a candidate's release date is unknown, it is skipped because its
+        age cannot be verified.
+    """
+    if not candidates:
+        return None
+
+    if cooldown_days <= 0:
+        tag, sha, _ = candidates[0]
+        return (tag, sha)
+
+    reference = now or datetime.now(timezone.utc)
+    cutoff = reference - timedelta(days=cooldown_days)
+
+    for tag, sha, published in candidates:
+        if published is None:
+            # Cannot verify the release age; skip under an active cooldown.
+            continue
+        if published <= cutoff:
+            return (tag, sha)
+
+    return None
 
 
 class AutoFixer:
@@ -1808,6 +1881,8 @@ class AutoFixer:
                     {alias}: repository(owner: "{owner}", name: "{base_name}") {{
                         latestRelease {{
                             tagName
+                            createdAt
+                            publishedAt
                             tagCommit {{
                                 oid
                             }}
@@ -1820,6 +1895,9 @@ class AutoFixer:
                                         oid
                                     }}
                                     ... on Tag {{
+                                        tagger {{
+                                            date
+                                        }}
                                         target {{
                                             ... on Commit {{
                                                 oid
@@ -1854,20 +1932,56 @@ class AutoFixer:
                 if not repo_data:
                     continue
 
-                # Collect all tags first for specificity resolution
+                # Collect all tags for specificity resolution. ``tag_dates``
+                # records a verifiable *publication* timestamp per tag so the
+                # cooldown can reason about release age: the tagger date for
+                # annotated tags. Lightweight tags carry no creation
+                # timestamp of their own (only the commit they point at,
+                # which may be far older than the tag), so they are recorded
+                # as undated and skipped while a cooldown applies. The latest
+                # release's publication date is layered on separately by
+                # ``_select_cooldown_version_graphql``.
                 refs = repo_data.get("refs", {}).get("nodes", [])
                 all_tags = []
+                tag_dates: dict[str, datetime | None] = {}
                 for ref in refs:
                     if ActionCallPatterns.VERSION_TAG_PATTERN.match(
                         ref["name"]
                     ):
                         target = ref.get("target", {})
                         if "oid" in target:
+                            # Lightweight tag: target is the commit itself and
+                            # has no verifiable tag-creation time.
                             all_tags.append((ref["name"], target["oid"]))
+                            tag_dates[ref["name"]] = None
                         elif "target" in target and "oid" in target["target"]:
+                            # Annotated tag: use the tagger date as the
+                            # publication timestamp.
                             all_tags.append(
                                 (ref["name"], target["target"]["oid"])
                             )
+                            tagger = target.get("tagger") or {}
+                            tag_dates[ref["name"]] = _parse_iso_datetime(
+                                tagger.get("date")
+                            )
+
+                # When a cooldown is active, select the newest version that
+                # has been available long enough, falling back to older
+                # eligible versions when the very latest is still "warming".
+                if self.config.cooldown_days > 0:
+                    cooldown_choice = self._select_cooldown_version_graphql(
+                        repo_data, all_tags, tag_dates
+                    )
+                    if cooldown_choice:
+                        results[repo_key] = cooldown_choice
+                    else:
+                        self.logger.debug(
+                            "No release for %s satisfies the %d-day "
+                            "cooldown; leaving reference unchanged",
+                            repo_key,
+                            self.config.cooldown_days,
+                        )
+                    continue
 
                 # Try latestRelease first, but only if prereleases are NOT allowed
                 # (latestRelease excludes prereleases by GitHub's API design)
@@ -1929,7 +2043,107 @@ class AutoFixer:
             self.logger.debug(f"GraphQL batch query failed: {e}")
             return {}
 
-    async def _get_latest_version_single(
+    def _select_cooldown_version_graphql(
+        self,
+        repo_data: dict[str, Any],
+        all_tags: list[tuple[str, str]],
+        tag_dates: dict[str, datetime | None],
+    ) -> tuple[str, str] | None:
+        """Choose a cooldown-eligible ``(tag, sha)`` from GraphQL repo data.
+
+        Builds a newest-first list of version-tag candidates (each
+        annotated with a verifiable publication timestamp) and delegates
+        to :func:`_select_version_with_cooldown`. The latest release's
+        publish date is layered on for its tag because it best reflects
+        when the version became consumable.
+
+        Args:
+            repo_data: The per-repository GraphQL response fragment.
+            all_tags: ``(tag, sha)`` pairs for every matching version tag.
+            tag_dates: Mapping of tag name to its publication ``datetime``
+                (``None`` when no verifiable publication time exists, e.g.
+                lightweight tags).
+
+        Returns:
+            The newest eligible ``(tag, sha)`` tuple, or ``None`` when no
+            version satisfies the configured cooldown.
+        """
+        # Prefer the published date of the latest release, which better
+        # reflects when the version became available to consumers.
+        latest_release = repo_data.get("latestRelease")
+        if latest_release:
+            release_tag = latest_release.get("tagName")
+            release_date = _parse_iso_datetime(
+                latest_release.get("publishedAt")
+                or latest_release.get("createdAt")
+            )
+            if release_tag and release_date is not None:
+                tag_dates[release_tag] = release_date
+
+        candidates = sorted(
+            ((name, sha, tag_dates.get(name)) for name, sha in all_tags),
+            key=lambda item: (
+                _parse_version(item[0]),
+                _get_version_specificity(item[0]),
+            ),
+            reverse=True,
+        )
+
+        selected = _select_version_with_cooldown(
+            candidates, self.config.cooldown_days
+        )
+        if not selected:
+            return None
+
+        tag, sha = selected
+        # Resolve to the most specific equivalent tag for the chosen SHA
+        # (e.g. prefer v8.0.0 over v8 when both point at the same commit).
+        specific_tag = _find_most_specific_version_tag(tag, sha, all_tags)
+        return (specific_tag, sha)
+
+    def _select_release_tag_with_cooldown(
+        self,
+        repo_key: str,
+        sorted_releases: list[dict[str, Any]],
+    ) -> str | None:
+        """Pick a REST release tag honouring the configured cooldown.
+
+        Args:
+            repo_key: Repository identifier (used for debug logging).
+            sorted_releases: REST API release objects ordered newest
+                version first.
+
+        Returns:
+            The chosen tag name, or ``None`` when no release satisfies the
+            cooldown window. When the cooldown is disabled the newest tag
+            is returned unchanged.
+        """
+        if self.config.cooldown_days <= 0:
+            return sorted_releases[0].get("tag_name")
+
+        candidates = [
+            (
+                release.get("tag_name", ""),
+                "",  # SHA is resolved separately by the caller
+                _parse_iso_datetime(
+                    release.get("published_at") or release.get("created_at")
+                ),
+            )
+            for release in sorted_releases
+        ]
+        selected = _select_version_with_cooldown(
+            candidates, self.config.cooldown_days
+        )
+        if selected is None:
+            self.logger.debug(
+                "No release for %s satisfies the %d-day cooldown",
+                repo_key,
+                self.config.cooldown_days,
+            )
+            return None
+        return selected[0]
+
+    async def _get_latest_version_single(  # noqa: PLR0911
         self, repo_key: str
     ) -> tuple[str, str] | None:
         """
@@ -1976,7 +2190,12 @@ class AutoFixer:
                             key=lambda r: _parse_version(r.get("tag_name", "")),
                             reverse=True,
                         )
-                        tag = sorted_releases[0].get("tag_name")
+                        tag = self._select_release_tag_with_cooldown(
+                            repo_key, sorted_releases
+                        )
+                        if tag is None:
+                            # No release satisfies the cooldown window.
+                            return None
                         # Get SHA for this tag
                         sha_info = await self._get_commit_sha_for_reference(
                             repo_key, tag
@@ -2001,6 +2220,16 @@ class AutoFixer:
                         )
                     ]
                     if clean_tags:
+                        if self.config.cooldown_days > 0:
+                            # The tags endpoint carries no release dates, so
+                            # we cannot verify the cooldown window here.
+                            self.logger.debug(
+                                "Cooldown active but %s exposes no release "
+                                "dates via the tags API; leaving reference "
+                                "unchanged",
+                                repo_key,
+                            )
+                            return None
                         sorted_tags = sorted(
                             clean_tags,
                             key=lambda t: _parse_version(t.get("name", "")),
@@ -2029,6 +2258,17 @@ class AutoFixer:
                         if ActionCallPatterns.VERSION_TAG_PATTERN.match(tag)
                     ]
                     if clean_tags:
+                        if self.config.cooldown_days > 0:
+                            # ``git ls-remote`` does not expose tag dates, so
+                            # the cooldown cannot be enforced for the Git
+                            # validation method.
+                            self.logger.debug(
+                                "Cooldown active but release dates are "
+                                "unavailable via Git for %s; leaving "
+                                "reference unchanged",
+                                repo_key,
+                            )
+                            return None
                         sorted_versions = sorted(
                             clean_tags, key=_parse_version, reverse=True
                         )

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -28,6 +28,7 @@ from .auto_fix import AutoFixer
 from .cache import CachePrimeReport, ValidationCache
 from .config import ConfigManager
 from .console import console
+from .dependabot import resolve_cooldown
 from .exceptions import (
     AuthenticationError,
     ConfigurationError,
@@ -66,6 +67,51 @@ def _get_relative_path(file_path: Path, base_path: Path) -> Path:
     except ValueError:
         # If relative path can't be computed, use the original path
         return file_path
+
+
+def _resolve_cooldown_days(
+    explicit: int | None,
+    scan_path: Path,
+    quiet: bool,
+    output_format: str,
+) -> int:
+    """Resolve the action-update cooldown window in days.
+
+    Precedence:
+        1. An explicit ``--cooldown`` CLI value.
+        2. The repository's Dependabot ``cooldown.default-days`` setting.
+        3. ``0`` (cooldown disabled; original behaviour).
+
+    When the value is sourced from the Dependabot configuration a single
+    informational line is emitted (unless suppressed by quiet/JSON mode).
+
+    Args:
+        explicit: The value passed via ``--cooldown`` (``None`` if unset).
+        scan_path: Path being linted; used to locate the Dependabot config.
+        quiet: Whether quiet mode is active.
+        output_format: The selected output format (``text`` or ``json``).
+
+    Returns:
+        The resolved cooldown window in days.
+    """
+    if explicit is not None:
+        return explicit
+
+    cooldown = resolve_cooldown(scan_path)
+    if cooldown is None:
+        return 0
+
+    if not quiet and output_format != "json":
+        # ``markup=False`` keeps the literal square brackets visible in the
+        # terminal instead of having Rich parse them as style tags. Emoji
+        # shortcodes are still rendered because emoji handling is a
+        # separate Rich option.
+        console.print(
+            f"Using cooldown timer/value [{cooldown.days}] from "
+            "dependabot configuration :robot_face:",
+            markup=False,
+        )
+    return cooldown.days
 
 
 def help_callback(ctx: typer.Context, _param: Any, value: bool) -> None:
@@ -185,6 +231,7 @@ def _preprocess_args_for_default_command(
         "--exclude",
         "-e",
         "--cache-ttl",
+        "--cooldown",
         "--validation-method",
         "--log-level",
         "--format",
@@ -457,6 +504,17 @@ def lint(
         "--fix-test-calls",
         help="Enable auto-fixing action calls with 'test' in comments (default: disabled unless overridden in config, test actions are skipped)",
     ),
+    cooldown: int | None = typer.Option(
+        None,
+        "--cooldown",
+        help=(
+            "Minimum number of days an action release must have been "
+            "available before updating to it. When unset, the value is "
+            "read from the repository's .github/dependabot.yml cooldown "
+            "setting, falling back to 0 (no cooldown)."
+        ),
+        min=0,
+    ),
     files: list[str] | None = typer.Option(
         None,
         "--files",
@@ -539,6 +597,9 @@ def lint(
         # Enable auto-fixing for actions with 'test' in comments (default is to skip them)
         gha-workflow-linter lint --auto-fix --fix-test-calls
 
+        # Only update to releases at least 7 days old (supply-chain cooldown)
+        gha-workflow-linter lint --auto-fix --auto-latest --cooldown 7
+
         # Scan only specific files
         gha-workflow-linter lint --files .github/workflows/ci.yml
 
@@ -600,6 +661,7 @@ def lint(
             two_space_comments=two_space_comments,
             skip_actions=skip_actions,
             fix_test_calls=fix_test_calls,
+            cooldown=cooldown,
             files=files,
         )
 
@@ -628,6 +690,13 @@ def lint(
             config.skip_actions = skip_actions
         if fix_test_calls is not None:
             config.fix_test_calls = fix_test_calls
+
+        # Resolve the action-update cooldown window. Precedence: explicit
+        # --cooldown flag, then the repository's Dependabot configuration,
+        # then 0 (no cooldown / original behaviour).
+        config.cooldown_days = _resolve_cooldown_days(
+            cooldown, path, quiet, output_format
+        )
 
         # Apply validation method override if specified
         if validation_method is not None:

--- a/src/gha_workflow_linter/dependabot.py
+++ b/src/gha_workflow_linter/dependabot.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Discovery and parsing of Dependabot cooldown configuration.
+
+GitHub Dependabot supports a ``cooldown`` stanza that delays opening
+dependency-bump pull requests until a release has been available for a
+minimum number of days. This guards against supply-chain attacks and
+hastily-retracted releases.
+
+This module locates the repository's ``.github/dependabot.yml`` (or
+``.yaml``) file by walking up the directory hierarchy from a starting
+path, then extracts the ``cooldown.default-days`` value so the linter can
+apply the same policy when updating action calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Ecosystem name Dependabot uses for GitHub Actions updates. We prefer the
+# cooldown configured for this ecosystem because that is what governs the
+# action-call updates this linter performs.
+_GITHUB_ACTIONS_ECOSYSTEM = "github-actions"
+
+# Candidate file names, in the order Dependabot itself resolves them.
+_DEPENDABOT_FILENAMES = ("dependabot.yml", "dependabot.yaml")
+
+
+@dataclass(frozen=True)
+class DependabotCooldown:
+    """Result of resolving a Dependabot cooldown value.
+
+    Attributes:
+        days: The ``cooldown.default-days`` value that was parsed.
+        source: Path to the ``dependabot.yml``/``.yaml`` file the value
+            was read from.
+        ecosystem: The ``package-ecosystem`` the cooldown was taken from.
+    """
+
+    days: int
+    source: Path
+    ecosystem: str
+
+
+def find_dependabot_config(start_path: Path) -> Path | None:
+    """Locate the nearest ``.github/dependabot.{yml,yaml}`` file.
+
+    Walks up the directory hierarchy from ``start_path`` (or its parent if
+    ``start_path`` is a file) until a Dependabot configuration file is
+    found or the filesystem root is reached.
+
+    Args:
+        start_path: Path to begin searching from (typically the directory
+            being linted).
+
+    Returns:
+        Path to the Dependabot configuration file, or ``None`` if no file
+        is found.
+    """
+    start = start_path.resolve()
+    search_dir = start if start.is_dir() else start.parent
+
+    for directory in (search_dir, *search_dir.parents):
+        github_dir = directory / ".github"
+        if not github_dir.is_dir():
+            continue
+        for filename in _DEPENDABOT_FILENAMES:
+            candidate = github_dir / filename
+            if candidate.is_file():
+                return candidate
+
+    return None
+
+
+def _extract_cooldown_days(
+    config_path: Path,
+) -> tuple[int, str] | None:
+    """Parse ``cooldown.default-days`` from a Dependabot config file.
+
+    Prefers the cooldown configured for the ``github-actions`` ecosystem,
+    falling back to the first ecosystem that declares a cooldown.
+
+    Args:
+        config_path: Path to the Dependabot configuration file.
+
+    Returns:
+        A ``(days, ecosystem)`` tuple, or ``None`` if no cooldown is
+        configured or the file cannot be parsed.
+    """
+    try:
+        with open(config_path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except (OSError, yaml.YAMLError) as exc:
+        logger.debug(
+            "Could not read Dependabot config %s: %s", config_path, exc
+        )
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    updates = data.get("updates")
+    if not isinstance(updates, list):
+        return None
+
+    fallback: tuple[int, str] | None = None
+
+    for update in updates:
+        if not isinstance(update, dict):
+            continue
+        cooldown = update.get("cooldown")
+        if not isinstance(cooldown, dict):
+            continue
+        days = cooldown.get("default-days")
+        if not isinstance(days, int) or isinstance(days, bool) or days < 0:
+            continue
+
+        ecosystem = str(update.get("package-ecosystem", ""))
+        if ecosystem == _GITHUB_ACTIONS_ECOSYSTEM:
+            return days, ecosystem
+        if fallback is None:
+            fallback = (days, ecosystem)
+
+    return fallback
+
+
+def resolve_cooldown(start_path: Path) -> DependabotCooldown | None:
+    """Resolve the Dependabot cooldown applicable to ``start_path``.
+
+    Args:
+        start_path: Path being linted; used to locate the repository's
+            Dependabot configuration.
+
+    Returns:
+        A :class:`DependabotCooldown` describing the parsed value, or
+        ``None`` when no usable cooldown configuration is found.
+    """
+    config_path = find_dependabot_config(start_path)
+    if config_path is None:
+        return None
+
+    extracted = _extract_cooldown_days(config_path)
+    if extracted is None:
+        return None
+
+    days, ecosystem = extracted
+    return DependabotCooldown(
+        days=days, source=config_path, ecosystem=ecosystem
+    )

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -421,6 +421,15 @@ class Config(BaseModel):
         default=False,
         description="Enable action call fixes with test-related keywords in comments (e.g., test, testing)",
     )
+    cooldown_days: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Minimum number of days an action release must have been "
+            "available before it is eligible for an update (0 disables "
+            "the cooldown)"
+        ),
+    )
 
     # pydantic BaseModel subclasses with all-defaulted fields require no
     # arguments (keyword args are still accepted), but basedpyright reports
@@ -508,6 +517,14 @@ class CLIOptions(BaseModel):
     )
     fix_test_calls: bool | None = Field(
         default=None, description="Fix action calls with test comments"
+    )
+    cooldown: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Minimum days a release must be available before updating "
+            "(falls back to Dependabot config, then 0)"
+        ),
     )
     files: list[str] | None = Field(
         default=None, description="Specific files to scan (supports wildcards)"

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for cooldown-aware version selection in the auto-fixer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import logging
+from typing import TYPE_CHECKING, Any
+
+from gha_workflow_linter import cli
+from gha_workflow_linter.auto_fix import (
+    AutoFixer,
+    _parse_iso_datetime,
+    _select_version_with_cooldown,
+)
+from gha_workflow_linter.models import Config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+NOW = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+
+def _days_ago(days: int) -> datetime:
+    return NOW - timedelta(days=days)
+
+
+def _iso_days_ago(days: int) -> str:
+    return _days_ago(days).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_fixer(cooldown_days: int) -> AutoFixer:
+    """Build an AutoFixer without running its heavyweight ``__init__``.
+
+    The cooldown selection helpers only rely on ``config`` and ``logger``,
+    so we bypass the cache priming and network client setup.
+    """
+    fixer = AutoFixer.__new__(AutoFixer)
+    fixer.config = Config(cooldown_days=cooldown_days)
+    fixer.logger = logging.getLogger("test.cooldown")
+    return fixer
+
+
+class TestParseIsoDatetime:
+    """Tests for ISO-8601 timestamp parsing."""
+
+    def test_parses_zulu_suffix(self) -> None:
+        parsed = _parse_iso_datetime("2026-01-02T03:04:05Z")
+        assert parsed == datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+    def test_parses_explicit_offset(self) -> None:
+        parsed = _parse_iso_datetime("2026-01-02T03:04:05+00:00")
+        assert parsed is not None
+        assert parsed.tzinfo is not None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert _parse_iso_datetime(None) is None
+        assert _parse_iso_datetime("") is None
+
+    def test_returns_none_for_garbage(self) -> None:
+        assert _parse_iso_datetime("not-a-date") is None
+
+
+class TestSelectVersionWithCooldown:
+    """Tests for the cooldown selection algorithm."""
+
+    def test_disabled_cooldown_returns_newest(self) -> None:
+        candidates: list[tuple[str, str, datetime | None]] = [
+            ("v3", "sha3", _days_ago(1)),
+            ("v2", "sha2", _days_ago(30)),
+        ]
+        assert _select_version_with_cooldown(candidates, 0) == ("v3", "sha3")
+
+    def test_negative_cooldown_returns_newest(self) -> None:
+        candidates: list[tuple[str, str, datetime | None]] = [
+            ("v3", "sha3", _days_ago(1))
+        ]
+        assert _select_version_with_cooldown(candidates, -5) == ("v3", "sha3")
+
+    def test_skips_versions_inside_window(self) -> None:
+        candidates: list[tuple[str, str, datetime | None]] = [
+            ("v3", "sha3", _days_ago(2)),  # too new
+            ("v2", "sha2", _days_ago(10)),  # eligible
+            ("v1", "sha1", _days_ago(40)),
+        ]
+        assert _select_version_with_cooldown(candidates, 7, now=NOW) == (
+            "v2",
+            "sha2",
+        )
+
+    def test_newest_eligible_when_all_old(self) -> None:
+        candidates: list[tuple[str, str, datetime | None]] = [
+            ("v3", "sha3", _days_ago(8)),
+            ("v2", "sha2", _days_ago(20)),
+        ]
+        assert _select_version_with_cooldown(candidates, 7, now=NOW) == (
+            "v3",
+            "sha3",
+        )
+
+    def test_boundary_exactly_at_cutoff_is_eligible(self) -> None:
+        candidates: list[tuple[str, str, datetime | None]] = [
+            ("v1", "sha1", _days_ago(7))
+        ]
+        assert _select_version_with_cooldown(candidates, 7, now=NOW) == (
+            "v1",
+            "sha1",
+        )
+
+    def test_returns_none_when_all_too_new(self) -> None:
+        candidates: list[tuple[str, str, datetime | None]] = [
+            ("v3", "sha3", _days_ago(1)),
+            ("v2", "sha2", _days_ago(3)),
+        ]
+        assert _select_version_with_cooldown(candidates, 7, now=NOW) is None
+
+    def test_skips_unknown_dates_under_cooldown(self) -> None:
+        candidates: list[tuple[str, str, datetime | None]] = [
+            ("v3", "sha3", None),  # unknown date, cannot verify
+            ("v2", "sha2", _days_ago(30)),
+        ]
+        assert _select_version_with_cooldown(candidates, 7, now=NOW) == (
+            "v2",
+            "sha2",
+        )
+
+    def test_returns_none_for_empty(self) -> None:
+        assert _select_version_with_cooldown([], 7) is None
+
+
+class TestSelectCooldownVersionGraphql:
+    """Tests for GraphQL cooldown selection wiring on the AutoFixer."""
+
+    def test_skips_release_inside_window(self) -> None:
+        fixer = _make_fixer(7)
+        repo_data: dict[str, Any] = {
+            "latestRelease": {
+                "tagName": "v3",
+                "publishedAt": _iso_days_ago(2),
+                "tagCommit": {"oid": "sha3"},
+            }
+        }
+        all_tags = [("v3", "sha3"), ("v2", "sha2")]
+        tag_dates: dict[str, datetime | None] = {
+            "v3": _days_ago(2),
+            "v2": _days_ago(20),
+        }
+        assert fixer._select_cooldown_version_graphql(
+            repo_data, all_tags, tag_dates
+        ) == ("v2", "sha2")
+
+    def test_selects_release_when_old_enough(self) -> None:
+        fixer = _make_fixer(7)
+        repo_data: dict[str, Any] = {
+            "latestRelease": {
+                "tagName": "v3",
+                "publishedAt": _iso_days_ago(30),
+                "tagCommit": {"oid": "sha3"},
+            }
+        }
+        all_tags = [("v3", "sha3"), ("v2", "sha2")]
+        tag_dates: dict[str, datetime | None] = {
+            "v3": _days_ago(30),
+            "v2": _days_ago(60),
+        }
+        assert fixer._select_cooldown_version_graphql(
+            repo_data, all_tags, tag_dates
+        ) == ("v3", "sha3")
+
+    def test_prefers_more_specific_tag_for_sha(self) -> None:
+        fixer = _make_fixer(7)
+        repo_data: dict[str, Any] = {}
+        # v8 and v8.0.0 point at the same commit; the more specific tag wins.
+        all_tags = [("v8", "sha8"), ("v8.0.0", "sha8")]
+        tag_dates: dict[str, datetime | None] = {
+            "v8": _days_ago(30),
+            "v8.0.0": _days_ago(30),
+        }
+        assert fixer._select_cooldown_version_graphql(
+            repo_data, all_tags, tag_dates
+        ) == ("v8.0.0", "sha8")
+
+    def test_returns_none_when_no_tags(self) -> None:
+        fixer = _make_fixer(7)
+        assert fixer._select_cooldown_version_graphql({}, [], {}) is None
+
+
+class TestResolveCooldownDays:
+    """Tests for the CLI cooldown resolution precedence."""
+
+    def test_explicit_flag_takes_precedence(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        # Even with a Dependabot config present, the explicit value wins.
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir()
+        (github_dir / "dependabot.yml").write_text(
+            "version: 2\nupdates:\n  - package-ecosystem: github-actions\n"
+            "    directory: /\n    cooldown:\n      default-days: 7\n",
+            encoding="utf-8",
+        )
+        printed: list[str] = []
+        monkeypatch.setattr(
+            "gha_workflow_linter.cli.console.print",
+            lambda *args, **kwargs: printed.append(str(args[0])),
+        )
+        result = cli._resolve_cooldown_days(
+            3, tmp_path, quiet=False, output_format="text"
+        )
+        assert result == 3
+        # No Dependabot message when the flag is explicit.
+        assert printed == []
+
+    def test_falls_back_to_dependabot(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir()
+        (github_dir / "dependabot.yml").write_text(
+            "version: 2\nupdates:\n  - package-ecosystem: github-actions\n"
+            "    directory: /\n    cooldown:\n      default-days: 7\n",
+            encoding="utf-8",
+        )
+        printed: list[str] = []
+        monkeypatch.setattr(
+            "gha_workflow_linter.cli.console.print",
+            lambda *args, **kwargs: printed.append(str(args[0])),
+        )
+        result = cli._resolve_cooldown_days(
+            None, tmp_path, quiet=False, output_format="text"
+        )
+        assert result == 7
+        assert len(printed) == 1
+        assert "[7]" in printed[0]
+        assert "dependabot configuration" in printed[0]
+
+    def test_defaults_to_zero(self, tmp_path: Path, monkeypatch: Any) -> None:
+        printed: list[str] = []
+        monkeypatch.setattr(
+            "gha_workflow_linter.cli.console.print",
+            lambda *args, **kwargs: printed.append(str(args[0])),
+        )
+        result = cli._resolve_cooldown_days(
+            None, tmp_path, quiet=False, output_format="text"
+        )
+        assert result == 0
+        assert printed == []
+
+    def test_quiet_suppresses_message(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir()
+        (github_dir / "dependabot.yml").write_text(
+            "version: 2\nupdates:\n  - package-ecosystem: github-actions\n"
+            "    directory: /\n    cooldown:\n      default-days: 7\n",
+            encoding="utf-8",
+        )
+        printed: list[str] = []
+        monkeypatch.setattr(
+            "gha_workflow_linter.cli.console.print",
+            lambda *args, **kwargs: printed.append(str(args[0])),
+        )
+        result = cli._resolve_cooldown_days(
+            None, tmp_path, quiet=True, output_format="text"
+        )
+        assert result == 7
+        assert printed == []

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for Dependabot cooldown discovery and parsing."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+from gha_workflow_linter.dependabot import (
+    DependabotCooldown,
+    find_dependabot_config,
+    resolve_cooldown,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+GITHUB_ACTIONS_CONFIG = textwrap.dedent(
+    """\
+    version: 2
+    updates:
+      - package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+          interval: "weekly"
+        cooldown:
+          default-days: 7
+    """
+)
+
+
+def _write_dependabot(
+    repo_root: Path, content: str, filename: str = "dependabot.yml"
+) -> Path:
+    github_dir = repo_root / ".github"
+    github_dir.mkdir(parents=True, exist_ok=True)
+    config_path = github_dir / filename
+    config_path.write_text(content, encoding="utf-8")
+    return config_path
+
+
+class TestFindDependabotConfig:
+    """Tests for locating the Dependabot configuration file."""
+
+    def test_finds_yml_in_same_directory(self, tmp_path: Path) -> None:
+        config_path = _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        assert find_dependabot_config(tmp_path) == config_path
+
+    def test_finds_yaml_extension(self, tmp_path: Path) -> None:
+        config_path = _write_dependabot(
+            tmp_path, GITHUB_ACTIONS_CONFIG, filename="dependabot.yaml"
+        )
+        assert find_dependabot_config(tmp_path) == config_path
+
+    def test_walks_up_directory_hierarchy(self, tmp_path: Path) -> None:
+        config_path = _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        assert find_dependabot_config(nested) == config_path
+
+    def test_accepts_file_as_start_path(self, tmp_path: Path) -> None:
+        config_path = _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+        workflow.parent.mkdir(parents=True, exist_ok=True)
+        workflow.write_text("name: ci\n", encoding="utf-8")
+        assert find_dependabot_config(workflow) == config_path
+
+    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
+        assert find_dependabot_config(tmp_path) is None
+
+    def test_prefers_yml_over_yaml(self, tmp_path: Path) -> None:
+        yml = _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        _write_dependabot(
+            tmp_path, GITHUB_ACTIONS_CONFIG, filename="dependabot.yaml"
+        )
+        assert find_dependabot_config(tmp_path) == yml
+
+
+class TestResolveCooldown:
+    """Tests for resolving the cooldown value from configuration."""
+
+    def test_resolves_github_actions_cooldown(self, tmp_path: Path) -> None:
+        config_path = _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        result = resolve_cooldown(tmp_path)
+        assert result == DependabotCooldown(
+            days=7, source=config_path, ecosystem="github-actions"
+        )
+
+    def test_prefers_github_actions_over_other_ecosystems(
+        self, tmp_path: Path
+    ) -> None:
+        content = textwrap.dedent(
+            """\
+            version: 2
+            updates:
+              - package-ecosystem: "uv"
+                directory: "/"
+                cooldown:
+                  default-days: 3
+              - package-ecosystem: "github-actions"
+                directory: "/"
+                cooldown:
+                  default-days: 14
+            """
+        )
+        _write_dependabot(tmp_path, content)
+        result = resolve_cooldown(tmp_path)
+        assert result is not None
+        assert result.days == 14
+        assert result.ecosystem == "github-actions"
+
+    def test_falls_back_to_other_ecosystem(self, tmp_path: Path) -> None:
+        content = textwrap.dedent(
+            """\
+            version: 2
+            updates:
+              - package-ecosystem: "uv"
+                directory: "/"
+                cooldown:
+                  default-days: 5
+            """
+        )
+        _write_dependabot(tmp_path, content)
+        result = resolve_cooldown(tmp_path)
+        assert result is not None
+        assert result.days == 5
+        assert result.ecosystem == "uv"
+
+    def test_returns_none_without_cooldown(self, tmp_path: Path) -> None:
+        content = textwrap.dedent(
+            """\
+            version: 2
+            updates:
+              - package-ecosystem: "github-actions"
+                directory: "/"
+                schedule:
+                  interval: "weekly"
+            """
+        )
+        _write_dependabot(tmp_path, content)
+        assert resolve_cooldown(tmp_path) is None
+
+    def test_returns_none_without_config(self, tmp_path: Path) -> None:
+        assert resolve_cooldown(tmp_path) is None
+
+    def test_ignores_invalid_default_days(self, tmp_path: Path) -> None:
+        content = textwrap.dedent(
+            """\
+            version: 2
+            updates:
+              - package-ecosystem: "github-actions"
+                directory: "/"
+                cooldown:
+                  default-days: "not-a-number"
+            """
+        )
+        _write_dependabot(tmp_path, content)
+        assert resolve_cooldown(tmp_path) is None
+
+    def test_ignores_malformed_yaml(self, tmp_path: Path) -> None:
+        _write_dependabot(tmp_path, "::: not valid yaml :::\n")
+        assert resolve_cooldown(tmp_path) is None
+
+    def test_zero_days_is_respected(self, tmp_path: Path) -> None:
+        content = textwrap.dedent(
+            """\
+            version: 2
+            updates:
+              - package-ecosystem: "github-actions"
+                directory: "/"
+                cooldown:
+                  default-days: 0
+            """
+        )
+        _write_dependabot(tmp_path, content)
+        result = resolve_cooldown(tmp_path)
+        assert result is not None
+        assert result.days == 0


### PR DESCRIPTION
## Summary

Adds a supply-chain **cooldown** to the auto-update logic. The linter will
only update an action call to a release once that release has been public
for a configurable number of days. This mirrors the
[Dependabot `cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-)
policy and protects against deploying actions that were retracted,
superseded, or compromised by a successful supply-chain attack shortly
after shipping.

## Motivation

An org-wide Dependabot cooldown timer now delays dependency-bump PRs for
seven days:

```yaml
cooldown:
  default-days: 7
```

This change lets `gha-workflow-linter` honour the same policy when it
auto-updates pinned action calls, so the linter and Dependabot stay
consistent.

## What changed

- **New `--cooldown N` CLI flag** (and `Config.cooldown_days`) that sets the
  minimum release age in days. The default of `0` preserves the previous
  behaviour (update to the newest release).
- **Dependabot config parser** (`dependabot.py`): walks up from the scanned
  path to locate `.github/dependabot.yml` / `.yaml` and reads
  `cooldown.default-days`, preferring the `github-actions` ecosystem.
  - Resolution precedence: explicit `--cooldown` flag → Dependabot config
    value → `0`.
  - When the value originates from Dependabot it is reported once, e.g.:

    ```text
    Using cooldown timer/value [7] from dependabot configuration 🤖
    ```

    The brackets are emitted with Rich `markup=False` so they render
    literally instead of being parsed as style tags.
- **Cooldown-aware version selection** in the GraphQL batch and REST release
  paths: the linter selects the newest release whose publication timestamp
  is old enough, falling back to an older-but-eligible release when the
  latest is still inside the window. Eligibility uses a verifiable
  publication timestamp — the release `publishedAt`/`createdAt`, or an
  annotated tag's `tagger.date`. Commit dates are deliberately **not** used,
  since a freshly-created tag pointing at an old commit would otherwise
  bypass the cooldown. Undated sources (lightweight tags, the tags-only REST
  fallback, and the Git validation method) are skipped while a cooldown
  applies, because release age cannot be verified there.

## Tests

- `tests/test_dependabot.py` — discovery (walk-up, `.yml`/`.yaml`,
  file-vs-dir start), ecosystem preference, malformed/missing config.
- `tests/test_cooldown.py` — ISO date parsing, the cooldown selection
  algorithm (boundary, all-too-new, unknown dates), the GraphQL selection
  wiring, and CLI resolution precedence + output behaviour.
- Full suite: 651 passed, 22 skipped; coverage 75%.

## Notes

The cooldown relies on a verifiable publication timestamp for each
candidate: the release publish date or an annotated tag's tagger date,
which the GitHub API (GraphQL/REST) validation method exposes. Lightweight
tags carry no creation timestamp of their own, and the Git validation
method cannot expose release dates, so the linter skips candidates it
cannot date while a cooldown applies. Documented in the README.