### PR TITLE
Fix: Ignore anonymous-definition in test fixtures

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,6 +13,10 @@
 # unique to these fixtures and do not collide with the real workflows
 # (build-test.yaml, build-test-release.yaml, testing.yaml).
 rules:
+  anonymous-definition:
+    ignore:
+      - test.yaml
+      - test-skip-testing.yaml
   artipacked:
     ignore:
       - test.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -170,7 +170,11 @@ repos:
       - id: pytest
         name: pytest
         entry: uv
-        args: [run, pytest, --tb=short, -q]
+        # pytest lives in the dev EXTRA, not a dependency group, so
+        # plain 'uv run' does not install it and the hook fails with
+        # exit 127. pre-commit.ci skips this hook, so the breakage was
+        # only ever visible locally.
+        args: [run, --extra, dev, pytest, --tb=short, -q]
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Two commits

**1. `Fix: Install the dev extra for the pytest hook`** — the local `pytest` hook ran `uv run pytest`, but `pytest` is declared under `project.optional-dependencies` rather than `dependency-groups`, so `uv run` never installed it and the hook failed with `exit 127`. `pre-commit.ci` skips this hook (it needs network), so the breakage was only ever visible locally — where it blocked *every* commit. With `--extra dev` the suite runs: **703 passed, 22 skipped, 79.61% coverage**.

**2. `Fix: Ignore anonymous-definition in test fixtures`** — the workflows under `test_autofix/.github/workflows/` are deliberately malformed fixtures for the auto-fix suite. Naming their jobs would change what the tests assert against, so the finding is ignored rather than "fixed", exactly as the seven rules already listed in `.github/zizmor.yml` are.

The real workflows stay audited: the ignore entries name the two fixture filenames, which don't collide with `build-test.yaml`, `build-test-release.yaml` or `testing.yaml`.
