### PR TITLE
Chore: Ignore PLR0917 too-many-positional-args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,10 +100,34 @@ ignore = [
     "E501",   # line too long, handled by formatter
     "B008",   # do not perform function calls in argument defaults
     "PLR0913", # too many arguments
+    "PLR0917", # too many positional arguments — see note below
     "PLR2004", # magic value used in comparison
     "PLR0912", # too many branches
     "PLR0915", # too many statements
 ]
+
+# PLR0917 was stabilised in ruff 0.16.0.  This project already selects
+# the "PLR" category, so the rule began firing the moment a routine
+# pre-commit autoupdate crossed that release, on code nobody had
+# touched.
+#
+# It is ignored globally, not scoped to tests, because every occurrence
+# is in src/ — there are none in the test suite, so a per-file-ignore
+# would fix nothing.  The signatures it flags are Typer command
+# definitions and internal constructors:
+#
+#   - cli.py:512 is the `lint` command, with 23 parameters carrying
+#     typer.Argument()/typer.Option() defaults.  Typer builds the CLI
+#     from that signature, and callers supply the values as command-line
+#     flags, never positionally from Python.  A keyword-only signature
+#     is not an option: it is how the framework works.  Note B008 is
+#     already ignored directly above for the same reason.
+#   - the remaining sites (auto_fix.py, cache.py, validator.py) are
+#     internal helpers whose breadth PLR0913 already tolerates.
+#
+# PLR0917 counts only those arguments that may be passed positionally,
+# so it is the narrower of the two; ignoring PLR0913 while enforcing
+# PLR0917 would be inconsistent.
 
 [tool.ruff.lint.isort]
 known-first-party = ["gha_workflow_linter"]


### PR DESCRIPTION
## Why

`#287` fixed this repository's **zizmor** gate. It did not help `#285`, because that PR fails on a **different** gate — `pre-commit.ci`, on ruff.

ruff 0.16.0 stabilised **`PLR0917`** (too many positional arguments). This repository already selects the `PLR` category, so the rule began firing the moment the autoupdate crossed that release, on code nobody had touched:

```
src/gha_workflow_linter/auto_fix.py:338    PLR0917 (6 > 5)
src/gha_workflow_linter/auto_fix.py:1115   PLR0917 (6 > 5)
src/gha_workflow_linter/cache.py:523       PLR0917 (6 > 5)
src/gha_workflow_linter/cli.py:512         PLR0917 (23 > 5)
src/gha_workflow_linter/cli.py:1650        PLR0917 (8 > 5)
src/gha_workflow_linter/validator.py:513   PLR0917 (6 > 5)
```

Same rule and root cause as `repository-metadata-action#148` and `gerrit-clone-action#235`.

## Why a global ignore, not a test-only one

`repository-metadata-action#148` scoped its ignore to `per-file-ignores` for tests. That would be **useless here**: all six occurrences are in `src/`, and there are none in the test suite at all.

The flagged signatures are Typer command definitions and internal constructors:

- **`cli.py:512`** is the `lint` command — 23 parameters carrying `typer.Argument()` / `typer.Option()` defaults:

  ```python
  @app.command()
  def lint(
      path: Path | None = typer.Argument(
          None,
          help="Path to scan for workflows (default: current directory)",
          ...
  ```

  Typer *builds the CLI from that signature*. Callers supply values as command-line flags, never positionally from Python. A keyword-only signature isn't merely inconvenient here — it's not how the framework works. Note **`B008` is already ignored** in this file's config for exactly the same Typer reason.

- **`auto_fix.py`, `cache.py`, `validator.py`** are internal helpers whose breadth **`PLR0913` already tolerates** — it sits directly above in the same `ignore` list.

`PLR0917` counts only those arguments that *may* be passed positionally, so it is the narrower of the two. Ignoring `PLR0913` while enforcing `PLR0917` would be inconsistent.

## Validation

Verified under **both** ruff 0.15.22 (currently pinned) and 0.16.0 (what the autoupdate moves to) — `src` and `tests` both report **All checks passed!**

`pre-commit run --all-files` → every hook passes, including the local `pytest` hook fixed by #287.

Configuration only; zero code changes.

Unblocks #285.
