### PR TITLE
Feat: Validate subdirectory action subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ gha-workflow-linter lint --format json
     "total_errors": 8,
     "invalid_repositories": 0,
     "invalid_references": 0,
+    "invalid_paths": 0,
     "syntax_errors": 0,
     "network_errors": 0,
     "timeouts": 0,
@@ -785,14 +786,15 @@ docker run --rm -v "$(pwd):/workspace" \
 
 <!-- markdownlint-disable MD013 -->
 
-| Error Type           | Description              | Resolution                                         |
-| -------------------- | ------------------------ | -------------------------------------------------- |
-| `invalid_repository` | Repository not found     | Check org/repo name spelling                       |
-| `invalid_reference`  | Branch/tag/SHA not found | Verify reference exists                            |
-| `invalid_syntax`     | Malformed action call    | Fix YAML syntax                                    |
-| `network_error`      | Connection failed        | Check network/credentials                          |
-| `timeout`            | Validation timed out     | Increase timeout settings                          |
-| `not_pinned_to_sha`  | Action not using SHA     | Pin to commit SHA or use `--no-require-pinned-sha` |
+| Error Type           | Description                                              | Resolution                                                              |
+| -------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `invalid_repository` | Repository not found                                     | Check org/repo name spelling                                            |
+| `invalid_reference`  | Branch/tag/SHA not found                                 | Verify reference exists                                                 |
+| `invalid_path`       | Subdirectory action path not found at the referenced ref | Check the subdirectory path (e.g. `owner/repo/path`) exists at that ref |
+| `invalid_syntax`     | Malformed action call                                    | Fix YAML syntax                                                         |
+| `network_error`      | Connection failed                                        | Check network/credentials                                               |
+| `timeout`            | Validation timed out                                     | Increase timeout settings                                               |
+| `not_pinned_to_sha`  | Action not using SHA                                     | Pin to commit SHA or use `--no-require-pinned-sha`                      |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -36,6 +36,7 @@ from .models import (
     ValidationMethod,
     ValidationResult,
 )
+from .paths import base_repository
 from .patterns import ActionCallPatterns
 from .utils import has_test_comment
 
@@ -365,10 +366,13 @@ class AutoFixer:
                 should_fix = False
             elif error.result in [
                 ValidationResult.INVALID_SYNTAX,
+                ValidationResult.INVALID_PATH,
                 ValidationResult.NETWORK_ERROR,
                 ValidationResult.TIMEOUT,
             ]:
-                # Cannot auto-fix these - skip
+                # Cannot auto-fix these - skip.
+                # INVALID_PATH means the subdirectory subpath itself is bogus;
+                # changing the ref will not make a non-existent path appear.
                 should_fix = False
 
             if should_fix:
@@ -2473,10 +2477,7 @@ class AutoFixer:
         Returns:
             Base repository (owner/repo)
         """
-        parts = repo_key.split("/")
-        if len(parts) >= 2:
-            return f"{parts[0]}/{parts[1]}"
-        return repo_key
+        return base_repository(repo_key)
 
     def _build_fixed_line(
         self,

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -1340,6 +1340,11 @@ def _display_validation_summary(
             console.print(
                 f"  - {validation_summary['invalid_references']} invalid references"
             )
+        if validation_summary.get("invalid_paths", 0) > 0:
+            console.print(
+                f"  - {validation_summary['invalid_paths']} invalid "
+                f"subdirectory action paths"
+            )
         if validation_summary["network_errors"] > 0:
             console.print(
                 f"  - {validation_summary['network_errors']} network errors"

--- a/src/gha_workflow_linter/git_validator.py
+++ b/src/gha_workflow_linter/git_validator.py
@@ -10,12 +10,15 @@ from concurrent.futures import ProcessPoolExecutor
 import logging
 import multiprocessing
 import re
+import tempfile
 from typing import TYPE_CHECKING
 
 from .exceptions import (
     GitError,
 )
 from .models import APICallStats, GitConfig, ReferenceType, ValidationResult
+from .paths import action_subpath, action_subpath_candidates
+from .paths import base_repository as _shared_base_repository
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,24 +29,19 @@ logger = logging.getLogger(__name__)
 def _base_repository(repository: str) -> str:
     """Return the ``owner/repo`` base, stripping any action subpath.
 
-    Monorepo / subdirectory actions are referenced as ``owner/repo/path``
-    (for example ``anchore/scan-action/download-grype`` or
-    ``github/codeql-action/init``). A Git remote only exists for the
-    ``owner/repo`` portion; the trailing path is a directory within the
-    repository. Strip it before building clone / ls-remote URLs so that
-    these actions validate against the correct remote.
+    Thin wrapper around :func:`gha_workflow_linter.paths.base_repository` so
+    the Git validation path shares a single definition of how subdirectory
+    action identifiers are split. Kept as an explicit module-level function so
+    it remains an importable symbol for callers and tests.
 
     Args:
         repository: Repository identifier, possibly including a subpath.
 
     Returns:
