### PR TITLE
Fix: exclude test fixtures from Zizmor audit

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,28 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# zizmor configuration for gha-workflow-linter.
+#
+# The workflows under test_autofix/.github/workflows/ are deliberately
+# malformed fixtures consumed by the auto-fix test suite (see tests/).
+# They intentionally pin outdated, vulnerable, and invalid action
+# references so the linter's own detection and auto-fix behaviour can be
+# exercised, so the findings they trigger are ignored here rather than
+# "fixed" (which would defeat the fixtures). The base filenames below are
+# unique to these fixtures and do not collide with the real workflows
+# (build-test.yaml, build-test-release.yaml, testing.yaml).
+rules:
+  artipacked:
+    ignore:
+      - test.yaml
+  excessive-permissions:
+    ignore:
+      - test.yaml
+      - test-skip-testing.yaml
+  impostor-commit:
+    ignore:
+      - test-skip-testing.yaml
+  known-vulnerable-actions:
+    ignore:
+      - test.yaml


### PR DESCRIPTION
## Summary

Resolves all 7 medium+ findings reported by the org-wide Zizmor audit
for this repository (`excessive-permissions` x2, `impostor-commit` x1,
`artipacked` x1, `known-vulnerable-actions` x3).

## Root cause

All 7 findings are located in the deliberately malformed workflow
fixtures under `test_autofix/.github/workflows/`
(`test.yaml`, `test-skip-testing.yaml`). These are consumed by the
auto-fix test suite (`tests/`) and intentionally pin outdated,
vulnerable, and invalid action references (e.g. `actions/checkout@…# master`,
known-vulnerable `upload-artifact@v2`) so the linter's own detection and
auto-fix behaviour can be exercised. The repository's real workflows and
`action.yaml` are already clean.

## Change

Editing the fixtures to satisfy Zizmor would defeat their purpose and
break the tests, so this adds a `.github/zizmor.yml` that ignores the
findings **by fixture base filename**, with a documented rationale:

- `test.yaml` → `artipacked`, `excessive-permissions`, `known-vulnerable-actions`
- `test-skip-testing.yaml` → `excessive-permissions`, `impostor-commit`

The base filenames are unique to the fixtures and do not collide with
the real workflows (`build-test.yaml`, `build-test-release.yaml`,
`testing.yaml`), which Zizmor continues to audit in full. Both the
org-wide scheduled scan and a local run auto-discover this config.

Verified with `zizmor --persona regular --min-severity medium` reporting
0 findings (exit 0), and the existing `pytest` suite still passes.