### PR TITLE
Chore: Disable pre-commit.ci autofix PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ci:
+  autofix_prs: false
   # pre-commit.ci sandbox prevents network calls; aislop runs engines
   # that can call the network at scan time, so it cannot run there
   # either. gha-workflow-linter validates action calls over the


### PR DESCRIPTION
## Summary

Adds `autofix_prs: false` to the `ci:` block in `.pre-commit-config.yaml`, stopping pre-commit.ci from pushing automatic fix commits to pull requests.

## Why

pre-commit.ci autofix rewrites contributor branches. That causes three recurring problems:

- **It breaks commit signing.** Autofix commits come from the pre-commit.ci bot, so a fully signed branch acquires an unsigned commit and the signing and DCO posture of the pull request stops being uniform.
- **It races local work.** A push from the bot moves the remote ahead of the contributor's checkout, so the next local push is rejected and needs an unplanned pull or rebase.
- **It masks defects.** A lint failure that should fail the pull request and prompt a deliberate fix is silently corrected instead, so the underlying problem never reaches review.

Disabling autofix keeps pre-commit.ci as a *reporting* gate: every hook still runs, and a failing hook still fails the pull request. Fixes then happen locally, where the full hook set, the signing identity and the DCO sign-off all apply.

## Scope

A one-line, behaviour-only change to pre-commit.ci. It does not alter which hooks run, their configuration, or their pass/fail behaviour.

`autofix_commit_msg` is deliberately left in place. It is inert once autofix is disabled, but removing it would enlarge the diff for no benefit.

Raised consistently across every repository in the organisation that uses pre-commit, so the change can be reviewed and merged in bulk.