-        The ``owner/repo`` portion (first two path segments) when a
-        subpath is present, otherwise the input unchanged.
+        The ``owner/repo`` portion when a subpath is present, otherwise the
+        input unchanged.
     """
-    parts = repository.split("/")
-    if len(parts) > 2:
-        return "/".join(parts[:2])
-    return repository
+    return _shared_base_repository(repository)
 
 
 class GitValidationClient:
@@ -229,6 +227,110 @@ class GitValidationClient:
 
         self.logger.debug(
             f"Reference validation complete: {len(results)} results"
+        )
+        return results
+
+    async def validate_subpaths_batch(
+        self, subpath_refs: list[tuple[str, str]]
+    ) -> dict[tuple[str, str], ValidationResult]:
+        """
+        Validate subdirectory-action subpaths exist at their referenced ref.
+
+        Each entry is a ``(repo_key, ref)`` tuple where ``repo_key`` is a full
+        action identifier that includes a subdirectory subpath
+        (``owner/repo/path``). The base repository and ref are assumed to have
+        already been validated; this method only confirms that ``path`` exists
+        in the repository tree at ``ref``.
+
+        ``ls-remote`` cannot inspect trees, so a blobless partial fetch of
+        the ref is performed (``--filter=blob:none``) followed by
+        ``git ls-tree`` of the candidate paths. This heavier path runs *only*
+        for subdirectory actions; plain ``owner/repo`` calls never reach here
+        and keep their lightweight ``ls-remote`` flow.
+
+        Args:
+            subpath_refs: List of ``(repo_key, ref)`` tuples, where each
+                ``repo_key`` includes a subdirectory subpath.
+
+        Returns:
+            Dictionary mapping ``(repo_key, ref)`` to a ``ValidationResult``:
+
+            * ``VALID`` -- the subpath exists at the ref.
+            * ``INVALID_PATH`` -- the ref was inspected cleanly and the
+              subpath is absent (a definitively bogus path).
+            * ``NETWORK_ERROR`` -- the check was inconclusive (e.g. a
+              transient partial-fetch / ``ls-tree`` failure, or a
+              gather-level error). Callers treat this as benefit-of-the-doubt
+              for the current run but must not cache it.
+        """
+        if not subpath_refs:
+            return {}
+
+        self.logger.debug(
+            f"Validating {len(subpath_refs)} subdirectory action subpaths "
+            f"using Git"
+        )
+
+        # Group entries by base repository so each repo is fetched once.
+        repo_to_entries: dict[str, list[tuple[str, str]]] = {}
+        for repo_key, ref in subpath_refs:
+            base = _base_repository(repo_key)
+            repo_to_entries.setdefault(base, []).append((repo_key, ref))
+
+        loop = asyncio.get_running_loop()
+        results: dict[tuple[str, str], ValidationResult] = {}
+
+        with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = []
+            entry_groups: list[list[tuple[str, str]]] = []
+            for base, entries in repo_to_entries.items():
+                futures.append(
+                    loop.run_in_executor(
+                        executor,
+                        _validate_repository_subpaths,
+                        base,
+                        entries,
+                        self.config,
+                    )
+                )
+                entry_groups.append(entries)
+
+            try:
+                group_results = await asyncio.gather(
+                    *futures, return_exceptions=True
+                )
+            except Exception as e:
+                self.logger.error(
+                    f"Unexpected error in subpath validation: {e}"
+                )
+                # Propagate the exception per group so the isinstance branch
+                # below maps it to NETWORK_ERROR (inconclusive). Substituting
+                # empty dicts here would instead be read as INVALID_PATH and
+                # misclassify an internal failure as a bogus subpath.
+                group_results = [e] * len(futures)
+
+            for entries, group_result in zip(entry_groups, group_results):
+                if isinstance(group_result, Exception):
+                    self.logger.warning(
+                        f"Failed to validate subpaths: {group_result}"
+                    )
+                    for entry in entries:
+                        results[entry] = ValidationResult.NETWORK_ERROR
+                        self.api_stats.increment_failed_call()
+                elif isinstance(group_result, dict):
+                    for entry in entries:
+                        results[entry] = group_result.get(
+                            entry, ValidationResult.INVALID_PATH
+                        )
+                        self.api_stats.increment_git()
+                    self.api_stats.git_clone_operations += 1
+                else:
+                    for entry in entries:
+                        results[entry] = ValidationResult.NETWORK_ERROR
+                        self.api_stats.increment_failed_call()
+
+        self.logger.debug(
+            f"Subpath validation complete: {len(results)} results"
         )
         return results
 
@@ -786,3 +888,237 @@ def _determine_reference_type(reference: str) -> ReferenceType:
 
     # Default to branch for everything else
     return ReferenceType.BRANCH
+
+
+def _validate_repository_subpaths(
+    base_repository_key: str,
+    entries: list[tuple[str, str]],
+    config: GitConfig,
+) -> dict[tuple[str, str], ValidationResult]:
+    """
+    Validate that subdirectory subpaths exist at their referenced ref.
+
+    Runs in a separate process. Performs one partial (``--filter=blob:none``)
+    shallow fetch per unique ref into a throwaway repository, then checks the
+    candidate paths with ``git ls-tree``. ``blob:none`` keeps file *contents*
+    off the wire while still downloading the tree objects ``ls-tree`` needs, so
+    the path-existence check works entirely offline after the fetch.
+
+    Args:
+        base_repository_key: ``owner/repo`` base (no subpath).
+        entries: List of ``(repo_key, ref)`` tuples sharing this base repo,
+            where each ``repo_key`` includes a subdirectory subpath.
+        config: Git configuration.
+
+    Returns:
+        Dictionary mapping ``(repo_key, ref)`` to a ``ValidationResult``
+        (``VALID``, ``INVALID_PATH`` or ``NETWORK_ERROR``).
+    """
+    import pathlib
+
+    results: dict[tuple[str, str], ValidationResult] = {}
+
+    https_url = f"https://github.com/{base_repository_key}.git"
+    ssh_url = f"git@github.com:{base_repository_key}.git"
+
+    # Group entries by ref so each ref is fetched only once.
+    ref_to_repo_keys: dict[str, list[str]] = {}
+    for repo_key, ref in entries:
+        ref_to_repo_keys.setdefault(ref, []).append(repo_key)
+
+    with tempfile.TemporaryDirectory(prefix="gha-subpath-") as tmpdir:
+        repo_dir = pathlib.Path(tmpdir)
+        if not _run_git_init(repo_dir, config):
+            for repo_key, ref in entries:
+                results[(repo_key, ref)] = ValidationResult.NETWORK_ERROR
+            return results
+
+        for ref, repo_keys in ref_to_repo_keys.items():
+            fetched = False
+            for url in (https_url, ssh_url):
+                if _run_git_fetch_partial(repo_dir, url, ref, config):
+                    fetched = True
+                    break
+
+            for repo_key in repo_keys:
+                entry = (repo_key, ref)
+                if not fetched:
+                    # The ref was already validated to exist, so a fetch
+                    # failure here is treated as a transient/network problem
+                    # rather than a bogus subpath.
+                    results[entry] = ValidationResult.NETWORK_ERROR
+                    continue
+
+                subpath = action_subpath(repo_key)
+                if subpath is None:
+                    results[entry] = ValidationResult.VALID
+                    continue
+
+                try:
+                    exists = _run_git_subpath_exists(
+                        repo_dir, "FETCH_HEAD", subpath, config
+                    )
+                except GitError as e:
+                    # The ls-tree check could not be completed (a local or
+                    # transient Git failure, distinct from the subpath being
+                    # absent). Treat as inconclusive so the caller does not
+                    # report or cache it as a bogus path.
+                    logger.debug(
+                        f"Inconclusive subpath check for {repo_key}@{ref}: {e}"
+                    )
+                    results[entry] = ValidationResult.NETWORK_ERROR
+                    continue
+
+                results[entry] = (
+                    ValidationResult.VALID
+                    if exists
+                    else ValidationResult.INVALID_PATH
+                )
+
+    return results
+
+
+def _run_git_init(repo_dir: Path, config: GitConfig) -> bool:
+    """Initialise an empty Git repository for partial fetches.
+
+    Args:
+        repo_dir: Directory in which to initialise the repository.
+        config: Git configuration.
+
+    Returns:
+        True if initialisation succeeded, False otherwise.
+    """
+    import subprocess
+
+    cmd = ["git", "init", "--quiet", str(repo_dir)]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=config.timeout_seconds,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _run_git_fetch_partial(
+    repo_dir: Path, url: str, ref: str, config: GitConfig
+) -> bool:
+    """Shallow, blobless fetch of a single ref into ``repo_dir``.
+
+    ``--filter=blob:none`` omits file contents while still fetching the tree
+    objects required to enumerate paths. ``--depth=1`` keeps history minimal.
+    Fetching by branch, tag, or (server permitting) commit SHA all resolve to
+    ``FETCH_HEAD``.
+
+    Args:
+        repo_dir: Initialised repository directory.
+        url: Git remote URL for the base ``owner/repo``.
+        ref: The branch, tag, or commit SHA to fetch.
+        config: Git configuration.
+
+    Returns:
+        True if the fetch succeeded, False otherwise.
+    """
+    import subprocess
+
+    cmd = [
+        "git",
+        "-C",
+        str(repo_dir),
+        "-c",
+        "protocol.version=2",
+        "fetch",
+        "--depth=1",
+        "--filter=blob:none",
+        "--no-tags",
+        "--quiet",
+        url,
+        ref,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=config.timeout_seconds,
+            check=False,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+    except Exception:
+        return False
+
+
+def _run_git_subpath_exists(
+    repo_dir: Path, treeish: str, subpath: str, config: GitConfig
+) -> bool:
+    """Check whether a subdirectory action path exists at ``treeish``.
+
+    Probes the candidate paths from :func:`action_subpath_candidates` (the
+    action metadata files first, then the directory itself) in a single
+    ``git ls-tree`` call. Non-empty output means at least one candidate exists.
+
+    A definitive absence (``ls-tree`` succeeds with no matching entry) is
+    distinguished from a failure to run the check at all (non-zero exit,
+    timeout, or other error). The former returns ``False``; the latter raises
+    ``GitError`` so callers can treat it as inconclusive rather than a bogus
+    path.
+
+    Args:
+        repo_dir: Repository directory containing the fetched objects.
+        treeish: Tree-ish to inspect (typically ``FETCH_HEAD``).
+        subpath: The subdirectory path to verify.
+        config: Git configuration.
+
+    Returns:
+        True if the subpath exists at the ref, False if it is definitively
+        absent.
+
+    Raises:
+        GitError: If the ``ls-tree`` check could not be completed.
+    """
+    import subprocess
+
+    candidates = action_subpath_candidates(subpath)
+    cmd = [
+        "git",
+        "-C",
+        str(repo_dir),
+        "ls-tree",
+        treeish,
+        "--",
+        *candidates,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=config.timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        raise GitError(
+            f"Git ls-tree timed out for {treeish} in {repo_dir}"
+        ) from None
+    except Exception as e:
+        raise GitError(
+            f"Git ls-tree failed for {treeish} in {repo_dir}: {e}"
+        ) from e
+
+    if result.returncode != 0:
+        # A non-zero exit means the command itself failed (e.g. a missing
+        # object or a local Git problem), which is distinct from the subpath
+        # being absent. Surface it as inconclusive rather than bogus.
+        raise GitError(
+            f"Git ls-tree failed (exit {result.returncode}) for {treeish} "
+            f"in {repo_dir}: {result.stderr.strip()}"
+        )
+
+    # Exit 0: the subpath exists iff ls-tree listed a matching entry.
+    return bool(result.stdout.strip())

--- a/src/gha_workflow_linter/github_api.py
+++ b/src/gha_workflow_linter/github_api.py
@@ -26,6 +26,11 @@ from .models import (
     GitHubAPIConfig,
     GitHubRateLimitInfo,
 )
+from .paths import (
+    action_subpath,
+    action_subpath_candidates,
+    base_repository,
+)
 from .system_utils import get_default_workers
 
 if TYPE_CHECKING:
@@ -61,6 +66,9 @@ class GitHubGraphQLClient:
         # Cache for validation results
         self._repository_cache: dict[str, bool] = {}
         self._reference_cache: dict[str, dict[str, bool]] = {}
+        # Cache for subdirectory-action subpath existence, keyed by
+        # (full action identifier including subpath, ref).
+        self._subpath_cache: dict[tuple[str, str], bool] = {}
 
         # Parallel workers for concurrent operations (set by validator)
         self.parallel_workers: int = (
@@ -292,6 +300,110 @@ class GitHubGraphQLClient:
         for repo_key, batch_result in batch_results_list:
             for ref, is_valid in batch_result.items():
                 results[(repo_key, ref)] = is_valid
+
+        return results
+
+    async def validate_subpaths_batch(
+        self, subpath_refs: list[tuple[str, str]]
+    ) -> dict[tuple[str, str], bool]:
+        """
+        Validate subdirectory-action subpaths exist at their referenced ref.
+
+        Each entry is a ``(repo_key, ref)`` tuple where ``repo_key`` is a full
+        action identifier that includes a subdirectory subpath
+        (``owner/repo/path``). The base repository and ref are assumed to have
+        already been validated; this method only confirms that ``path`` exists
+        in the repository tree at ``ref`` (preferring an ``action.yml`` /
+        ``action.yaml`` within it). A cheap GraphQL ``object(expression: ...)``
+        tree lookup is used, batched alongside other subpath checks, so this
+        adds ~O(1) extra work per subdirectory action.
+
+        Args:
+            subpath_refs: List of ``(repo_key, ref)`` tuples, where each
+                ``repo_key`` includes a subdirectory subpath.
+
+        Returns:
+            Dictionary mapping ``(repo_key, ref)`` to subpath-existence result.
+        """
+        results: dict[tuple[str, str], bool] = {}
+
+        # Check cache first.
+        uncached: list[tuple[str, str]] = []
+        for repo_key, ref in subpath_refs:
+            cache_key = (repo_key, ref)
+            if cache_key in self._subpath_cache:
+                self.api_stats.increment_cache_hit()
+                results[cache_key] = self._subpath_cache[cache_key]
+                self.logger.debug(f"Subpath cache hit: {repo_key}@{ref}")
+            else:
+                uncached.append((repo_key, ref))
+
+        if not uncached:
+            return results
+
+        self.logger.debug(
+            f"Validating {len(uncached)} subdirectory action subpaths via "
+            f"GraphQL (cache hits: {len(results)})"
+        )
+
+        # Process in batches - create all tasks for parallel execution.
+        batch_size = self.config.max_repositories_per_query
+        batches = [
+            uncached[i : i + batch_size]
+            for i in range(0, len(uncached), batch_size)
+        ]
+
+        semaphore = asyncio.Semaphore(self.parallel_workers)
+
+        async def process_subpath_batch_with_limit(
+            batch: list[tuple[str, str]],
+        ) -> dict[tuple[str, str], bool]:
+            """Process a single subpath batch with rate limiting."""
+            async with semaphore:
+                await self._check_rate_limit()
+                try:
+                    batch_results = (
+                        await self._validate_subpaths_graphql_batch(batch)
+                    )
+                    for cache_key, is_valid in batch_results.items():
+                        self._subpath_cache[cache_key] = is_valid
+                    return batch_results
+                except (
+                    NetworkError,
+                    GitHubAPIError,
+                    AuthenticationError,
+                    RateLimitError,
+                    TemporaryAPIError,
+                ):
+                    # Re-raise known API/network errors so the caller can
+                    # surface them rather than treating them as bogus paths.
+                    # (TemporaryAPIError subclasses GitHubAPIError, so it is
+                    # already covered; it is named explicitly for clarity and
+                    # to mirror the validator's abort handler.)
+                    self.logger.error(
+                        "Error validating subdirectory action subpaths"
+                    )
+                    raise
+                except Exception as e:
+                    # Propagate unexpected (non-API/network) errors instead of
+                    # caching a bogus ``False`` (INVALID_PATH) for every entry.
+                    # Returning False here would poison ``_subpath_cache`` for
+                    # the rest of the run and misclassify an internal bug as a
+                    # real bogus subpath. The validator turns any raised error
+                    # into a ValidationAbortedError, mirroring how the Git path
+                    # keeps inconclusive checks out of the cache.
+                    self.logger.error(
+                        f"Unexpected error validating subpath batch: {e}"
+                    )
+                    self.api_stats.increment_failed_call()
+                    raise
+
+        batch_results_list = await asyncio.gather(
+            *[process_subpath_batch_with_limit(batch) for batch in batches]
+        )
+
+        for batch_result in batch_results_list:
+            results.update(batch_result)
 
         return results
 
@@ -570,6 +682,141 @@ class GitHubGraphQLClient:
             # Found if exists as either branch or tag
             is_valid = bool(repo_data.get(alias) or repo_data.get(tag_alias))
             results[ref] = is_valid
+
+        return results
+
+    @staticmethod
+    def _graphql_string_literal(value: str) -> str:
+        """Escape a value for safe inclusion in a GraphQL string literal.
+
+        Refs and paths are interpolated into GraphQL ``expression`` strings;
+        escape the characters that would otherwise terminate or corrupt the
+        string literal. Refs/paths almost never contain these, but escaping
+        keeps the generated query well-formed regardless of input.
+
+        Args:
+            value: Raw string to embed inside a GraphQL double-quoted string.
+
+        Returns:
+            The escaped string (without surrounding quotes).
+        """
+        return (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
+
+    async def _validate_subpaths_graphql_batch(
+        self, subpath_refs: list[tuple[str, str]]
+    ) -> dict[tuple[str, str], bool]:
+        """
+        Validate a batch of subdirectory subpaths using a single GraphQL query.
+
+        For each ``(repo_key, ref)`` entry, the subpath is probed at the ref
+        via ``object(expression: "<ref>:<candidate>")`` for each candidate path
+        returned by :func:`action_subpath_candidates` (the action metadata
+        files first, then the directory itself). The subpath is considered to
+        exist if any candidate object resolves to a non-null tree/blob.
+
+        Args:
+            subpath_refs: List of ``(repo_key, ref)`` tuples to validate.
+
+        Returns:
+            Dictionary mapping ``(repo_key, ref)`` to subpath-existence result.
+        """
+        query_parts: list[str] = []
+        # alias -> (cache_key, list of candidate aliases)
+        entry_aliases: dict[tuple[str, str], list[str]] = {}
+
+        for i, (repo_key, ref) in enumerate(subpath_refs):
+            base = base_repository(repo_key)
+            subpath = action_subpath(repo_key)
+            if subpath is None:
+                # No subpath: nothing to verify, treat as present.
+                entry_aliases[(repo_key, ref)] = []
+                continue
+
+            try:
+                owner, name = base.split("/", 1)
+            except ValueError:
+                self.logger.warning(
+                    f"Invalid repository format for subpath check: {repo_key}"
+                )
+                entry_aliases[(repo_key, ref)] = []
+                continue
+
+            repo_alias = f"sp_{i}"
+            object_parts: list[str] = []
+            candidate_aliases: list[str] = []
+            for j, candidate in enumerate(
+                action_subpath_candidates(subpath)
+            ):
+                obj_alias = f"{repo_alias}_c{j}"
+                candidate_aliases.append(f"{repo_alias}.{obj_alias}")
+                expression = self._graphql_string_literal(f"{ref}:{candidate}")
+                object_parts.append(
+                    f'{obj_alias}: object(expression: "{expression}") '
+                    f"{{ __typename }}"
+                )
+
+            owner_lit = self._graphql_string_literal(owner)
+            name_lit = self._graphql_string_literal(name)
+            query_parts.append(
+                f'{repo_alias}: repository(owner: "{owner_lit}", '
+                f'name: "{name_lit}") {{ {" ".join(object_parts)} }}'
+            )
+            entry_aliases[(repo_key, ref)] = candidate_aliases
+
+        results: dict[tuple[str, str], bool] = {}
+
+        # If no entry produced a queryable subpath (all entries lacked a
+        # subpath or had an invalid format), there is nothing to disprove, so
+        # treat them all as present.
+        if not query_parts:
+            return dict.fromkeys(entry_aliases, True)
+
+        query = f"query {{ {' '.join(query_parts)} }}"
+
+        try:
+            response_data = await self._execute_graphql_query(query)
+        except (
+            AuthenticationError,
+            RateLimitError,
+            NetworkError,
+            TemporaryAPIError,
+            GitHubAPIError,
+        ):
+            raise
+        except Exception as e:
+            # Propagate unexpected errors rather than reporting every entry as
+            # a bogus subpath. Returning False here would let the caller cache
+            # a potentially-wrong INVALID_PATH for a non-data failure (e.g. a
+            # response-parsing bug); re-raising lets the validator abort the
+            # run, consistent with the Git path's inconclusive handling.
+            self.logger.debug(
+                f"Unexpected subpath batch validation error: {e}"
+            )
+            raise
+
+        data = response_data.get("data", {}) or {}
+
+        for cache_key, candidate_aliases in entry_aliases.items():
+            if not candidate_aliases:
+                # No subpath to verify (defensive: should not normally reach
+                # here since such entries are filtered out upstream).
+                results[cache_key] = True
+                continue
+
+            found = False
+            for combined in candidate_aliases:
+                repo_alias, obj_alias = combined.split(".", 1)
+                repo_obj = data.get(repo_alias) or {}
+                if repo_obj.get(obj_alias) is not None:
+                    found = True
+                    break
+            results[cache_key] = found
 
         return results
 

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -37,6 +37,7 @@ class ValidationResult(str, Enum):
     VALID = "valid"
     INVALID_REPOSITORY = "invalid_repository"
     INVALID_REFERENCE = "invalid_reference"
+    INVALID_PATH = "invalid_path"
     INVALID_SYNTAX = "invalid_syntax"
     NETWORK_ERROR = "network_error"
     TIMEOUT = "timeout"

--- a/src/gha_workflow_linter/paths.py
+++ b/src/gha_workflow_linter/paths.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Shared helpers for GitHub Actions repository path / subpath handling.
+
+A GitHub Action can be referenced either as a top-level repository
+(``owner/repo@ref``) or as a *subdirectory* (monorepo / composite) action
+that lives in a directory within a repository (``owner/repo/path@ref``,
+for example ``github/codeql-action/init`` or
+``anchore/scan-action/download-grype``).
+
+A Git remote only exists for the ``owner/repo`` portion; the trailing path
+is a directory inside the repository at a given ref. These helpers provide a
+single, shared definition of how an action identifier is split into its base
+repository and subdirectory subpath, and of how a subpath's existence is
+probed, so the GitHub API and Git validation paths stay consistent.
+"""
+
+from __future__ import annotations
+
+# Action metadata filenames recognised by GitHub for composite / Docker /
+# JavaScript actions. By GitHub's rules a directory containing one of these is
+# a real action, so their presence is the strongest legitimacy signal for a
+# subpath. Subpath validation prefers them but also accepts the directory
+# itself as a fallback (see ``action_subpath_candidates``); this constant
+# therefore documents the preferred signal, not a hard requirement enforced by
+# the validators.
+ACTION_METADATA_FILENAMES: tuple[str, ...] = ("action.yml", "action.yaml")
+
+
+def split_repository_subpath(repository: str) -> tuple[str, str | None]:
+    """Split an action identifier into its base repository and subpath.
+
+    Monorepo / subdirectory actions are referenced as ``owner/repo/path``.
+    A Git remote only exists for the ``owner/repo`` portion; the trailing
+    path is a directory within the repository.
+
+    Args:
+        repository: Repository identifier, possibly including a subpath.
+
+    Returns:
+        A ``(base_repository, subpath)`` tuple. ``base_repository`` is the
+        ``owner/repo`` portion (first two path segments). ``subpath`` is the
+        remaining path (everything after ``owner/repo``) or ``None`` when no
+        subpath is present.
+    """
+    parts = repository.split("/")
+    if len(parts) > 2:
+        return "/".join(parts[:2]), "/".join(parts[2:])
+    return repository, None
+
+
+def base_repository(repository: str) -> str:
+    """Return the ``owner/repo`` base, stripping any action subpath.
+
+    Args:
+        repository: Repository identifier, possibly including a subpath.
+
+    Returns:
+        The ``owner/repo`` portion when a subpath is present, otherwise the
+        input unchanged.
+    """
+    return split_repository_subpath(repository)[0]
+
+
+def action_subpath(repository: str) -> str | None:
+    """Return the subdirectory subpath of an action identifier, if any.
+
+    Args:
+        repository: Repository identifier, possibly including a subpath.
+
+    Returns:
+        The subpath (everything after ``owner/repo``) or ``None`` when the
+        identifier refers to a top-level repository.
+    """
+    return split_repository_subpath(repository)[1]
+
+
+def has_action_subpath(repository: str) -> bool:
+    """Report whether an action identifier includes a subdirectory subpath.
+
+    Args:
+        repository: Repository identifier, possibly including a subpath.
+
+    Returns:
+        ``True`` when the identifier has more than two path segments
+        (``owner/repo/path``), ``False`` otherwise.
+    """
+    return split_repository_subpath(repository)[1] is not None
+
+
+def action_subpath_candidates(subpath: str) -> list[str]:
+    """Return the candidate paths whose existence proves a subdir action.
+
+    The list is ordered from the strongest legitimacy signal to the weakest:
+
+    1. ``<subpath>/action.yml`` and ``<subpath>/action.yaml`` -- a directory
+       containing one of these is, by definition, a GitHub Action.
+    2. ``<subpath>`` -- the directory (or file) itself, used as a fallback so
+       that a path which genuinely exists at the ref is never reported as
+       bogus even if its action metadata is named unusually.
+
+    Both the GitHub API (GraphQL tree lookup) and Git (``ls-tree``) paths
+    consume this single definition so their results stay consistent.
+
+    Args:
+        subpath: The subdirectory path within the repository.
+
+    Returns:
+        Ordered list of candidate paths to probe at the referenced ref.
+    """
+    sub = subpath.strip("/")
+    candidates = [f"{sub}/{name}" for name in ACTION_METADATA_FILENAMES]
+    candidates.append(sub)
+    return candidates

