### PR TITLE
Fix: resolve zizmor auditor persona findings

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -7,6 +7,8 @@
 # policy, and support documentation.
 
 name: "OpenSSF Scorecard"
+
+# yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
   # For Branch-Protection check. Only the default branch is supported. See
@@ -29,12 +31,11 @@ jobs:
   openssf-scorecard:
     name: "OpenSSF Scorecard"
     # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@f412e6f89527da7611a5f4a5f861de86d98d3e9e # v0.7.0
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267  # v0.7.2
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      # yamllint disable-line rule:line-length
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain Scorecard badge via OIDC
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,16 +20,26 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -42,6 +42,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Checkout sample repository'
         # yamllint disable-line rule:line-length
@@ -49,6 +51,7 @@ jobs:
         with:
           repository: 'lfreleng-actions/actions-template'
           path: 'actions-template'
+          persist-credentials: false
 
       - name: "Running local action: ${{ github.repository }}"
         uses: ./

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,6 +16,11 @@ rules:
   artipacked:
     ignore:
       - test.yaml
+      - test-skip-testing.yaml
+  concurrency-limits:
+    ignore:
+      - test.yaml
+      - test-skip-testing.yaml
   excessive-permissions:
     ignore:
       - test.yaml
@@ -26,3 +31,11 @@ rules:
   known-vulnerable-actions:
     ignore:
       - test.yaml
+  ref-version-mismatch:
+    ignore:
+      - test.yaml
+      - test-skip-testing.yaml
+  stale-action-refs:
+    ignore:
+      - test.yaml
+      - test-skip-testing.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -81,11 +81,13 @@ runs:
 
     - name: "Install gha-workflow-linter (if local)"
       shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
       run: |
-        if [[ -f "${{ github.action_path }}/pyproject.toml" ]]; then
+        if [[ -f "$ACTION_PATH/pyproject.toml" ]]; then
           # Install from local source when running from the action repository
           echo "Installing gha-workflow-linter from local source..."
-          cd "${{ github.action_path }}"
+          cd "$ACTION_PATH"
           uv pip install --system -e .
           echo "USE_UVX=false" >> "$GITHUB_ENV"
         else


### PR DESCRIPTION
## Summary

Resolves the zizmor **auditor** persona findings (`min-severity: low`)
that fail the organisation's required "Audit Workflows" gate and block
Dependabot pull requests from merging.

## Method

- **`release-drafter.yaml`**: replaced byte-for-byte with the canonical
  `actions-template` version (adds harden-runner block-mode egress via
  `harden-runner-block-action` and a documented permission scope —
  `undocumented-permissions`).
- **`openssf-scorecard.yaml`**: leading permission comments converted
  to trailing comments on the permission lines
  (`undocumented-permissions`); the reusable workflow call updated to
  `reuse-openssf-scorecard.yaml@fd3c1b4` (`v0.7.2`) to match the
  canonical template. The repository-specific `paths:` push filter is
  preserved.
- **`testing.yaml`**: `persist-credentials: false` added to both
  checkout steps (`artipacked`).
- **`action.yaml`**: `${{ github.action_path }}` hoisted out of the
  install step's `run:` block into a step-level `ACTION_PATH`
  environment variable (`template-injection`).
- **`.github/zizmor.yml`**: extended the existing fixture ignores to
  cover `artipacked`, `concurrency-limits`, `ref-version-mismatch`,
  and `stale-action-refs` for the `test_autofix` workflows (the
  latter two are online audits flagged by the required CI gate).
  Those files are deliberately malformed fixtures consumed by the
  auto-fix test suite (see the rationale already documented in that
  file), so "fixing" them would defeat their purpose.

Verified with `zizmor --persona auditor --min-severity low` (clean),
with no action pin downgrades.
