### PR TITLE
Chore: Resolve CodeQL code quality findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,10 +158,6 @@ module = [
 ]
 disable_error_code = ["attr-defined", "call-arg", "arg-type", "comparison-overlap", "index", "misc", "func-returns-value", "call-overload", "union-attr", "var-annotated", "operator", "no-untyped-def"]
 
-[[tool.mypy.overrides]]
-module = ["tests.test_exceptions_simple"]
-disable_error_code = ["unreachable"]
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -1704,8 +1704,10 @@ class AutoFixer:
                 # Use git ls-remote to get the SHA for the reference
                 import subprocess
 
-                # Try as branch
-                cmd = ["git", "ls-remote", "--heads", url, ref]
+                # Try as branch. The ``--`` end-of-options marker stops git
+                # from misreading a ref beginning with "-" (REF_PATTERN allows
+                # it) as an option (argument injection).
+                cmd = ["git", "ls-remote", "--heads", "--", url, ref]
                 try:
                     result = subprocess.run(
                         cmd,
@@ -1727,6 +1729,7 @@ class AutoFixer:
                     "git",
                     "ls-remote",
                     "--tags",
+                    "--",
                     url,
                     f"refs/tags/{ref}",
                     f"refs/tags/{ref}^{{}}",

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -1398,8 +1398,15 @@ class AutoFixer:
                 if response.status_code == 200:
                     release_data = response.json()
                     return release_data.get("tag_name")  # type: ignore[no-any-return]
-            except Exception:
-                pass
+            except Exception as e:
+                # A request failure or malformed-JSON error: fall back to the
+                # tags API below. (A non-200 status such as 404 -- normal for
+                # repos that only tag -- is not an error here: it simply skips
+                # the block above and falls through, since the response is not
+                # raised for status.)
+                self.logger.debug(
+                    f"Failed to get latest release via API for {repo_key}: {e}"
+                )
 
             # Fall back to getting latest tag via API
             try:
@@ -1711,6 +1718,7 @@ class AutoFixer:
                         sha = result.stdout.strip().split("\t")[0]
                         return {"sha": sha, "type": "branch"}
                 except subprocess.CalledProcessError:
+                    # ref is not a branch; fall through to try it as a tag.
                     pass
 
                 # Try as tag - need to dereference annotated tags
@@ -1743,6 +1751,8 @@ class AutoFixer:
                             sha = lines[0].split("\t")[0]
                             return {"sha": sha, "type": "tag"}
                 except subprocess.CalledProcessError:
+                    # ref is not a tag either; leave it unresolved (returns
+                    # None below) so the caller can handle the miss.
                     pass
 
             except Exception as e:

--- a/src/gha_workflow_linter/git_validator.py
+++ b/src/gha_workflow_linter/git_validator.py
@@ -327,10 +327,17 @@ class GitValidationClient:
                         self.api_stats.increment_failed_call()
                 elif isinstance(group_result, dict):
                     for entry in entries:
-                        results[entry] = group_result.get(
-                            entry, ValidationResult.INVALID_PATH
-                        )
-                        self.api_stats.increment_git()
+                        if entry in group_result:
+                            results[entry] = group_result[entry]
+                            self.api_stats.increment_git()
+                        else:
+                            # A missing per-entry result means the worker
+                            # returned a partial dict (an internal/edge-case
+                            # failure), not a definitive absence. Treat it as
+                            # inconclusive so it is not cached or reported as a
+                            # bogus INVALID_PATH.
+                            results[entry] = ValidationResult.NETWORK_ERROR
+                            self.api_stats.increment_failed_call()
                     self.api_stats.git_clone_operations += 1
                 else:
                     for entry in entries:
@@ -1044,6 +1051,9 @@ def _run_git_fetch_partial(
         "--filter=blob:none",
         "--no-tags",
         "--quiet",
+        # End option parsing so a ref beginning with "-" (REF_PATTERN allows
+        # it) cannot be misread by git as an option (argument injection).
+        "--",
         url,
         ref,
     ]

--- a/src/gha_workflow_linter/github_api.py
+++ b/src/gha_workflow_linter/github_api.py
@@ -727,7 +727,7 @@ class GitHubGraphQLClient:
             Dictionary mapping ``(repo_key, ref)`` to subpath-existence result.
         """
         query_parts: list[str] = []
-        # alias -> (cache_key, list of candidate aliases)
+        # (repo_key, ref) -> list of candidate GraphQL field aliases
         entry_aliases: dict[tuple[str, str], list[str]] = {}
 
         for i, (repo_key, ref) in enumerate(subpath_refs):

--- a/src/gha_workflow_linter/scanner.py
+++ b/src/gha_workflow_linter/scanner.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
     from .models import ActionCall, Config
 
-    pass
-
 import yaml
 
 from .patterns import ActionCallPatterns

--- a/src/gha_workflow_linter/validator.py
+++ b/src/gha_workflow_linter/validator.py
@@ -15,8 +15,6 @@ if TYPE_CHECKING:
 
     from rich.progress import Progress, TaskID
 
-    pass
-
 
 from .cache import ValidationCache
 from .exceptions import (

--- a/tests/test_exceptions_simple.py
+++ b/tests/test_exceptions_simple.py
@@ -19,6 +19,19 @@ from gha_workflow_linter.exceptions import (
 )
 
 
+def _raise(exc: BaseException) -> None:
+    """Raise ``exc``.
+
+    Tests use this indirection so the ``raise`` inside a
+    ``with pytest.raises(...)`` block is a normal function call rather than the
+    sole, unconditional statement of the block. That keeps the assertions that
+    follow the block reachable for static analysis (mypy ``warn_unreachable``
+    and CodeQL), neither of which models ``pytest.raises`` as suppressing the
+    exception.
+    """
+    raise exc
+
+
 class TestValidationError:
     """Test the ValidationError base class."""
 
@@ -225,14 +238,14 @@ class TestErrorExceptionHandling:
     def test_raise_and_catch_network_error(self) -> None:
         """Test raising and catching NetworkError."""
         with pytest.raises(NetworkError) as exc_info:
-            raise NetworkError("Test network error")
+            _raise(NetworkError("Test network error"))
 
         assert exc_info.value.message == "Test network error"
 
     def test_raise_and_catch_authentication_error(self) -> None:
         """Test raising and catching AuthenticationError."""
         with pytest.raises(AuthenticationError) as exc_info:
-            raise AuthenticationError("Bad token")
+            _raise(AuthenticationError("Bad token"))
 
         assert exc_info.value.message == "Bad token"
         assert exc_info.value.status_code == 401
@@ -240,13 +253,13 @@ class TestErrorExceptionHandling:
     def test_catch_base_validation_error(self) -> None:
         """Test catching derived errors as ValidationError."""
         with pytest.raises(ValidationError):
-            raise NetworkError("Network issue")
+            _raise(NetworkError("Network issue"))
 
         with pytest.raises(ValidationError):
-            raise GitHubAPIError("API issue")
+            _raise(GitHubAPIError("API issue"))
 
         with pytest.raises(ValidationError):
-            raise AuthenticationError("Auth issue")
+            _raise(AuthenticationError("Auth issue"))
 
     def test_exception_error_chaining(self) -> None:
         """Test exception chaining with original errors."""

--- a/tests/test_git_validator.py
+++ b/tests/test_git_validator.py
@@ -344,3 +344,50 @@ async def test_validate_subpaths_batch_gather_failure_is_network_error(
     assert results[("github/codeql-action/analyze", "v3")] == (
         ValidationResult.NETWORK_ERROR
     )
+
+
+@pytest.mark.asyncio
+async def test_validate_subpaths_batch_partial_result_is_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A worker dict missing an entry maps that entry to NETWORK_ERROR.
+
+    If ``_validate_repository_subpaths`` ever returns a partial dict (an
+    internal/edge-case failure), the absent entry must be treated as
+    inconclusive rather than a definitive ``INVALID_PATH``, so it is neither
+    cached nor reported as a bogus subpath. The present entry is unaffected.
+    Uses a fake executor so no real subprocess/network runs.
+    """
+    import concurrent.futures
+
+    # Both share base ``github/codeql-action`` so they land in one group whose
+    # single worker future returns a dict containing only ``present``.
+    present = ("github/codeql-action/init", "v3")
+    missing = ("github/codeql-action/analyze", "v3")
+
+    class _FakeExecutor:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> _FakeExecutor:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def submit(
+            self, _fn: object, *_args: object, **_kwargs: object
+        ) -> concurrent.futures.Future[object]:
+            future: concurrent.futures.Future[object] = (
+                concurrent.futures.Future()
+            )
+            future.set_result({present: ValidationResult.VALID})
+            return future
+
+    monkeypatch.setattr(git_validator, "ThreadPoolExecutor", _FakeExecutor)
+
+    client = GitValidationClient(GitConfig())
+    results = await client.validate_subpaths_batch([present, missing])
+
+    assert results[present] == ValidationResult.VALID
+    assert results[missing] == ValidationResult.NETWORK_ERROR


### PR DESCRIPTION
## Summary

Resolve the CodeQL code-quality findings reported on `main`, plus several
Copilot review items against the (now-merged) subdirectory-action validation
and version-resolution code. Each is fixed at the root rather than suppressed.

## CodeQL findings (commit 1)

- **Empty except (3) — `auto_fix.py`**: the latest-release lookup now logs and
  documents its deliberate fall-through to the tags API; the two `git ls-remote`
  `CalledProcessError` handlers are annotated as expected control flow.
- **Unreachable code (3) — `tests/test_exceptions_simple.py`**: a bare `raise`
  as the sole statement in `with pytest.raises(...)` blocks tripped both CodeQL
  and mypy `warn_unreachable`. Routed through a typed `_raise` helper (runtime
  unchanged); the now-redundant mypy `unreachable` override is removed.
- **Unnecessary pass (2) — `scanner.py`, `validator.py`**: dropped leftover
  `pass` statements in `TYPE_CHECKING` blocks.

## Git command hardening (commit 2)

Review items against the Git command paths:

- **Argument injection** — refs are parsed from workflow files and `REF_PATTERN`
  allows a leading `-`, so a crafted ref forwarded positionally to `git` could be
  misread as an option. Added a `--` end-of-options marker before the URL/ref in
  every ref-forwarding invocation: `_run_git_fetch_partial` (subpath fetch) and
  both `git ls-remote` calls in `_get_commit_sha_for_reference` (branch/tag SHA
  resolution). The remaining `ls-remote` calls forward only the constructed URL
  and were audited as not injectable.
- **Partial worker result** — in `validate_subpaths_batch`, a missing per-entry
  result from a worker dict now maps to the inconclusive `NETWORK_ERROR` (and a
  failed-call stat) instead of a definitive `INVALID_PATH`, so a partial dict
  can't poison the cache or produce a false negative. Adds a hermetic test.
- **Comment accuracy** — corrected the `entry_aliases` comment (`(repo_key, ref)`
  keys, not "alias").

## Validation

- `prek run --all-files` — clean.
- `uv run pytest` — full suite passes (incl. the new regression test).
