### PR TITLE
Fix: Validate subdirectory actions via Git method

### DIFF
--- a/src/gha_workflow_linter/git_validator.py
+++ b/src/gha_workflow_linter/git_validator.py
@@ -23,6 +23,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _base_repository(repository: str) -> str:
+    """Return the ``owner/repo`` base, stripping any action subpath.
+
+    Monorepo / subdirectory actions are referenced as ``owner/repo/path``
+    (for example ``anchore/scan-action/download-grype`` or
+    ``github/codeql-action/init``). A Git remote only exists for the
+    ``owner/repo`` portion; the trailing path is a directory within the
+    repository. Strip it before building clone / ls-remote URLs so that
+    these actions validate against the correct remote.
+
+    Args:
+        repository: Repository identifier, possibly including a subpath.
+
+    Returns:
+        The ``owner/repo`` portion (first two path segments) when a
+        subpath is present, otherwise the input unchanged.
+    """
+    parts = repository.split("/")
+    if len(parts) > 2:
+        return "/".join(parts[:2])
+    return repository
+
+
 class GitValidationClient:
     """Client for validating GitHub Actions using Git operations."""
 
@@ -230,8 +253,11 @@ def _validate_repository_exists(
         ValidationResult indicating if repository exists
     """
     # Try both HTTPS and SSH URLs
-    https_url = f"https://github.com/{repository}.git"
-    ssh_url = f"git@github.com:{repository}.git"
+    # Strip any action subpath (e.g. anchore/scan-action/download-grype)
+    # so the URL targets the real owner/repo remote.
+    base_repo = _base_repository(repository)
+    https_url = f"https://github.com/{base_repo}.git"
+    ssh_url = f"git@github.com:{base_repo}.git"
 
     # Try HTTPS first (more likely to work without auth for public repos)
     for url in [https_url, ssh_url]:
@@ -264,8 +290,11 @@ def _validate_repository_references(
     results = {}
 
     # Try both HTTPS and SSH URLs
-    https_url = f"https://github.com/{repository}.git"
-    ssh_url = f"git@github.com:{repository}.git"
+    # Strip any action subpath (e.g. anchore/scan-action/download-grype)
+    # so the URL targets the real owner/repo remote.
+    base_repo = _base_repository(repository)
+    https_url = f"https://github.com/{base_repo}.git"
+    ssh_url = f"git@github.com:{base_repo}.git"
 
     # Group references by type for optimization
     commit_shas = []

--- a/tests/test_git_validator.py
+++ b/tests/test_git_validator.py
@@ -31,7 +31,9 @@ def test_base_repository_strips_subpath(repository: str, expected: str) -> None:
     assert _base_repository(repository) == expected
 
 
-def test_validate_repository_exists_uses_base_repo_url(monkeypatch) -> None:
+def test_validate_repository_exists_uses_base_repo_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Subdirectory actions validate against the owner/repo remote URL.
 
     Regression test: ``anchore/scan-action/download-grype`` previously built

--- a/tests/test_git_validator.py
+++ b/tests/test_git_validator.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Tests for Git-based validation of subdirectory (monorepo) action calls."""
+
+from __future__ import annotations
+
+import pytest
+
+from gha_workflow_linter import git_validator
+from gha_workflow_linter.git_validator import (
+    _base_repository,
+    _validate_repository_exists,
+)
+from gha_workflow_linter.models import GitConfig, ValidationResult
+
+
+@pytest.mark.parametrize(
+    ("repository", "expected"),
+    [
+        ("actions/checkout", "actions/checkout"),
+        ("anchore/scan-action/download-grype", "anchore/scan-action"),
+        ("github/codeql-action/init", "github/codeql-action"),
+        ("owner/repo/nested/path", "owner/repo"),
+        ("owner/repo", "owner/repo"),
+        ("single", "single"),
+    ],
+)
+def test_base_repository_strips_subpath(repository: str, expected: str) -> None:
+    """The owner/repo base is returned, dropping any trailing action subpath."""
+    assert _base_repository(repository) == expected
+
+
+def test_validate_repository_exists_uses_base_repo_url(monkeypatch) -> None:
+    """Subdirectory actions validate against the owner/repo remote URL.
+
+    Regression test: ``anchore/scan-action/download-grype`` previously built
+    ``https://github.com/anchore/scan-action/download-grype.git`` and failed
+    with INVALID_REPOSITORY under the token-less Git validation path, because
+    a Git remote only exists for the ``owner/repo`` portion.
+    """
+    seen_urls: list[str] = []
+
+    def fake_ls_remote(url: str, _config: GitConfig) -> bool:
+        seen_urls.append(url)
+        return True
+
+    monkeypatch.setattr(git_validator, "_run_git_ls_remote", fake_ls_remote)
+
+    result = _validate_repository_exists(
+        "anchore/scan-action/download-grype", GitConfig()
+    )
+
+    assert result == ValidationResult.VALID
+    assert seen_urls == ["https://github.com/anchore/scan-action.git"]
+    assert "download-grype" not in seen_urls[0]


### PR DESCRIPTION
## Problem

When validating without a GitHub token (the **Git/SSH** method), subdirectory / monorepo action calls are incorrectly reported as **invalid repositories**.

Examples that fail today:

```
anchore/scan-action/download-grype@<sha>
github/codeql-action/init@<sha>
```

The token-less path builds the clone / `ls-remote` URL from the **full** action identifier, including the subdirectory path:

```
https://github.com/anchore/scan-action/download-grype.git   ❌ no such remote
```

A Git remote only exists for the `owner/repo` portion (`anchore/scan-action`); `download-grype` is a directory *inside* that repo. So `git ls-remote` fails and the call is flagged as `INVALID_REPOSITORY`.

Only the **Git** method is affected — the GitHub API/GraphQL path already resolves the base repository (`base_name = name.split("/")[0]`), which is why this only surfaces in token-less environments (e.g. CI runners without `GITHUB_TOKEN`, falling back to Git validation).

Real-world hit: this blocks downstream pre-commit/CI runs that pin `anchore/scan-action/download-grype` (a very common Grype install action).

## Fix

Strip any action subpath to the `owner/repo` base before building Git URLs, via a small `_base_repository()` helper, applied in both `_validate_repository_exists` and `_validate_repository_references`:

```
anchore/scan-action/download-grype  ->  anchore/scan-action
github/codeql-action/init           ->  github/codeql-action
actions/checkout                    ->  actions/checkout   (unchanged)
```

Results continue to be keyed by the full action identifier; only the URL used for the remote probe changes.

## Testing

- New `tests/test_git_validator.py`:
  - parametrised coverage of `_base_repository` (plain, subpath, deep subpath, single segment),
  - a regression test asserting `_validate_repository_exists` probes `https://github.com/anchore/scan-action.git` (not the subpath URL).
- Verified against the real network: `_validate_repository_exists("anchore/scan-action/download-grype", GitConfig())` now returns `VALID` (previously `INVALID_REPOSITORY`).
- `ruff check`, `ruff format --check`, and `mypy` pass on the changed files.

Co-authored with an AI assistant; reviewed and validated locally.