--- a/src/gha_workflow_linter/validator.py
+++ b/src/gha_workflow_linter/validator.py
@@ -39,6 +39,11 @@ from .models import (
     ValidationMethod,
     ValidationResult,
 )
+from .paths import (
+    action_subpath,
+    base_repository,
+    has_action_subpath,
+)
 from .utils import has_test_comment
 
 
@@ -493,6 +498,91 @@ class ActionCallValidator:
                     original_error=e,
                 ) from e
 
+        # Step 2.5: Validate subdirectory (monorepo) action subpaths.
+        #
+        # Both validation methods strip any subpath to ``owner/repo`` for the
+        # repository and reference checks above. For subdirectory actions
+        # (``owner/repo/path@ref``) we additionally confirm that ``path``
+        # exists in the repository tree at ``ref``; otherwise an action with a
+        # valid base repo and ref but a bogus subpath would pass. This work is
+        # gated to subdirectory actions whose repo + ref already validated, so
+        # plain ``owner/repo`` calls add no extra network work.
+        subpath_results: dict[tuple[str, str], bool] = {}
+        # Subpath checks that could not be decided (e.g. a transient Git fetch
+        # failure on an already-valid ref). These are given the benefit of the
+        # doubt for the current run's surfaced result, but must NOT be cached
+        # so a transient failure cannot persist as a false VALID that masks a
+        # bogus subpath; the next run re-checks them instead.
+        inconclusive_subpaths: set[tuple[str, str]] = set()
+        subpath_refs_to_validate = [
+            (repo_key, ref)
+            for (repo_key, ref) in valid_repo_refs_to_validate
+            if has_action_subpath(repo_key)
+            and ref_results.get((repo_key, ref), False)
+        ]
+
+        if subpath_refs_to_validate:
+            self.logger.debug(
+                f"Validating {len(subpath_refs_to_validate)} subdirectory "
+                f"action subpaths (after cache)"
+            )
+            try:
+                if use_github_api:
+                    assert self._github_client is not None
+                    subpath_results = (
+                        await self._github_client.validate_subpaths_batch(
+                            subpath_refs_to_validate
+                        )
+                    )
+                    self._merge_api_stats(self._github_client.get_api_stats())
+                else:
+                    assert self._git_client is not None
+                    git_subpath_results = (
+                        await self._git_client.validate_subpaths_batch(
+                            subpath_refs_to_validate
+                        )
+                    )
+                    # Classify into three states. A definitive INVALID_PATH
+                    # marks the subpath bogus; VALID marks it present; any
+                    # other (e.g. NETWORK_ERROR/TIMEOUT) is inconclusive --
+                    # given the benefit of the doubt for this run but recorded
+                    # so it is excluded from caching.
+                    for key, result in git_subpath_results.items():
+                        if result == ValidationResult.INVALID_PATH:
+                            subpath_results[key] = False
+                        elif result == ValidationResult.VALID:
+                            subpath_results[key] = True
+                        else:
+                            subpath_results[key] = True
+                            inconclusive_subpaths.add(key)
+            except (
+                NetworkError,
+                GitHubAPIError,
+                AuthenticationError,
+                RateLimitError,
+                TemporaryAPIError,
+            ) as e:
+                error_context = (
+                    "GitHub API/Network" if use_github_api else "Git/Network"
+                )
+                self.logger.error(
+                    f"{error_context} error during subpath validation: {e}"
+                )
+                raise ValidationAbortedError(
+                    "Unable to validate GitHub Actions due to API/network issues",
+                    reason=str(e),
+                    original_error=e,
+                ) from e
+            except Exception as e:
+                self.logger.error(
+                    f"Unexpected error during subpath validation: {e}"
+                )
+                raise ValidationAbortedError(
+                    "Validation failed due to unexpected error",
+                    reason=str(e),
+                    original_error=e,
+                ) from e
+
         # Merge cached reference results
         for (repo, ref), cached_entry in cached_results.items():
             ref_results[(repo, ref)] = (
@@ -511,10 +601,19 @@ class ActionCallValidator:
         # Cache new validation results
         cache_entries_to_store = []
         for repo, ref in refs_to_validate:
+            # Skip caching entries whose subpath check was inconclusive so a
+            # transient failure is retried next run rather than persisted as a
+            # (benefit-of-the-doubt) VALID.
+            if (repo, ref) in inconclusive_subpaths:
+                continue
+
             repo_valid = repo_results.get(repo, False)
             ref_valid = ref_results.get((repo, ref), False)
+            # Subpath is considered valid unless we explicitly determined it is
+            # bogus. Entries without a subpath never populate subpath_results.
+            subpath_valid = subpath_results.get((repo, ref), True)
 
-            if repo_valid and ref_valid:
+            if repo_valid and ref_valid and subpath_valid:
                 result = ValidationResult.VALID
                 api_call_type = "graphql" if use_github_api else "git"
                 error_message = None
@@ -522,11 +621,18 @@ class ActionCallValidator:
                 result = ValidationResult.INVALID_REPOSITORY
                 api_call_type = "graphql" if use_github_api else "git"
                 error_message = f"Repository {repo} not found or not accessible"
-            else:
+            elif not ref_valid:
                 result = ValidationResult.INVALID_REFERENCE
                 api_call_type = "graphql" if use_github_api else "git"
                 error_message = (
                     f"Reference {ref} not found in repository {repo}"
+                )
+            else:
+                result = ValidationResult.INVALID_PATH
+                api_call_type = "graphql" if use_github_api else "git"
+                error_message = (
+                    f"Subdirectory path '{action_subpath(repo)}' not found in "
+                    f"{base_repository(repo)} at {ref}"
                 )
 
             cache_entries_to_store.append(
@@ -548,18 +654,29 @@ class ActionCallValidator:
         # all_repo_refs = repo_refs  # Not needed since we use repo_refs directly
         all_repo_results = repo_results.copy()
         all_ref_results = ref_results.copy()
+        all_subpath_results = dict(subpath_results)
 
-        # Add cached results to the full results dictionaries
+        # Add cached results to the full results dictionaries. A cached
+        # INVALID_PATH means the base repo and ref are valid but the
+        # subdirectory subpath is bogus, so it must be reflected as
+        # repo-valid + ref-valid + subpath-invalid (not as an invalid ref).
         for (repo, ref), cached_entry in cached_results.items():
             all_repo_results[repo] = cached_entry.result not in [
                 ValidationResult.INVALID_REPOSITORY
             ]
-            all_ref_results[(repo, ref)] = (
-                cached_entry.result == ValidationResult.VALID
+            all_ref_results[(repo, ref)] = cached_entry.result in (
+                ValidationResult.VALID,
+                ValidationResult.INVALID_PATH,
+            )
+            all_subpath_results[(repo, ref)] = (
+                cached_entry.result != ValidationResult.INVALID_PATH
             )
 
         validation_results = self._combine_validation_results(
-            unique_calls, all_repo_results, all_ref_results
+            unique_calls,
+            all_repo_results,
+            all_ref_results,
+            all_subpath_results,
         )
 
         for call_key, result in validation_results.items():
@@ -723,18 +840,23 @@ class ActionCallValidator:
         unique_calls: dict[str, ActionCall],
         repo_results: dict[str, bool],
         ref_results: dict[tuple[str, str], bool],
+        subpath_results: dict[tuple[str, str], bool] | None = None,
     ) -> dict[str, ValidationResult]:
         """
-        Combine repository and reference validation results.
+        Combine repository, reference and subpath validation results.
 
         Args:
             unique_calls: Dictionary of unique action calls
             repo_results: Repository validation results
             ref_results: Reference validation results
+            subpath_results: Subdirectory-action subpath validation results,
+                keyed by ``(repo_key, ref)``. Entries are present only for
+                subdirectory actions; a missing entry is treated as valid.
 
         Returns:
             Dictionary mapping call keys to validation results
         """
+        subpath_results = subpath_results or {}
         validation_results = {}
 
         for call_key, action_call in unique_calls.items():
@@ -758,7 +880,14 @@ class ActionCallValidator:
                 )
                 continue
 
-            # Both repository and reference are valid
+            # Check subdirectory subpath validity (subdir actions only)
+            if has_action_subpath(repo_key) and not subpath_results.get(
+                ref_key, True
+            ):
+                validation_results[call_key] = ValidationResult.INVALID_PATH
+                continue
+
+            # Repository, reference and subpath are all valid
             validation_results[call_key] = ValidationResult.VALID
 
         return validation_results
@@ -791,6 +920,7 @@ class ActionCallValidator:
         messages = {
             ValidationResult.INVALID_REPOSITORY: "Repository not found",
             ValidationResult.INVALID_REFERENCE: "Invalid branch, tag, or commit SHA",
+            ValidationResult.INVALID_PATH: "Subdirectory action path not found at reference",
             ValidationResult.INVALID_SYNTAX: "Invalid action call syntax",
             ValidationResult.NETWORK_ERROR: "Network error during validation",
             ValidationResult.TIMEOUT: "Timeout during validation",
@@ -824,6 +954,7 @@ class ActionCallValidator:
             "duplicate_calls_avoided": max(0, total_calls - unique_calls),
             "invalid_repositories": 0,
             "invalid_references": 0,
+            "invalid_paths": 0,
             "syntax_errors": 0,
             "network_errors": 0,
             "timeouts": 0,
@@ -848,6 +979,8 @@ class ActionCallValidator:
                 summary["invalid_repositories"] += 1
             elif error.result == ValidationResult.INVALID_REFERENCE:
                 summary["invalid_references"] += 1
+            elif error.result == ValidationResult.INVALID_PATH:
+                summary["invalid_paths"] += 1
             elif error.result == ValidationResult.INVALID_SYNTAX:
                 summary["syntax_errors"] += 1
             elif error.result == ValidationResult.NETWORK_ERROR:

--- a/tests/test_git_validator.py
+++ b/tests/test_git_validator.py
@@ -5,12 +5,18 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from gha_workflow_linter import git_validator
+from gha_workflow_linter.exceptions import GitError
 from gha_workflow_linter.git_validator import (
+    GitValidationClient,
     _base_repository,
+    _run_git_subpath_exists,
     _validate_repository_exists,
+    _validate_repository_subpaths,
 )
 from gha_workflow_linter.models import GitConfig, ValidationResult
 
@@ -56,3 +62,285 @@ def test_validate_repository_exists_uses_base_repo_url(
     assert result == ValidationResult.VALID
     assert seen_urls == ["https://github.com/anchore/scan-action.git"]
     assert "download-grype" not in seen_urls[0]
+
+
+def test_validate_repository_subpaths_valid_and_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing subpaths validate; bogus subpaths report INVALID_PATH.
+
+    The base repo + ref are assumed already validated, so this exercises only
+    the tree-existence check: ``init`` exists at the ref while ``not-real``
+    does not.
+    """
+    monkeypatch.setattr(
+        git_validator, "_run_git_init", lambda _dir, _config: True
+    )
+
+    fetched_refs: list[str] = []
+
+    def fake_fetch(
+        _repo_dir: object, _url: str, ref: str, _config: GitConfig
+    ) -> bool:
+        fetched_refs.append(ref)
+        return True
+
+    monkeypatch.setattr(git_validator, "_run_git_fetch_partial", fake_fetch)
+
+    def fake_subpath_exists(
+        _repo_dir: object, _treeish: str, subpath: str, _config: GitConfig
+    ) -> bool:
+        return subpath == "init"
+
+    monkeypatch.setattr(
+        git_validator, "_run_git_subpath_exists", fake_subpath_exists
+    )
+
+    entries = [
+        ("github/codeql-action/init", "v3"),
+        ("github/codeql-action/not-real", "v3"),
+    ]
+    results = _validate_repository_subpaths(
+        "github/codeql-action", entries, GitConfig()
+    )
+
+    assert results[("github/codeql-action/init", "v3")] == (
+        ValidationResult.VALID
+    )
+    assert results[("github/codeql-action/not-real", "v3")] == (
+        ValidationResult.INVALID_PATH
+    )
+    # The shared ref is fetched exactly once for both subpath entries.
+    assert fetched_refs == ["v3"]
+
+
+def test_validate_repository_subpaths_fetch_failure_is_not_bogus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fetch failure on an already-valid ref is a network error, not bogus.
+
+    Reporting INVALID_PATH here would be a false negative, so the worker
+    returns NETWORK_ERROR and never consults the tree.
+    """
+    monkeypatch.setattr(
+        git_validator, "_run_git_init", lambda _dir, _config: True
+    )
+    monkeypatch.setattr(
+        git_validator,
+        "_run_git_fetch_partial",
+        lambda _repo_dir, _url, _ref, _config: False,
+    )
+
+    def unexpected_subpath_check(*_args: object, **_kwargs: object) -> bool:
+        raise AssertionError("subpath check must not run when fetch fails")
+
+    monkeypatch.setattr(
+        git_validator, "_run_git_subpath_exists", unexpected_subpath_check
+    )
+
+    entries = [("github/codeql-action/init", "v3")]
+    results = _validate_repository_subpaths(
+        "github/codeql-action", entries, GitConfig()
+    )
+
+    assert results[("github/codeql-action/init", "v3")] == (
+        ValidationResult.NETWORK_ERROR
+    )
+
+
+def test_run_git_subpath_exists_command_and_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ls-tree probes all candidates and treats non-empty output as present."""
+    import pathlib
+    import subprocess
+
+    captured: dict[str, list[str]] = {}
+
+    class FakeCompleted:
+        def __init__(self, returncode: int, stdout: str) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> FakeCompleted:
+        captured["cmd"] = cmd
+        # Simulate a found directory entry.
+        return FakeCompleted(0, "040000 tree abc123\tinit\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    exists = _run_git_subpath_exists(
+        pathlib.Path("/tmp/repo"), "FETCH_HEAD", "init", GitConfig()
+    )
+
+    assert exists is True
+    # All candidate paths are passed to a single ls-tree invocation.
+    assert "ls-tree" in captured["cmd"]
+    assert "init/action.yml" in captured["cmd"]
+    assert "init/action.yaml" in captured["cmd"]
+    assert "init" in captured["cmd"]
+
+
+def test_run_git_subpath_exists_empty_output_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty ls-tree output (exit 0) means the path does not exist."""
+    import pathlib
+    import subprocess
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda _cmd, **_kwargs: FakeCompleted(),
+    )
+
+    exists = _run_git_subpath_exists(
+        pathlib.Path("/tmp/repo"), "FETCH_HEAD", "not-real", GitConfig()
+    )
+
+    assert exists is False
+
+
+def test_run_git_subpath_exists_nonzero_exit_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero ls-tree exit is inconclusive and raises GitError.
+
+    A command failure (e.g. a missing object) must be distinguished from a
+    subpath being genuinely absent, so callers can treat it as inconclusive
+    rather than a bogus path.
+    """
+    import pathlib
+    import subprocess
+
+    class FakeCompleted:
+        returncode = 128
+        stdout = ""
+        stderr = "fatal: not a tree object"
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda _cmd, **_kwargs: FakeCompleted(),
+    )
+
+    with pytest.raises(GitError):
+        _run_git_subpath_exists(
+            pathlib.Path("/tmp/repo"), "FETCH_HEAD", "init", GitConfig()
+        )
+
+
+def test_run_git_subpath_exists_timeout_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout while running ls-tree is inconclusive and raises GitError."""
+    import pathlib
+    import subprocess
+
+    def fake_run(_cmd: list[str], **_kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(cmd="git ls-tree", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(GitError):
+        _run_git_subpath_exists(
+            pathlib.Path("/tmp/repo"), "FETCH_HEAD", "init", GitConfig()
+        )
+
+
+def test_validate_repository_subpaths_ls_tree_failure_is_inconclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GitError from the ls-tree check maps to NETWORK_ERROR, not bogus.
+
+    The repo + ref are already validated and the fetch succeeds, so a failure
+    to run the tree check itself must be reported as inconclusive rather than
+    a definitive INVALID_PATH.
+    """
+    monkeypatch.setattr(
+        git_validator, "_run_git_init", lambda _dir, _config: True
+    )
+    monkeypatch.setattr(
+        git_validator,
+        "_run_git_fetch_partial",
+        lambda _repo_dir, _url, _ref, _config: True,
+    )
+
+    def boom(*_args: object, **_kwargs: object) -> bool:
+        raise GitError("ls-tree exploded")
+
+    monkeypatch.setattr(git_validator, "_run_git_subpath_exists", boom)
+
+    entries = [("github/codeql-action/init", "v3")]
+    results = _validate_repository_subpaths(
+        "github/codeql-action", entries, GitConfig()
+    )
+
+    assert results[("github/codeql-action/init", "v3")] == (
+        ValidationResult.NETWORK_ERROR
+    )
+
+
+@pytest.mark.asyncio
+async def test_validate_subpaths_batch_gather_failure_is_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gather-level failure maps every entry to NETWORK_ERROR, not bogus.
+
+    If ``asyncio.gather`` itself raises (e.g. cancellation), the fallback must
+    route entries through the ``isinstance(..., Exception)`` branch so they are
+    reported as inconclusive ``NETWORK_ERROR`` rather than misclassified as
+    ``INVALID_PATH``. Uses a fake executor so no real subprocess/network runs.
+    """
+    import concurrent.futures
+
+    class _FakeExecutor:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> _FakeExecutor:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def submit(
+            self, _fn: object, *_args: object, **_kwargs: object
+        ) -> concurrent.futures.Future[object]:
+            future: concurrent.futures.Future[object] = (
+                concurrent.futures.Future()
+            )
+            # Never consumed: gather is patched to raise before awaiting.
+            future.set_result({})
+            return future
+
+    monkeypatch.setattr(git_validator, "ProcessPoolExecutor", _FakeExecutor)
+
+    async def boom(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("gather exploded")
+
+    # Patch the shared asyncio module object (git_validator references the same
+    # singleton via ``import asyncio``); nothing between here and the awaited
+    # call uses gather, so this only affects validate_subpaths_batch.
+    monkeypatch.setattr(asyncio, "gather", boom)
+
+    client = GitValidationClient(GitConfig())
+    results = await client.validate_subpaths_batch(
+        [
+            ("github/codeql-action/init", "v3"),
+            ("github/codeql-action/analyze", "v3"),
+        ]
+    )
+
+    assert results[("github/codeql-action/init", "v3")] == (
+        ValidationResult.NETWORK_ERROR
+    )
+    assert results[("github/codeql-action/analyze", "v3")] == (
+        ValidationResult.NETWORK_ERROR
+    )

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the shared repository path / subpath helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from gha_workflow_linter.paths import (
+    ACTION_METADATA_FILENAMES,
+    action_subpath,
+    action_subpath_candidates,
+    base_repository,
+    has_action_subpath,
+    split_repository_subpath,
+)
+
+
+@pytest.mark.parametrize(
+    ("repository", "expected_base", "expected_subpath"),
+    [
+        ("actions/checkout", "actions/checkout", None),
+        (
+            "anchore/scan-action/download-grype",
+            "anchore/scan-action",
+            "download-grype",
+        ),
+        ("github/codeql-action/init", "github/codeql-action", "init"),
+        ("owner/repo/nested/path", "owner/repo", "nested/path"),
+        ("owner/repo", "owner/repo", None),
+        ("single", "single", None),
+    ],
+)
+def test_split_repository_subpath(
+    repository: str, expected_base: str, expected_subpath: str | None
+) -> None:
+    """Identifiers split into ``(owner/repo, subpath)`` correctly."""
+    base, subpath = split_repository_subpath(repository)
+    assert base == expected_base
+    assert subpath == expected_subpath
+
+
+@pytest.mark.parametrize(
+    ("repository", "expected"),
+    [
+        ("actions/checkout", "actions/checkout"),
+        ("anchore/scan-action/download-grype", "anchore/scan-action"),
+        ("github/codeql-action/init", "github/codeql-action"),
+        ("owner/repo/nested/path", "owner/repo"),
+        ("owner/repo", "owner/repo"),
+        ("single", "single"),
+    ],
+)
+def test_base_repository(repository: str, expected: str) -> None:
+    """The owner/repo base is returned, dropping any trailing subpath."""
+    assert base_repository(repository) == expected
+
+
+@pytest.mark.parametrize(
+    ("repository", "expected"),
+    [
+        ("actions/checkout", None),
+        ("github/codeql-action/init", "init"),
+        ("owner/repo/nested/path", "nested/path"),
+        ("single", None),
+    ],
+)
+def test_action_subpath(repository: str, expected: str | None) -> None:
+    """The trailing subpath (or None) is returned."""
+    assert action_subpath(repository) == expected
+
+
+@pytest.mark.parametrize(
+    ("repository", "expected"),
+    [
+        ("actions/checkout", False),
+        ("github/codeql-action/init", True),
+        ("owner/repo/nested/path", True),
+        ("owner/repo", False),
+        ("single", False),
+    ],
+)
+def test_has_action_subpath(repository: str, expected: bool) -> None:
+    """Subdirectory actions are detected by path-segment count."""
+    assert has_action_subpath(repository) is expected
+
+
+def test_action_subpath_candidates_order_and_content() -> None:
+    """Candidates prefer action metadata files, then the directory itself."""
+    candidates = action_subpath_candidates("init")
+    assert candidates == [
+        "init/action.yml",
+        "init/action.yaml",
+        "init",
+    ]
+    # Metadata filenames are sourced from the shared constant.
+    assert candidates[: len(ACTION_METADATA_FILENAMES)] == [
+        f"init/{name}" for name in ACTION_METADATA_FILENAMES
+    ]
+
+
+def test_action_subpath_candidates_strips_surrounding_slashes() -> None:
+    """Leading/trailing slashes in the subpath are normalised away."""
+    assert action_subpath_candidates("/nested/path/") == [
+        "nested/path/action.yml",
+        "nested/path/action.yaml",
+        "nested/path",
+    ]

--- a/tests/test_subpath_validation.py
+++ b/tests/test_subpath_validation.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for subdirectory (monorepo) action subpath validation.
+
+Covers the GitHub GraphQL API path, and the validator orchestration for both
+the API and Git validation methods, ensuring that a subdirectory action with a
+valid base repo + ref but a bogus subpath is rejected, while a real one is
+accepted -- consistently across methods and with results cached.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from gha_workflow_linter.github_api import GitHubGraphQLClient
+from gha_workflow_linter.models import (
+    ActionCall,
+    ActionCallType,
+    CacheConfig,
+    Config,
+    GitHubAPIConfig,
+    GitHubRateLimitInfo,
+    ReferenceType,
+    ValidationError,
+    ValidationMethod,
+    ValidationResult,
+)
+from gha_workflow_linter.validator import ActionCallValidator
+
+# ---------------------------------------------------------------------------
+# GitHub GraphQL API path
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> GitHubGraphQLClient:
+    # Deliberately not a real GitHub token shape (no ``ghp_`` prefix) so secret
+    # scanning does not flag it; GitHubAPIConfig does not validate token form.
+    return GitHubGraphQLClient(GitHubAPIConfig(token="fake-test-token"))
+
+
+@pytest.mark.asyncio
+async def test_subpaths_graphql_batch_valid_and_invalid() -> None:
+    """A real subpath resolves; a bogus subpath does not."""
+    client = _make_client()
+
+    # sp_0 -> github/codeql-action/init (valid: action.yml present)
+    # sp_1 -> github/codeql-action/not-real (bogus: nothing resolves)
+    response = {
+        "data": {
+            "sp_0": {
+                "sp_0_c0": {"__typename": "Blob"},
+                "sp_0_c1": None,
+                "sp_0_c2": {"__typename": "Tree"},
+            },
+            "sp_1": {
+                "sp_1_c0": None,
+                "sp_1_c1": None,
+                "sp_1_c2": None,
+            },
+        }
+    }
+
+    with patch.object(
+        client, "_execute_graphql_query", return_value=response
+    ) as mock_execute:
+        results = await client._validate_subpaths_graphql_batch(
+            [
+                ("github/codeql-action/init", "v3"),
+                ("github/codeql-action/not-real", "v3"),
+            ]
+        )
+
+    assert results[("github/codeql-action/init", "v3")] is True
+    assert results[("github/codeql-action/not-real", "v3")] is False
+
+    # The generated query targets the base repo and probes the subpath at ref.
+    query = mock_execute.call_args[0][0]
+    assert 'repository(owner: "github", name: "codeql-action")' in query
+    assert "v3:init/action.yml" in query
+    assert "v3:not-real/action.yml" in query
+    # The subpath must never leak into the repository name.
+    assert 'name: "codeql-action/init"' not in query
+
+
+@pytest.mark.asyncio
+async def test_subpaths_graphql_batch_directory_fallback() -> None:
+    """A directory that exists without action metadata still validates."""
+    client = _make_client()
+
+    response = {
+        "data": {
+            "sp_0": {
+                "sp_0_c0": None,
+                "sp_0_c1": None,
+                # Only the directory itself resolves (fallback candidate).
+                "sp_0_c2": {"__typename": "Tree"},
+            }
+        }
+    }
+
+    with patch.object(client, "_execute_graphql_query", return_value=response):
+        results = await client._validate_subpaths_graphql_batch(
+            [("owner/repo/tools", "v1")]
+        )
+
+    assert results[("owner/repo/tools", "v1")] is True
+
+
+@pytest.mark.asyncio
+async def test_validate_subpaths_batch_uses_and_populates_cache() -> None:
+    """Repeated subpath checks are served from the in-memory cache."""
+    client = _make_client()
+
+    call_count = {"n": 0}
+
+    async def fake_batch(
+        batch: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], bool]:
+        call_count["n"] += 1
+        return dict.fromkeys(batch, True)
+
+    with patch.object(
+        client, "_validate_subpaths_graphql_batch", side_effect=fake_batch
+    ):
+        first = await client.validate_subpaths_batch(
+            [("github/codeql-action/init", "v3")]
+        )
+        # Second call for the same (repo_key, ref) should hit the cache.
+        second = await client.validate_subpaths_batch(
+            [("github/codeql-action/init", "v3")]
+        )
+
+    assert first == {("github/codeql-action/init", "v3"): True}
+    assert second == {("github/codeql-action/init", "v3"): True}
+    assert call_count["n"] == 1
+    assert client.api_stats.cache_hits >= 1
+
+
+def test_graphql_string_literal_escapes_special_characters() -> None:
+    """Quotes and backslashes are escaped to keep the query well-formed."""
+    escaped = GitHubGraphQLClient._graphql_string_literal('a"b\\c')
+    assert escaped == 'a\\"b\\\\c'
+
+
+@pytest.mark.asyncio
+async def test_subpaths_graphql_batch_unexpected_error_propagates() -> None:
+    """An unexpected (non-API) error re-raises instead of returning False.
+
+    A non-data failure (e.g. a response-parsing bug) must not be reported as a
+    bogus subpath; it propagates so the validator can abort the run.
+    """
+    client = _make_client()
+
+    with (
+        patch.object(
+            client,
+            "_execute_graphql_query",
+            side_effect=ValueError("boom"),
+        ),
+        pytest.raises(ValueError, match="boom"),
+    ):
+        await client._validate_subpaths_graphql_batch(
+            [("github/codeql-action/init", "v3")]
+        )
+
+
+@pytest.mark.asyncio
+async def test_validate_subpaths_batch_unexpected_error_not_cached() -> None:
+    """An unexpected error propagates and is never cached as a bogus False.
+
+    Caching ``False`` for an internal failure would poison the subpath cache
+    for the rest of the run and permanently mask a real subpath. The error
+    must propagate (so the validator aborts) and leave the cache untouched.
+    """
+    client = _make_client()
+
+    async def boom(
+        _batch: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], bool]:
+        raise ValueError("unexpected")
+
+    with (
+        patch.object(
+            client, "_validate_subpaths_graphql_batch", side_effect=boom
+        ),
+        pytest.raises(ValueError, match="unexpected"),
+    ):
+        await client.validate_subpaths_batch(
+            [("github/codeql-action/init", "v3")]
+        )
+
+    # Nothing was cached, so a later run re-checks rather than serving a
+    # benefit-of-the-doubt or bogus result.
+    assert client._subpath_cache == {}
+    assert client.api_stats.failed_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Validator orchestration (both methods)
+# ---------------------------------------------------------------------------
+
+
+def _subdir_action() -> ActionCall:
+    return ActionCall(
+        raw_line="uses: github/codeql-action/init@v3",
+        line_number=1,
+        organization="github",
+        repository="codeql-action/init",
+        reference="v3",
+        reference_type=ReferenceType.TAG,
+        call_type=ActionCallType.ACTION,
+        comment=None,
+    )
+
+
+def _plain_action() -> ActionCall:
+    return ActionCall(
+        raw_line="uses: actions/checkout@v4",
+        line_number=2,
+        organization="actions",
+        repository="checkout",
+        reference="v4",
+        reference_type=ReferenceType.TAG,
+        call_type=ActionCallType.ACTION,
+        comment=None,
+    )
+
+
+def _validator() -> ActionCallValidator:
+    config = Config(
+        require_pinned_sha=False,
+        cache=CacheConfig(enabled=False),
+    )
+    validator = ActionCallValidator(config)
+    validator._validation_method = ValidationMethod.GITHUB_API
+    return validator
+
+
+def _api_client_mock(stats_owner: ActionCallValidator) -> AsyncMock:
+    """Build an AsyncMock GitHub client with sync stat accessors.
+
+    ``get_api_stats`` and ``get_rate_limit_info`` are synchronous methods on
+    the real client, so they must not be left as coroutine-returning
+    AsyncMocks.
+    """
+    client = AsyncMock()
+    client.get_api_stats = Mock(return_value=stats_owner.api_stats)
+    client.get_rate_limit_info = Mock(return_value=GitHubRateLimitInfo())
+    return client
+
+
+@pytest.mark.asyncio
+async def test_validator_api_rejects_bogus_subpath() -> None:
+    """API method: valid base repo + ref but bogus subpath -> INVALID_PATH."""
+    validator = _validator()
+
+    repo_key = "github/codeql-action/not-real"
+    client = _api_client_mock(validator)
+    client.validate_repositories_batch.return_value = {repo_key: True}
+    client.validate_references_batch.return_value = {(repo_key, "v3"): True}
+    client.validate_subpaths_batch.return_value = {(repo_key, "v3"): False}
+    validator._github_client = client
+
+    action_call = _subdir_action().model_copy(
+        update={"repository": "codeql-action/not-real"}
+    )
+    action_calls = {Path("wf.yml"): {1: action_call}}
+
+    errors = await validator._perform_validation(
+        action_calls, use_github_api=True
+    )
+
+    assert len(errors) == 1
+    assert errors[0].result == ValidationResult.INVALID_PATH
+    # Only the subdirectory action triggers a subpath check.
+    client.validate_subpaths_batch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_validator_api_accepts_real_subpath() -> None:
+    """API method: a real subpath at a valid ref validates as VALID."""
+    validator = _validator()
+
+    repo_key = "github/codeql-action/init"
+    client = _api_client_mock(validator)
+    client.validate_repositories_batch.return_value = {repo_key: True}
+    client.validate_references_batch.return_value = {(repo_key, "v3"): True}
+    client.validate_subpaths_batch.return_value = {(repo_key, "v3"): True}
+    validator._github_client = client
+
+    action_calls = {Path("wf.yml"): {1: _subdir_action()}}
+
+    errors = await validator._perform_validation(
+        action_calls, use_github_api=True
+    )
+
+    assert errors == []
+
+
+@pytest.mark.asyncio
+async def test_validator_plain_action_skips_subpath_check() -> None:
+    """A plain owner/repo action never triggers subpath validation."""
+    validator = _validator()
+
+    client = _api_client_mock(validator)
+    client.validate_repositories_batch.return_value = {"actions/checkout": True}
+    client.validate_references_batch.return_value = {
+        ("actions/checkout", "v4"): True
+    }
+    validator._github_client = client
+
+    action_calls = {Path("wf.yml"): {2: _plain_action()}}
+
+    errors = await validator._perform_validation(
+        action_calls, use_github_api=True
+    )
+
+    assert errors == []
+    client.validate_subpaths_batch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_validator_git_rejects_bogus_subpath() -> None:
+    """Git method: a bogus subpath maps to INVALID_PATH consistently."""
+    validator = _validator()
+    validator._validation_method = ValidationMethod.GIT
+
+    repo_key = "github/codeql-action/not-real"
+    client = AsyncMock()
+    client.validate_repositories_batch.return_value = {
+        repo_key: ValidationResult.VALID
+    }
+    client.validate_references_batch.return_value = {
+        (repo_key, "v3"): ValidationResult.VALID
+    }
+    client.validate_subpaths_batch.return_value = {
+        (repo_key, "v3"): ValidationResult.INVALID_PATH
+    }
+    validator._git_client = client
+
+    action_call = _subdir_action().model_copy(
+        update={"repository": "codeql-action/not-real"}
+    )
+    action_calls = {Path("wf.yml"): {1: action_call}}
+
+    errors = await validator._perform_validation(
+        action_calls, use_github_api=False
+    )
+
+    assert len(errors) == 1
+    assert errors[0].result == ValidationResult.INVALID_PATH
+    client.validate_subpaths_batch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_validator_git_network_error_not_treated_as_bogus() -> None:
+    """Git method: a transient subpath error does not flag a bogus path."""
+    validator = _validator()
+    validator._validation_method = ValidationMethod.GIT
+
+    repo_key = "github/codeql-action/init"
+    client = AsyncMock()
+    client.validate_repositories_batch.return_value = {
+        repo_key: ValidationResult.VALID
+    }
+    client.validate_references_batch.return_value = {
+        (repo_key, "v3"): ValidationResult.VALID
+    }
+    # A NETWORK_ERROR result must be given the benefit of the doubt.
+    client.validate_subpaths_batch.return_value = {
+        (repo_key, "v3"): ValidationResult.NETWORK_ERROR
+    }
+    validator._git_client = client
+
+    action_calls = {Path("wf.yml"): {1: _subdir_action()}}
+
+    errors = await validator._perform_validation(
+        action_calls, use_github_api=False
+    )
+
+    assert errors == []
+
+
+@pytest.mark.asyncio
+async def test_validator_git_inconclusive_subpath_not_cached() -> None:
+    """Git method: an inconclusive subpath check is not cached as VALID.
+
+    A transient failure (NETWORK_ERROR) is given the benefit of the doubt for
+    the current run, but must be excluded from the cache so the next run
+    retries instead of persisting a false VALID that masks a bogus subpath. A
+    conclusively-valid subpath alongside it is still cached.
+    """
+    validator = _validator()
+    validator._validation_method = ValidationMethod.GIT
+
+    valid_key = "github/codeql-action/init"
+    incon_key = "github/codeql-action/analyze"
+
+    client = AsyncMock()
+    client.validate_repositories_batch.return_value = {
+        valid_key: ValidationResult.VALID,
+        incon_key: ValidationResult.VALID,
+    }
+    client.validate_references_batch.return_value = {
+        (valid_key, "v3"): ValidationResult.VALID,
+        (incon_key, "v3"): ValidationResult.VALID,
+    }
+    client.validate_subpaths_batch.return_value = {
+        (valid_key, "v3"): ValidationResult.VALID,
+        (incon_key, "v3"): ValidationResult.NETWORK_ERROR,
+    }
+    validator._git_client = client
+
+    # Spy on cache reads/writes.
+    cache = Mock()
+    cache.get_batch.return_value = (
+        {},
+        [(valid_key, "v3"), (incon_key, "v3")],
+    )
+    cache.stats.hits = 0
+    validator._cache = cache
+
+    init_call = _subdir_action()
+    analyze_call = _subdir_action().model_copy(
+        update={"repository": "codeql-action/analyze", "line_number": 2}
+    )
+    action_calls = {Path("wf.yml"): {1: init_call, 2: analyze_call}}
+
+    errors = await validator._perform_validation(
+        action_calls, use_github_api=False
+    )
+
+    # Neither surfaces an error this run (inconclusive gets the benefit of
+    # the doubt).
+    assert errors == []
+
+    # Only the conclusively-valid subpath is cached; the inconclusive one is
+    # excluded so it can be retried.
+    cache.put_batch.assert_called_once()
+    stored_keys = {
+        (repo, ref) for repo, ref, *_ in cache.put_batch.call_args[0][0]
+    }
+    assert (valid_key, "v3") in stored_keys
+    assert (incon_key, "v3") not in stored_keys
+
+
+def test_invalid_path_error_message_and_summary() -> None:
+    """INVALID_PATH has a human-readable message and its own summary counter."""
+    validator = _validator()
+
+    message = validator._get_error_message(ValidationResult.INVALID_PATH)
+    assert "path" in message.lower()
+
+    error = ValidationError(
+        file_path=Path("wf.yml"),
+        action_call=_subdir_action(),
+        result=ValidationResult.INVALID_PATH,
+        error_message=message,
+    )
+    summary = validator.get_validation_summary(
+        [error], total_calls=1, unique_calls=1
+    )
+    assert summary["invalid_paths"] == 1
+    assert summary["invalid_references"] == 0


### PR DESCRIPTION
## Summary

Closes #238.

Neither validation method verified that the **subdirectory path** of a monorepo / composite action actually exists at the referenced ref. Both methods stripped the subpath to `owner/repo` and validated only the base repository and the ref, so an action with a valid base repo and ref but a **bogus subpath** was wrongly accepted as valid:

```yaml
uses: actions/checkout/not-a-real-action@v4   # base repo + ref valid, subpath bogus -> previously PASSED
```

This closes the remaining gap left open after #237, consistently across **both** the GitHub API (GraphQL) and Git validation paths.

## Approach: shared central helpers

New module `paths.py` is the single source of truth for subpath handling, consumed by every path:

- `split_repository_subpath` / `base_repository` / `action_subpath` / `has_action_subpath`
- `action_subpath_candidates` — the one shared definition of what proves a subdir action exists: `<sub>/action.yml`, `<sub>/action.yaml`, then `<sub>` itself (directory fallback). Both methods probe identically, guaranteeing consistent results.

`git_validator._base_repository` and `auto_fix._get_base_repository` now delegate to this module.

## Both validation methods

- **GitHub API** (`github_api.py`): `validate_subpaths_batch` resolves each subpath with a batched GraphQL `object(expression: "<ref>:<path>")` tree lookup (~O(1) per subdir action), with an in-memory subpath cache and GraphQL-literal escaping.
- **Git** (`git_validator.py`): `validate_subpaths_batch` does one blobless, shallow partial fetch (`--filter=blob:none`) per ref into a throwaway repo, then `git ls-tree` of the candidate paths. A fetch failure on an already-valid ref is treated as a transient error (never bogus) to avoid false negatives.

## Orchestration, caching, performance

- The validator gates the subpath check (Step 2.5) to subdirectory actions whose repo **and** ref already validated — plain `owner/repo` calls add **zero** extra network work.
- New `ValidationResult.INVALID_PATH`, folded into the existing validation cache (already keyed by the full identifier incl. subpath), so results cache and reload consistently — including cached `INVALID_PATH` reconstructing correctly through `_combine_validation_results`.
- Auto-fix preserves subpaths (including on redirects) and treats `INVALID_PATH` as non-fixable (changing the ref cannot make a non-existent path appear).
- README error-type table and JSON summary updated.

## Acceptance criteria

- [x] A valid subdirectory action (`owner/repo/path@ref` where `path` exists at `ref`) validates as VALID.
- [x] An invalid subdirectory action (`owner/repo/bogus@ref` with valid base repo + ref) is rejected (`INVALID_PATH`).
- [x] Behaviour is consistent across the API and Git validation methods.
- [x] Subdirectory checks only add network work for subdirectory actions; plain `owner/repo` calls are unaffected.
- [x] Results are cached consistently with existing repo/ref validation.
- [x] Regression tests cover valid and invalid subpaths under a valid repo/ref, for both methods.

## Tests

- `tests/test_paths.py` — shared helper unit tests
- `tests/test_git_validator.py` — Git subpath worker (valid / invalid / fetch-failure) + `ls-tree` command/parsing
- `tests/test_subpath_validation.py` — GraphQL batch (valid / invalid / directory fallback / caching / escaping) and validator integration for **both** methods, plain-action skip, and error-message/summary wiring

Full suite: **695 passed, 22 skipped**. `ruff`, `mypy`, `reuse`, and all `pre-commit` hooks pass; coverage gate 75.6% (> 70%).