### PR TITLE
Chore: Raise lint baseline to Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,9 @@ version-file = "src/gha_workflow_linter/_version.py"
 packages = ["src/gha_workflow_linter"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 80
+extend-exclude = ["src/gha_workflow_linter/_version.py"]
 
 [tool.ruff.lint]
 select = [
@@ -114,7 +115,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest-asyncio>=0.25.0",
     "pytest-mock>=3.14.0",
+    "pytest-timeout>=2.3.1",
     "mypy>=1.19.1",
     "ruff>=0.14.10",
     "pre-commit>=4.5.1",
@@ -174,6 +175,12 @@ addopts = [
     "--cov-report=html",
     "--cov-report=xml",
     "--cov-fail-under=70",
+    # Fail (with a traceback of all threads) any test that hangs, instead of
+    # silently consuming the job's timeout-minutes. The thread method dumps
+    # stacks even when the hang is in C/subprocess code. No individual test
+    # should take anywhere near this long.
+    "--timeout=120",
+    "--timeout-method=thread",
 ]
 filterwarnings = [
     "ignore:install \"ipywidgets\" for Jupyter support:UserWarning",

--- a/scripts/profile_performance.py
+++ b/scripts/profile_performance.py
@@ -19,7 +19,6 @@ import pstats
 from pstats import SortKey
 import sys
 import time
-from typing import Optional
 
 # Add parent directory to path to import the linter
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -28,7 +27,7 @@ from gha_workflow_linter.cli import app as cli_app
 
 
 def profile_with_cprofile(
-    args: list[str], output_file: Optional[str] = None
+    args: list[str], output_file: str | None = None
 ) -> pstats.Stats:
     """Profile the linter using cProfile."""
     profiler = cProfile.Profile()

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -1845,7 +1845,7 @@ class AutoFixer:
         else:
             fetch_results = []
 
-        for repo_key, result in zip(repos_to_fetch, fetch_results):
+        for repo_key, result in zip(repos_to_fetch, fetch_results, strict=True):
             if isinstance(result, Exception):
                 self.logger.debug(
                     f"Failed to fetch latest version for {repo_key}: {result}"
@@ -2400,7 +2400,7 @@ class AutoFixer:
         ]
         fetch_results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        for (repo_key, ref), result in zip(refs, fetch_results):
+        for (repo_key, ref), result in zip(refs, fetch_results, strict=True):
             if isinstance(result, Exception):
                 self.logger.debug(
                     f"Failed to fetch SHA for {repo_key}@{ref}: {result}"

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -2052,6 +2052,7 @@ class AutoFixer:
         repo_data: dict[str, Any],
         all_tags: list[tuple[str, str]],
         tag_dates: dict[str, datetime | None],
+        now: datetime | None = None,
     ) -> tuple[str, str] | None:
         """Choose a cooldown-eligible ``(tag, sha)`` from GraphQL repo data.
 
@@ -2067,6 +2068,8 @@ class AutoFixer:
             tag_dates: Mapping of tag name to its publication ``datetime``
                 (``None`` when no verifiable publication time exists, e.g.
                 lightweight tags).
+            now: Reference time for the cooldown window (defaults to the
+                current UTC time); primarily an injection point for tests.
 
         Returns:
             The newest eligible ``(tag, sha)`` tuple, or ``None`` when no
@@ -2094,7 +2097,7 @@ class AutoFixer:
         )
 
         selected = _select_version_with_cooldown(
-            candidates, self.config.cooldown_days
+            candidates, self.config.cooldown_days, now=now
         )
         if not selected:
             return None

--- a/src/gha_workflow_linter/exceptions.py
+++ b/src/gha_workflow_linter/exceptions.py
@@ -8,8 +8,6 @@ This module defines exception classes that provide more granular error handling,
 particularly for network connectivity and API access issues.
 """
 
-from typing import Optional
-
 
 class ValidationError(Exception):
     """Base class for validation errors."""
@@ -20,9 +18,7 @@ class ValidationError(Exception):
 class NetworkError(ValidationError):
     """Raised when network connectivity issues prevent validation."""
 
-    def __init__(
-        self, message: str, original_error: Optional[Exception] = None
-    ):
+    def __init__(self, message: str, original_error: Exception | None = None):
         self.message = message
         self.original_error = original_error
         super().__init__(message)
@@ -34,8 +30,8 @@ class GitHubAPIError(ValidationError):
     def __init__(
         self,
         message: str,
-        status_code: Optional[int] = None,
-        original_error: Optional[Exception] = None,
+        status_code: int | None = None,
+        original_error: Exception | None = None,
     ):
         self.message = message
         self.status_code = status_code
@@ -63,8 +59,8 @@ class TemporaryAPIError(GitHubAPIError):
     def __init__(
         self,
         message: str,
-        status_code: Optional[int] = None,
-        original_error: Optional[Exception] = None,
+        status_code: int | None = None,
+        original_error: Exception | None = None,
     ):
         self.message = message
         self.status_code = status_code
@@ -79,7 +75,7 @@ class ValidationAbortedError(ValidationError):
         self,
         message: str,
         reason: str,
-        original_error: Optional[Exception] = None,
+        original_error: Exception | None = None,
     ):
         self.message = message
         self.reason = reason
@@ -90,9 +86,7 @@ class ValidationAbortedError(ValidationError):
 class GitError(ValidationError):
     """Raised when Git operations fail."""
 
-    def __init__(
-        self, message: str, original_error: Optional[Exception] = None
-    ):
+    def __init__(self, message: str, original_error: Exception | None = None):
         self.message = message
         self.original_error = original_error
         super().__init__(message)
@@ -101,7 +95,7 @@ class GitError(ValidationError):
 class RepositoryNotFoundError(ValidationError):
     """Raised when a repository cannot be found or accessed."""
 
-    def __init__(self, repository: str, message: Optional[str] = None):
+    def __init__(self, repository: str, message: str | None = None):
         self.repository = repository
         if message is None:
             message = f"Repository not found: {repository}"
@@ -112,7 +106,7 @@ class ReferenceNotFoundError(ValidationError):
     """Raised when a Git reference cannot be found."""
 
     def __init__(
-        self, repository: str, reference: str, message: Optional[str] = None
+        self, repository: str, reference: str, message: str | None = None
     ):
         self.repository = repository
         self.reference = reference

--- a/src/gha_workflow_linter/git_validator.py
+++ b/src/gha_workflow_linter/git_validator.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 import logging
-import multiprocessing
+import os
 import re
 import tempfile
 from typing import TYPE_CHECKING
@@ -63,7 +63,7 @@ class GitValidationClient:
             self._max_workers = config.max_parallel_operations
         else:
             # Use CPU count, but cap at reasonable limits
-            cpu_count = multiprocessing.cpu_count()
+            cpu_count = os.cpu_count() or 4
             self._max_workers = min(max(cpu_count, 4), 16)
 
         self.logger.debug(
@@ -89,10 +89,14 @@ class GitValidationClient:
             f"Validating {len(repositories)} repositories using Git"
         )
 
-        # Use asyncio to run the multiprocessing validation
+        # Run the blocking Git operations in a thread pool. The work is
+        # I/O-bound (it shells out to ``git``), so threads avoid the per-call
+        # process-pool startup cost and the multiprocessing start-method
+        # differences across platforms / Python versions (e.g. Python 3.14
+        # defaulting to ``forkserver`` on Linux).
         loop = asyncio.get_running_loop()
 
-        with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             # Submit all validation tasks
             futures = [
                 loop.run_in_executor(
@@ -170,7 +174,7 @@ class GitValidationClient:
         loop = asyncio.get_running_loop()
         results = {}
 
-        with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             # Submit validation tasks grouped by repository
             futures = []
             repo_ref_list = []
@@ -282,7 +286,7 @@ class GitValidationClient:
         loop = asyncio.get_running_loop()
         results: dict[tuple[str, str], ValidationResult] = {}
 
-        with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             futures = []
             entry_groups: list[list[tuple[str, str]]] = []
             for base, entries in repo_to_entries.items():
@@ -349,7 +353,7 @@ def _validate_repository_exists(
     """
     Validate that a repository exists and is accessible via Git.
 
-    This function runs in a separate process.
+    This function runs in a worker thread.
 
     Args:
         repository: Repository name (org/repo format)
@@ -383,7 +387,7 @@ def _validate_repository_references(
     """
     Validate multiple references for a single repository.
 
-    This function runs in a separate process.
+    This function runs in a worker thread.
 
     Args:
         repository: Repository name (org/repo format)
@@ -902,7 +906,7 @@ def _validate_repository_subpaths(
     """
     Validate that subdirectory subpaths exist at their referenced ref.
 
-    Runs in a separate process. Performs one partial (``--filter=blob:none``)
+    Runs in a worker thread. Performs one partial (``--filter=blob:none``)
     shallow fetch per unique ref into a throwaway repository, then checks the
     candidate paths with ``git ls-tree``. ``blob:none`` keeps file *contents*
     off the wire while still downloading the tree objects ``ls-tree`` needs, so

--- a/src/gha_workflow_linter/git_validator.py
+++ b/src/gha_workflow_linter/git_validator.py
@@ -90,7 +90,7 @@ class GitValidationClient:
         )
 
         # Use asyncio to run the multiprocessing validation
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
             # Submit all validation tasks
@@ -116,7 +116,9 @@ class GitValidationClient:
 
             # Process results
             results = {}
-            for repo, result in zip(repositories, validation_results):
+            for repo, result in zip(
+                repositories, validation_results, strict=True
+            ):
                 if isinstance(result, Exception):
                     self.logger.warning(
                         f"Failed to validate repository {repo}: {result}"
@@ -165,7 +167,7 @@ class GitValidationClient:
                 repo_to_refs[repo] = []
             repo_to_refs[repo].append(ref)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         results = {}
 
         with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
@@ -197,7 +199,7 @@ class GitValidationClient:
 
             # Process results
             for (repo, refs), repo_results in zip(
-                repo_ref_list, validation_results
+                repo_ref_list, validation_results, strict=True
             ):
                 if isinstance(repo_results, Exception):
                     self.logger.warning(
@@ -309,7 +311,9 @@ class GitValidationClient:
                 # misclassify an internal failure as a bogus subpath.
                 group_results = [e] * len(futures)
 
-            for entries, group_result in zip(entry_groups, group_results):
+            for entries, group_result in zip(
+                entry_groups, group_results, strict=True
+            ):
                 if isinstance(group_result, Exception):
                     self.logger.warning(
                         f"Failed to validate subpaths: {group_result}"

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -148,7 +148,7 @@ class TestSelectCooldownVersionGraphql:
             "v2": _days_ago(20),
         }
         assert fixer._select_cooldown_version_graphql(
-            repo_data, all_tags, tag_dates
+            repo_data, all_tags, tag_dates, now=NOW
         ) == ("v2", "sha2")
 
     def test_selects_release_when_old_enough(self) -> None:
@@ -166,7 +166,7 @@ class TestSelectCooldownVersionGraphql:
             "v2": _days_ago(60),
         }
         assert fixer._select_cooldown_version_graphql(
-            repo_data, all_tags, tag_dates
+            repo_data, all_tags, tag_dates, now=NOW
         ) == ("v3", "sha3")
 
     def test_prefers_more_specific_tag_for_sha(self) -> None:
@@ -179,12 +179,14 @@ class TestSelectCooldownVersionGraphql:
             "v8.0.0": _days_ago(30),
         }
         assert fixer._select_cooldown_version_graphql(
-            repo_data, all_tags, tag_dates
+            repo_data, all_tags, tag_dates, now=NOW
         ) == ("v8.0.0", "sha8")
 
     def test_returns_none_when_no_tags(self) -> None:
         fixer = _make_fixer(7)
-        assert fixer._select_cooldown_version_graphql({}, [], {}) is None
+        assert (
+            fixer._select_cooldown_version_graphql({}, [], {}, now=NOW) is None
+        )
 
 
 class TestResolveCooldownDays:

--- a/tests/test_git_validator.py
+++ b/tests/test_git_validator.py
@@ -320,7 +320,7 @@ async def test_validate_subpaths_batch_gather_failure_is_network_error(
             future.set_result({})
             return future
 
-    monkeypatch.setattr(git_validator, "ProcessPoolExecutor", _FakeExecutor)
+    monkeypatch.setattr(git_validator, "ThreadPoolExecutor", _FakeExecutor)
 
     async def boom(*_args: object, **_kwargs: object) -> object:
         raise RuntimeError("gather exploded")

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -286,6 +287,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.10" },
@@ -804,6 +806,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The project already declares `requires-python = ">=3.10"`, but the linting
tooling still targeted Python 3.9. This raises the Ruff and mypy baselines to
3.10 so modern syntax is preferred/checked against the correct runtime, and
fixes the issues the stricter baseline surfaces. Two pre-existing,
Python-version-sensitive failures uncovered while getting CI green on the full
3.10–3.14 matrix are fixed alongside (details below).

## Changes (lint baseline)

- `pyproject.toml`
  - `[tool.ruff] target-version`: `py39` → `py310`
  - `[tool.mypy] python_version`: `3.9` → `3.10`
  - Exclude the generated `src/gha_workflow_linter/_version.py` from Ruff.
- **UP045** — `Optional[X]` → `X | None` in `exceptions.py` and
  `scripts/profile_performance.py`.
- **B905** — explicit `strict=True` on `zip()` calls in `git_validator.py` and
  `auto_fix.py`.
- Modernise the Git client: the two remaining `asyncio.get_event_loop()` calls
  become `asyncio.get_running_loop()`.

## Bundled fix 1 — date-dependent cooldown test

`TestSelectCooldownVersionGraphql` built fixtures from a fixed `NOW` but
`_select_cooldown_version_graphql` didn't thread a reference time through, so it
compared them against real wall-clock time. As of 2026-06-17 a "2-days-ago"
fixture fell outside the 7-day window and the test began failing — a time bomb
on `main`. Thread an optional `now` through the wrapper (mirroring
`_select_version_with_cooldown`) and inject the fixed `NOW` in tests. No
production behaviour change.

## Bundled fix 2 — Git validation hung the Python 3.14 CI job

The Git client created a `ProcessPoolExecutor` per batch call. Those workers are
I/O-bound (they shell out to `git`), so process isolation buys nothing — but the
per-call pool pays the active multiprocessing start method's worker-startup cost.
**Python 3.14 changed the Linux default start method from `fork` to
`forkserver`**, so each worker became a fresh interpreter re-importing the
(coverage-instrumented) package; across the suite's pool cycles this pushed the
3.14 test job past its 12-minute timeout and it was cancelled. Switched the three
batch methods to `ThreadPoolExecutor` — instant startup, no pickling/re-import,
immune to fork/forkserver/spawn differences across versions. Worker functions are
unchanged (now run in-process, which also lets coverage observe them: 75.9% →
78.2%). Raising `timeout-minutes` was rejected as a band-aid that would leave the
3.14 runs slow and `forkserver` fragile.

## Validation

- `prek run --all-files` — clean.
- `uv run pytest` — 702 passed, 22 skipped; coverage 78.2% (gate 70%).

## Notes

- Originally stacked on #239 (now merged); rebased onto `main`, so the diff is the
  focused lint-baseline change plus the two bundled fixes above.
