### PR TITLE
Feat: phase 0 - exit codes and annotated tag SHAs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,13 +83,30 @@ repos:
     rev: d55eabd2531b4f4a4c49c30fba627ce3a636ab79  # frozen: 1.39.9
     hooks:
       - id: basedpyright
-        files: ^src/.+\.py$
+        # No `files:` filter on purpose. This hook previously carried
+        # `^src/.+\.py$`, so tests/, scripts/ and examples/ were never
+        # type-checked and real findings (dead isinstance narrowing in
+        # tests/conftest.py, 49 unannotated mock parameters) went
+        # unnoticed. Relying on the hook's default python file matching
+        # means a new top-level Python directory is covered the day it
+        # appears, with no config change to forget. Keep
+        # [tool.basedpyright] include in pyproject.toml in step for the
+        # benefit of editors and bare invocations.
 
   - repo: https://github.com/btford/write-good
     rev: ab66ce10136dfad5146e69e70f82a3efac8842c1 # frozen: v1.0.8
     hooks:
       - id: write-good
         files: "\\.(rst|md|markdown|mdown|mkdn)$"
+        # write-good targets reader-facing prose, where passive voice and
+        # hedging genuinely cost clarity. ALLOW_LIST_FEATURE.md is a dense
+        # technical specification of a different genre: there "only",
+        # "deliberately" and "silently" carry precise meaning, and passive
+        # constructions ("the SHA is peeled to a commit") read more clearly
+        # than forced active ones. Enforcing the same style rules on it
+        # produced ~200 findings, none of them real. Excluded by name
+        # rather than by directory so future docs/ prose stays covered.
+        exclude: ^docs/ALLOW_LIST_FEATURE\.md$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: 745eface02aef23e168a8afb6b5737818efbea95 # frozen: v0.11.0.1

--- a/docs/ALLOW_LIST_FEATURE.md
+++ b/docs/ALLOW_LIST_FEATURE.md
@@ -1,0 +1,1638 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+
+# Allow-List Pin Detection and Remediation
+
+Design and implementation plan for detecting (and optionally bumping)
+stale `harden-runner-block-action` allow-list pins in
+`gha-workflow-linter`.
+
+Tracking issues:
+
+- [`lfreleng-actions/gha-workflow-linter#296`][issue-296] — detect stale
+  harden-runner allow-list pins
+- [`lfreleng-actions/.github#146`][issue-146] — scheduled tool/workflow
+  to bump allow-list pins automatically, with Slack notification
+
+[issue-296]: https://github.com/lfreleng-actions/gha-workflow-linter/issues/296
+[issue-146]: https://github.com/lfreleng-actions/.github/issues/146
+
+## Table of contents
+
+1. [Problem statement](#1-problem-statement)
+2. [The reference format we must understand](#2-the-reference-format-we-must-understand)
+3. [What exists in the linter today](#3-what-exists-in-the-linter-today)
+4. [Design principles](#4-design-principles)
+5. [Detection design](#5-detection-design)
+6. [Resolution design](#6-resolution-design)
+7. [Finding model, severity and suppression](#7-finding-model-severity-and-suppression)
+8. [Error handling, issue taxonomy and exit codes](#8-error-handling-issue-taxonomy-and-exit-codes)
+9. [CLI surface](#9-cli-surface)
+10. [Remediation design](#10-remediation-design)
+11. [Multi-repository mode](#11-multi-repository-mode)
+12. [Module layout](#12-module-layout)
+13. [Shared/centralised helpers](#13-sharedcentralised-helpers)
+14. [Configuration file surface](#14-configuration-file-surface)
+15. [Scheduled workflow and Slack notification](#15-scheduled-workflow-and-slack-notification)
+16. [Test plan](#16-test-plan)
+17. [Documentation changes](#17-documentation-changes)
+18. [Delivery phases](#18-delivery-phases)
+19. [Risks, edge cases and open questions](#19-risks-edge-cases-and-open-questions)
+
+---
+
+## 1. Problem statement
+
+The `lfreleng-actions` workflow-repository family pins the
+`step-security/harden-runner` egress allow-list using a custom,
+`uses:`-style coordinate consumed by
+`lfreleng-actions/harden-runner-block-action`. Because these are values
+of `config:` / `default:` keys and **not** `uses:` references,
+Dependabot cannot see them, and neither can the linter today.
+
+Two pin shapes appear in the estate:
+
+<!-- markdownlint-disable MD013 -->
+
+```yaml
+# 1. Reusable-workflow input default (explicit path form)
+on:
+  workflow_call:
+    inputs:
+      harden_runner_allowlist:
+        type: string
+        # yamllint disable-line rule:line-length
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@bf6642f68d58c1b81bbe993e676d6cc339ac3654'  # v0.12.2
+
+# 2. Internal workflow step (shorthand form)
+steps:
+  - uses: lfreleng-actions/harden-runner-block-action@6db537b3...  # v0.2.1
+    with:
+      config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+```
+
+<!-- markdownlint-enable MD013 -->
+
+Drift is real and severe. A sweep on 2026-07-31 found reusable-workflow
+defaults spread across v0.4.1 → v0.12.1, while the internal
+`tag-push` / `release-drafter` / `clear-action-cache` workflows were
+stuck at **v0.1.1** in most repositories. Verified against the local
+`.github` checkout at the time of writing:
+
+<!-- markdownlint-disable MD013 -->
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+| Pinned SHA                                 | Tag       | Where seen                                                                     | Latest `.github` tag |
+| ------------------------------------------ | --------- | ------------------------------------------------------------------------------ | -------------------- |
+| `bf6642f68d58c1b81bbe993e676d6cc339ac3654` | `v0.12.2` | `java-workflows` reusable defaults                                             | `v0.12.2` ✅         |
+| `8f4f0cf83e6a015957e83261ed379fd811fc060e` | `v0.5.1`  | `.github` aislop/repo-discovery workflows                                      | `v0.12.2` ❌         |
+| `18d9c4446bea555d0783e850f6d295f844fe8f67` | `v0.1.1`  | `.github` zizmor/tag-push/release-drafter, `java-workflows` internal workflows | `v0.12.2` ❌         |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+<!-- markdownlint-enable MD013 -->
+
+A stale pin does not fail loudly. It silently omits newly allow-listed
+endpoints, so block-mode jobs fail much later with confusing
+`ECONNREFUSED` errors against hosts that were fixed in the allow-list
+weeks earlier.
+
+### 1.1 Not all staleness matters equally
+
+The `.github` repository is, ironically, the most stale repository in the
+estate — the repository that *publishes* the allow-list carries the
+oldest pins. That is a curiosity rather than an emergency, and the design
+treats it as such.
+
+The impact of a stale pin depends entirely on what the workflow *does*:
+
+<!-- markdownlint-disable MD013 -->
+
+| Tier         | Repositories               | Why staleness matters                                                                                                                                                                                   | Sweep behaviour           |
+| ------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **Critical** | `*-workflows`              | These host the reusable build workflows consumers actually run. Builds reach package registries, artifact stores and scanner backends, so a missing endpoint breaks real builds in downstream projects. | PRs raised, Slack digest  |
+| **Advisory** | `.github`, everything else | Standard GitHub plumbing (labelling, tagging, release drafting, SARIF upload) touches a small, stable endpoint set. A pin several versions behind has little or no practical effect.                    | Reported only; PRs opt-in |
+
+<!-- markdownlint-enable MD013 -->
+
+This tiering is a **policy** concern, not a tool concern. The linter stays
+neutral — it reports what it finds, wherever it runs — and the tiering
+lives in the scheduled sweep's scope configuration (§15). Two consequences
+follow, and both are load-bearing for the rest of this design:
+
+1. The default advisory (warning-only) posture is clearly correct. Most
+   detections are genuinely not urgent, and a linter that blocks commits
+   over a non-urgent policy will be switched off.
+2. Suppression must be a first-class, supported mechanism (§7.4), not an
+   afterthought. Deliberately lagging pins are a legitimate and expected
+   state, especially outside the critical tier.
+
+## 2. The reference format we must understand
+
+The grammar is defined by `resolve_config_source.py`, a file mirrored
+byte-for-byte between `harden-runner-block-action` and
+`python-audit-action`. We must **mirror its parsing semantics exactly**;
+divergence produces false positives on valid pins.
+
+```text
+<config> ::= <source> [ "@" <ref> ] [ <ws>+ "#" <comment> ]
+<source> ::= [ <host-org> [ "/" <repo> ] ] [ "//" <subpath> ]
+```
+
+Defaults applied to omitted elements:
+
+<!-- markdownlint-disable MD013 -->
+
+| Element   | Default                                                              |
+| --------- | -------------------------------------------------------------------- |
+| host-org  | `github.repository_owner` (the *workflow* org)                       |
+| repo      | `.github`                                                            |
+| directory | `.github/<family>/<workflow-org>/` then `.github/<family>/`          |
+| filename  | `allow_list.txt`                                                     |
+| ref       | the host repo's default branch (`HEAD`)                              |
+
+<!-- markdownlint-enable MD013 -->
+
+`<family>` is `harden-runner` for `harden-runner-block-action`.
+
+Behaviours the parser must reproduce:
+
+- **`//` separates repo from in-repo path** (go-getter/Terraform
+  convention). Text after `//` that is empty, or a bare filename with no
+  `/`, keeps the two-candidate directory search chain; text containing a
+  `/` is an explicit path with no search.
+- **Comment splitting** — a `#` preceded by at least one space or tab
+  starts a trailing comment. `foo#bar` is a single token, *not* a
+  comment. This matters: the version comment is the secondary signal we
+  cross-check against, and mis-splitting it corrupts the pin.
+- **Shorthand `@<sha>`** — an empty source means "the workflow org's
+  `.github` repo, default search chain, `allow_list.txt`". This is the
+  form used by every internal workflow, and it is the form that drifted
+  the furthest.
+- **At most one `@` and at most one `//`**; violations are errors.
+- **Validation** of org (`ORG_RE`), repo (`REPO_RE`), ref (`REF_RE`, no
+  leading `-` or `/`, no `..`, no `@{`, ≤ 255 chars) and each path
+  segment (`SEGMENT_RE`, no empty segments, no `..`).
+
+### Annotated tags matter
+
+`.github` releases use **annotated** tags, and the pins carry the
+**commit** SHA, not the tag-object SHA. Confirmed locally:
+
+```console
+$ git rev-parse v0.12.2            # tag object
+8f363565e79650362c3359ee23b6d6fd295866ee
+$ git rev-parse v0.12.2^{commit}   # what the pins actually contain
+bf6642f68d58c1b81bbe993e676d6cc339ac3654
+```
+
+Any comparison must peel to the commit. Comparing against the tag object
+SHA would flag every correctly-pinned reference as stale.
+
+### Two comment positions
+
+The version comment can sit in either of two places, and the design must
+handle both:
+
+```yaml
+# A. YAML comment — the '#' is OUTSIDE the quotes.
+#    The action never sees it; YAML discards it before the value is read.
+config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
+
+# B. In-scalar comment — the '#' is INSIDE the quotes.
+#    Part of the scalar; the action's own split_comment() strips it.
+config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e # v0.5.1'
+```
+
+Form B is why `split_comment` exists in the action at all, and the action
+README documents it (`lfit@ab7a940… # v1.0.0`). Across the current estate,
+however, **every one of the 20 pins uses form A**; form B appears only in
+documentation. The implementation supports both and must preserve
+whichever form it finds, but form A is the case to optimise for and the
+one the fixture suite should weight most heavily.
+
+This distinction matters again for suppression directives (§7.4), which
+are recognised in the *effective* trailing comment regardless of which
+side of the quote it falls on.
+
+### Values we must *not* treat as pins
+
+- `config: ${{ inputs.harden_runner_allowlist }}` — a GitHub expression,
+  resolved at run time. Not a pin; skip silently.
+- `config: 'lfreleng-actions@main'` — a branch ref. Not stale by SHA
+  comparison, but *unpinned*; reported under a separate finding kind.
+
+## 3. What exists in the linter today
+
+Relevant facts established by auditing the codebase:
+
+- **CLI** is Typer, with subcommands `lint` and `cache`, plus argv
+  preprocessing (`_preprocess_args_for_default_command`) that injects
+  `lint` when no subcommand is given. Any new value-taking option must be
+  added to the `value_taking_options` set in that function.
+- **Exit codes** are only `0` and `1`, decided in `_determine_exit_code`.
+  There is no central definition; `typer.Exit(1)` literals are scattered
+  through `cli.py`. Click reserves `2` for usage errors.
+- **Config** is `models.Config` (pydantic v2), loaded from YAML by
+  `config.ConfigManager`. CLI overrides use a tri-state (`None` = not
+  specified) in `models.CLIOptions`, merged by `_apply_cli_overrides`.
+- **Scanning** is regex-per-line (`patterns.ActionCallPatterns`) over
+  files found by `scanner.WorkflowScanner`. `scanner._is_valid_yaml`
+  already parses each file with `yaml.safe_load` and **throws the result
+  away** — a free hook for structural detection.
+- **No severity model exists.** `ValidationResult` conflates outcome and
+  issue kind; every non-`VALID` result is an error.
+- **No tag → commit SHA resolution exists** in either backend.
+  `github_api.py` only asks "does this ref exist?" and discards the OID.
+  `git_validator._get_remote_tags` runs `git ls-remote --tags`, already
+  handles the `^{}` peel suffix, and then **discards the SHA column**.
+- **`cache.ValidationCache` already has `get_latest_version` /
+  `put_latest_version`** storing `(latest_tag, latest_sha)` per
+  repository with TTL — the exact storage shape we need.
+- **Auto-fix rewrites files** via `AutoFixer._apply_fixes_to_file`:
+  read all lines, replace by 1-based index, write back. It is
+  non-atomic, has no backup, and hard-codes `\n`.
+- **`--auto-latest`** gates `check_for_updates`, which distinguishes
+  "fix validation errors" from "bump to newest release".
+
+## 4. Design principles
+
+1. **Never break the pre-commit contract.** The linter runs as a
+   pre-commit hook. Allow-list checking is an `lfreleng-actions`-specific
+   policy, not GitHub-native validation, so by default it is
+   **advisory**: it reports and never changes the exit code.
+2. **Opt-in enforcement.** `--verify-allow-list` promotes advisory
+   findings to errors with a dedicated, documented exit code.
+3. **Fail open on infrastructure problems.** No token, no network, rate
+   limited, unresolvable release → warn and skip. A developer offline on
+   a train must still be able to commit.
+4. **Mirror the canonical grammar, do not reinvent it.** The spec parser
+   is a faithful port of `resolve_config_source.py` with a test suite
+   derived from that action's own cases.
+5. **Reuse before adding.** Latest-release resolution, caching, token
+   discovery, file discovery and line rewriting all have existing homes.
+   Extend them rather than growing a parallel stack.
+6. **Structural detection, line-accurate edits.** Identify pins from the
+   YAML node tree (precision); rewrite by line and column (formatting
+   preservation).
+7. **Treat every consumer identically.** The central repository hosts one
+   allow-list directory per consumer family, side by side, by design. The
+   linter special-cases none of them and needs to know about none of
+   them (§5.4).
+
+## 5. Detection design
+
+### 5.1 Two-stage: structural identification, lexical edit
+
+PyYAML's `yaml.compose()` produces a node tree whose scalar nodes carry
+`start_mark` / `end_mark` (line and column). This needs no new
+dependency and gives us both precision *and* exact source positions.
+
+Stage 1 — **structural identification** (`allow_list_scanner.py`):
+
+Walk the composed node tree of each workflow / action file and collect
+candidate scalars from three known locations:
+
+<!-- markdownlint-disable MD013 -->
+
+| #   | Location                                                                                   | Example                                                  |
+| --- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| 1   | `jobs.<job>.steps[*].with.config` — the shared resolver's input is always named `config`   | `config: '@18d9c444…'`                                   |
+| 2   | `on.workflow_call.inputs.<name>.default` where the value parses as a valid spec            | `default: 'lfreleng-actions//…/allow_list.txt@bf6642f…'` |
+| 3   | `jobs.<job>.with.<name>` (reusable-workflow caller) where the value parses as a valid spec | `harden_runner_allowlist: '…@bf6642f…'`                  |
+
+<!-- markdownlint-enable MD013 -->
+
+**There is no per-consumer registry.** Detection is anchored on the
+*syntax* — an input named `config`, or a scalar that parses as a valid
+config spec — never on which action happens to consume it. See §5.4.
+
+**Recogniser predicate** for locations 2 and 3 (where the key name is
+arbitrary) — the scalar qualifies when it parses as a valid spec **and**
+either:
+
+- the resolved candidate path ends in the conventional allow-list
+  filename (`allow_list.txt`), or
+- the key name matches a configurable pattern list, default
+  `["*allow_list*", "*allowlist*", "*allow-list*"]`.
+
+This is a documented, deterministic rule rather than a heuristic, and it
+is deliberately conservative: an unrecognised scalar is simply not a pin.
+
+> **YAML gotcha:** PyYAML resolves the bare key `on` to boolean `True`
+> under YAML 1.1. The walker must accept both `"on"` and `True` as the
+> trigger-block key. This is a classic source of silent misses.
+
+Stage 2 — **lexical extraction and edit anchoring**: for each candidate
+scalar node, record `start_mark.line` (0-based → 1-based line number),
+`start_mark.column`, `end_mark`, the raw source line, the quoting style
+(inferred from the source text at that column), and the trailing
+`# vX.Y.Z` comment recovered from the raw line by the same
+`split_comment` rule the action uses.
+
+If `start_mark.line != end_mark.line`, the scalar spans multiple lines
+(block scalar or wrapped flow scalar). Record the pin, report it, but
+mark it `auto_fixable=False` — we will not attempt a multi-line rewrite.
+
+### 5.2 Skip rules
+
+Skip (no finding, debug log only) when the scalar:
+
+- contains `${{` — a GitHub expression, resolved at run time;
+- fails to parse under the spec grammar **and** the recogniser only
+  matched on key name (avoids noisy findings on unrelated inputs);
+- resolves to a host repo the run cannot resolve (see §6.4).
+
+### 5.3 File discovery
+
+Reuse `WorkflowScanner.find_workflow_files()` unchanged — it already
+covers `.github/workflows/*.y{a,}ml` at any depth plus `action.y{a,}ml`,
+honours `scan_extensions`, `exclude_patterns`, `skip_actions` and
+`--files`. Issue #296 mentions `examples/`; example caller workflows
+under `examples/` that are *not* inside a `.github/workflows` directory
+are not currently discovered. Add an opt-in
+`allow_list.extra_globs` config key (default
+`["examples/**/*.yaml", "examples/**/*.yml"]`, applied **only** to the
+allow-list checker) so the existing action-call scan behaviour is not
+changed.
+
+### 5.4 Consumers are not special-cased
+
+The central repository's layout was designed from the outset to host any
+number of allow-lists side by side, one directory per consumer family:
+
+```text
+.github/harden-runner/<org>/allow_list.txt   # egress endpoints
+.github/python-audit/<org>/allow_list.txt    # vulnerability IDs
+.github/<future-family>/<org>/allow_list.txt
+```
+
+The families are **data**, not code. Every consumer shares one grammar,
+one resolver (`resolve_config_source.py`, mirrored byte-for-byte between
+the consuming actions), one host repository (`<org>/.github`) and one
+convention for the input name (`config`). The only per-consumer
+difference is a `--family` flag chosen by the action at run time, which
+selects a directory.
+
+The linter therefore needs **no knowledge of any consumer at all**:
+
+- **Staleness is family-independent.** A pin is stale when its ref is not
+  the latest release commit of the host repository. That comparison never
+  touches the in-repo path, so the family cannot affect the verdict.
+- **The family is needed only for display.** It is read out of the
+  resolved path when one is present, purely so reports can say which
+  allow-list a pin refers to. Nothing branches on it.
+- **New consumers are free.** `node-audit-action` (whose README states it
+  mirrors `python-audit-action`) and anything after it are covered on the
+  day they appear, with no code change, no registry entry and no release.
+
+This is why the earlier sketch of a "known consumer actions registry"
+with per-action family/filename mappings has been removed: it would have
+re-encoded, as special cases in the linter, a distinction the central
+design deliberately keeps out of the mechanism. Treating consumers
+uniformly is both simpler and more faithful to the model.
+
+One consequence worth stating plainly: because detection keys on syntax
+rather than on a consumer allow-list, an unrecognised or brand-new
+consumer is handled correctly by default, and the failure mode for an
+unrelated `config:` value is a skip (§5.2), not a false finding.
+
+## 6. Resolution design
+
+### 6.1 What "latest" means
+
+For each distinct resolved `host_org/repo` across all detected pins,
+resolve the **latest release** and peel its annotated tag to a commit:
+
+```text
+latest release tag  →  refs/tags/<tag>  →  peel to commit  →  target SHA
+```
+
+Preference order, mirroring the existing `auto_fix_versions` logic:
+
+1. `latestRelease` (excluding drafts; excluding prereleases unless
+   `allow_prerelease`), when its tag matches `VERSION_TAG_PATTERN`.
+2. Newest tag by `(_get_version_specificity, _parse_version)` descending.
+3. Give up → resolution failure (§6.4).
+
+`--cooldown` / `cooldown_days` is honoured, reusing
+`version_utils._select_version_with_cooldown`, so an allow-list bump
+obeys the same supply-chain quarantine as an action bump.
+
+### 6.2 Backends
+
+Both existing backends are extended rather than bypassed:
+
+**GitHub API** (`github_api.py`) — add one batched GraphQL method:
+
+```python
+async def resolve_latest_releases_batch(
+    self, repo_keys: list[str]
+) -> dict[str, LatestRelease | None]:
+    """Resolve each repo's latest release tag and peeled commit SHA."""
+```
+
+The query selects `latestRelease { tagName, publishedAt }` and
+`refs(refPrefix: "refs/tags/", first: 100, orderBy: {field: TAG_COMMIT_DATE,
+direction: DESC})` with
+`target { oid ... on Tag { target { oid } } }`, so annotated tags peel in
+a single round trip. `_extract_sha_from_ref_data` in
+`auto_fix_resolution.py` already implements exactly this peel and is
+reused verbatim.
+
+**Git** (`git_validator.py`) — add:
+
+```python
+def _get_remote_tag_shas(url: str, config: GitConfig) -> dict[str, str]:
+    """Map tag name -> commit SHA, preferring the peeled ``^{}`` line."""
+```
+
+This is a small, high-value change: `_get_remote_tags` already parses the
+`^{}` suffix and then throws the SHA away. Preserving both columns gives
+token-free tag listing *and* annotated-tag peeling. The git backend
+cannot supply release dates, so — consistent with the existing
+`_get_latest_version_via_git` behaviour — it returns `None` when
+`cooldown_days > 0` rather than guessing.
+
+### 6.3 Determining the workflow org
+
+The shorthand `@<sha>` resolves `host_org` from the *workflow* org,
+which at lint time we must infer. Precedence:
+
+1. `--allow-list-org` CLI flag (explicit).
+2. `allow_list.org` config key.
+3. `GITHUB_REPOSITORY_OWNER` environment variable (set in Actions).
+4. Owner parsed from the `upstream` git remote of the scanned repository.
+5. Owner parsed from the `origin` git remote.
+6. Unresolvable → skip shorthand pins with a warning (§6.4).
+
+Preferring `upstream` over `origin` is deliberate: LF contributors work
+from personal forks (`origin` = `modeseven-lfreleng-actions/...`,
+`upstream` = `lfreleng-actions/...`), and the pins are meant to track the
+upstream org's `.github` repository. A fork owner would resolve to a
+`.github` repo that does not exist.
+
+In multi-repository mode (§11) this is resolved **per repository**.
+
+### 6.4 Failure handling
+
+Resolution failure (no token and no network, rate limited, repository
+not found, no releases, cooldown excludes everything):
+
+- **Default mode** — emit a single consolidated notice
+  (`Allow-list check skipped: <reason>`), record nothing, do not change
+  the exit code.
+- **`--verify-allow-list`** — exit code `4` (§8). Enforcement that
+  silently degrades to "pass" is worse than useless in CI.
+
+Successful resolutions are written to `ValidationCache` via the existing
+`put_latest_version` / `get_latest_version` pair, so a repeated
+pre-commit run costs zero API calls within the TTL.
+
+## 7. Finding model, severity and suppression
+
+### 7.1 Introducing severity
+
+The codebase has no severity concept. Rather than retrofit severity onto
+`ValidationResult` (which would ripple through the validator, the summary
+counters and the JSON schema), introduce it **alongside**, scoped to the
+new subsystem, with a shared enum that the existing subsystem can adopt
+later:
+
+```python
+class Severity(str, Enum):
+    """Reporting severity for a linter finding."""
+
+    ERROR = "error"      # fails the run (subject to mode/flags)
+    WARNING = "warning"  # reported, never fails the run
+    NOTICE = "notice"    # informational only
+```
+
+### 7.2 Finding kinds
+
+```python
+class AllowListFindingKind(str, Enum):
+    STALE = "stale"                        # SHA != latest release commit
+    COMMENT_MISMATCH = "comment_mismatch"  # trailing # vX.Y.Z lies
+    UNPINNED = "unpinned"                  # ref is a branch/tag, not a SHA
+    UNRESOLVABLE = "unresolvable"          # SHA not present in host repo
+    INVALID_SPEC = "invalid_spec"          # fails the config grammar
+```
+
+Default severities, and behaviour under each flag:
+
+<!-- markdownlint-disable MD013 -->
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+| Kind               | Default   | `--verify-allow-list`                  | Auto-fixable by `--update-allow-list` |
+| ------------------ | --------- | -------------------------------------- | ------------------------------------- |
+| `STALE`            | `WARNING` | `ERROR`                                | ✅                                    |
+| `COMMENT_MISMATCH` | `WARNING` | `ERROR`                                | ✅ (rewrites the comment)             |
+| `UNPINNED`         | `NOTICE`  | `ERROR` only when `require_pinned_sha` | ✅ (pins to latest release commit)    |
+| `UNRESOLVABLE`     | `WARNING` | `ERROR`                                | ✅ (repins to latest release commit)  |
+| `INVALID_SPEC`     | `ERROR`   | `ERROR`                                | ❌ (needs human judgement)            |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+<!-- markdownlint-enable MD013 -->
+
+`INVALID_SPEC` is an error even by default because it is a *local*
+correctness problem with no network dependency: the action will fail at
+run time. It is exactly the kind of thing a linter should catch, and it
+cannot produce false failures from stale network state.
+
+`COMMENT_MISMATCH` is deliberately a first-class finding, not a
+sub-detail of `STALE`. As issue #296 notes, "the comment can lie" — a pin
+whose SHA is current but whose comment claims an old version misleads
+every subsequent human reviewer.
+
+### 7.3 Data model
+
+```python
+@dataclass(frozen=True)
+class AllowListPin:
+    """A detected allow-list coordinate in a workflow file."""
+
+    file_path: Path
+    line_number: int          # 1-based
+    column: int               # 0-based, start of the scalar
+    key_path: tuple[str, ...] # e.g. ("jobs", "publish", "steps", "0", "with", "config")
+    raw_line: str
+    raw_value: str            # scalar as written, comment excluded
+    quote_style: QuoteStyle   # NONE | SINGLE | DOUBLE
+    version_comment: str | None
+    directives: frozenset[Directive]  # parsed suppression directives
+    suppressed_by: SuppressionSource | None
+    spec: ResolvedSpec        # host_org, repo, ref, candidates, path_explicit
+    auto_fixable: bool
+
+
+@dataclass(frozen=True)
+class AllowListFinding:
+    pin: AllowListPin
+    kind: AllowListFindingKind
+    severity: Severity
+    message: str
+    current_sha: str | None
+    target_sha: str | None
+    target_version: str | None
+    suppressed: bool
+```
+
+### 7.4 Suppression directives
+
+Deliberately lagging pins are a legitimate state (§1.1), so suppression is
+a **compulsory** part of the implementation, not a later addition. Both
+forms below are supported.
+
+#### Form 1 — preceding-line directive
+
+```yaml
+- uses: lfreleng-actions/harden-runner-block-action@6db537b3…  # v0.2.1
+  with:
+    # gha-workflow-linter: allow-list-pin-ok
+    config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
+```
+
+#### Form 2 — inline keyword
+
+```yaml
+- uses: lfreleng-actions/harden-runner-block-action@6db537b3…  # v0.2.1
+  with:
+    config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1 allow-list-pin-ok
+```
+
+#### Grammar and matching rules
+
+```text
+<preceding>  ::= <ws>* "#" <ws>* "gha-workflow-linter:" <ws>+ <body>
+<inline>     ::= <version-token> <ws>+ <body>
+<body>       ::= <directives> [ <reason> ]
+<directives> ::= <directive> ( <ws>+ <directive> )*
+<directive>  ::= "allow-list-pin-ok"
+<reason>     ::= <ws>+ "--" <ws>+ <free text>
+```
+
+- **Form 1 must be the immediately preceding line.** No blank lines and
+  no intervening content. This follows the near-universal convention of
+  `# noqa`, `# type: ignore` and `eslint-disable-next-line`, and it keeps
+  the directive unambiguously bound to one pin. Indentation is *not*
+  significant — YAML permits comments at any column, and requiring
+  alignment would produce baffling silent failures.
+- **Form 2 is recognised in the effective trailing comment**, which is
+  the in-scalar comment when present, otherwise the YAML comment on the
+  same line (§2, "Two comment positions"). If both exist, either may
+  carry the directive.
+- **The version token stays first.** `# v0.5.1 allow-list-pin-ok` parses
+  as version `v0.5.1` plus directive `allow-list-pin-ok`. The version
+  comment parser must therefore tokenise on whitespace and treat the
+  first token as the version and subsequent recognised tokens as
+  directives — it can no longer assume the whole comment is a version.
+  Unrecognised trailing tokens are preserved verbatim and ignored.
+- **An optional reason** may follow after ` -- `, for example
+  `# v0.5.1 allow-list-pin-ok -- blocked on ONAP mirror rollout`. The
+  reason is surfaced in reports so a suppression carries its own
+  justification.
+- **Both forms may appear together.** They are idempotent, not
+  cumulative; no error.
+- **Directives are inert at run time.** In form A the `#` is outside the
+  quotes, so YAML discards it and the action never sees it. In form B the
+  action's own `split_comment` strips it. Either way the directive cannot
+  change what the action fetches — which is exactly the property a
+  linter directive must have.
+
+#### What suppression does and does not cover
+
+This is the sharpest design decision in the mechanism. `allow-list-pin-ok`
+asserts *"this pin is deliberately at this version"*. It is a statement
+about **currency**, not about **correctness**:
+
+<!-- markdownlint-disable MD013 -->
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+| Kind               | Suppressible | Reasoning                                                                                       |
+| ------------------ | ------------ | ----------------------------------------------------------------------------------------------- |
+| `STALE`            | ✅           | Exactly what the directive asserts                                                              |
+| `UNPINNED`         | ✅           | Pinning to `@main` can be a deliberate development choice                                       |
+| `COMMENT_MISMATCH` | ❌           | A comment that lies is a defect regardless of intent, and it is what every human reviewer reads |
+| `UNRESOLVABLE`     | ❌           | A SHA that does not exist in the host repo is broken now, not merely old                        |
+| `INVALID_SPEC`     | ❌           | The action will fail at run time; no intent makes that acceptable                               |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+<!-- markdownlint-enable MD013 -->
+
+Making the directive suppress *everything* would be simpler to implement
+and much worse in practice: a single comment would mask genuine breakage,
+and the estate would accumulate pins that are silently non-functional.
+The split maps cleanly onto the defect/currency taxonomy in §8.
+
+#### Interaction with remediation
+
+- `--update-allow-list` **must not** rewrite a suppressed pin. That is the
+  entire point; a suppression that survives detection but loses to the
+  fixer is worse than none.
+- When a pin carrying directives *is* rewritten (because the finding was
+  a non-suppressible kind), the fixer **preserves the directives and any
+  reason text**, rewriting only the version token. Losing a suppression
+  during an unrelated repair would silently re-enable churn on the next
+  run.
+
+#### Visibility
+
+Suppressions must not become invisible forever. Two mitigations:
+
+- A one-line summary is always emitted when any suppression is active:
+  `3 allow-list pins suppressed (2 files) — use --show-suppressed for
+  detail`.
+- `--show-suppressed` reports each suppressed pin as a `NOTICE`, with its
+  reason and the version it *would* move to. This is what the org-wide
+  audit run uses. It never changes the exit code.
+
+Suppressed findings always appear in the `--format json` output with
+`"suppressed": true`, so machine consumers see the full picture without
+needing the flag.
+
+### 7.5 Why a linter-owned directive rather than a config file
+
+An alternative design puts suppressions in `gha-workflow-linter.yaml` as
+a list of file/line exclusions. Rejected: line numbers drift, the
+justification lives far from the code it excuses, and a reviewer reading
+the workflow cannot tell that a pin is deliberately frozen. An in-file
+directive is self-documenting and travels with the line under `git blame`.
+
+## 8. Error handling, issue taxonomy and exit codes
+
+### 8.1 What the tool distinguishes today (and what it conflates)
+
+Auditing the current flow answers the question directly: the linter
+**does not** cleanly separate "this pin is broken" from "this pin could be
+newer", and several distinct defects share one uninformative label.
+
+<!-- markdownlint-disable MD013 -->
+
+| Situation                                         | Today                                         | Problem                                                                                 |
+| ------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Repository missing                                | `INVALID_REPOSITORY`                          | Fine                                                                                    |
+| Branch or tag does not exist                      | `INVALID_REFERENCE`                           | Fine                                                                                    |
+| **SHA does not resolve to a commit**              | `INVALID_REFERENCE`                           | Conflated with the above; message says "Invalid branch, tag, or commit SHA"             |
+| **SHA is an annotated tag object, not a commit**  | `INVALID_REFERENCE` (API) / **`VALID` (git)** | Backends disagree; see §8.2                                                             |
+| **Comment version disagrees with the pinned SHA** | *no result kind*                              | Silently repaired by `auto_fix` to the comment's version; never surfaced, never counted |
+| Not pinned to a SHA                               | `NOT_PINNED_TO_SHA`                           | Fine                                                                                    |
+| **Valid, pinned, but a newer release exists**     | *no result kind*                              | Reported out-of-band via `stale_actions_summary`; invisible to exit codes               |
+| Network/API failure                               | `ValidationAbortedError`                      | Fine — correctly aborts rather than mass-failing                                        |
+
+<!-- markdownlint-enable MD013 -->
+
+The three bolded gaps are worth closing, and the infrastructure this
+feature adds (tag peeling, the `Severity` enum, centralised exit codes)
+makes closing them nearly free.
+
+### 8.2 Confirmed defect: backends disagree on annotated tag SHAs
+
+`git ls-remote --tags` emits two lines per annotated tag — verified
+against the live repository:
+
+```console
+$ git ls-remote --tags git@github.com:lfreleng-actions/.github.git | grep v0.12.2
+8f363565e79650362c3359ee23b6d6fd295866ee  refs/tags/v0.12.2      # tag object
+bf6642f68d58c1b81bbe993e676d6cc339ac3654  refs/tags/v0.12.2^{}   # commit
+```
+
+`_get_all_remote_refs` collects `parts[0]` from **both** lines, and
+`_validate_commit_shas_git` then does a plain set membership test. So:
+
+- **Git backend** — `uses: org/repo@8f363565…` (tag object SHA) is
+  reported **`VALID`**.
+- **GitHub API backend** — the same reference is reported
+  **`INVALID_REFERENCE`**, because `_validate_commit_shas_graphql`
+  narrows with `... on Commit { oid }` and a `Tag` object yields nothing.
+
+GitHub Actions cannot check out a tag-object SHA, so the git backend
+issues a **false pass on a reference that fails at run time** — and which
+backend you get depends on whether a token happens to be available. This
+is exactly the class of bug that erodes trust in a linter.
+
+### 8.3 New issue kinds
+
+Add three kinds, all of which fall out of work already planned:
+
+```python
+ANNOTATED_TAG_SHA   # pin is a tag object SHA; the commit SHA is <peeled>
+SHA_COMMENT_MISMATCH # pinned SHA is valid but '# vX.Y.Z' names another version
+OUTDATED_ACTION      # valid and correctly pinned, but a newer release exists
+```
+
+`ANNOTATED_TAG_SHA` is the highest-value addition. `_get_remote_tag_shas`
+(Phase 0) gives both backends the tag-object → commit map, so the git
+backend stops false-passing **and** the message becomes actionable:
+
+```text
+.github/workflows/build.yaml
+  line 42: uses: lfreleng-actions/.github@8f363565…  # v0.12.2
+
+  This is the SHA of the annotated tag object for v0.12.2, not a commit.
+  GitHub Actions cannot check out a tag object. Use the peeled commit:
+
+      bf6642f68d58c1b81bbe993e676d6cc339ac3654  # v0.12.2
+```
+
+It is also auto-fixable with total confidence — the correct value is
+known exactly, with no "latest version" judgement involved — so it is
+repaired under plain `--auto-fix`, not only under `--update-actions`.
+
+This kind is directly relevant to `lfreleng-actions`: every `.github`
+release uses annotated tags, so hand-copying a SHA from `git rev-parse
+vX.Y.Z` (rather than `git rev-parse vX.Y.Z^{commit}`) silently produces a
+broken pin. The tool should catch that, in both action calls and
+allow-list pins.
+
+### 8.4 Defect versus currency
+
+Every finding is classified on two axes, which is what makes the exit
+codes principled rather than ad hoc:
+
+<!-- markdownlint-disable MD013 -->
+
+| Category         | Meaning                          | Kinds                                                                                                                                                                        |
+| ---------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEFECT`         | Wrong **now**; will or does fail | `INVALID_REPOSITORY`, `INVALID_REFERENCE`, `INVALID_PATH`, `INVALID_SYNTAX`, `ANNOTATED_TAG_SHA`, `SHA_COMMENT_MISMATCH`, `COMMENT_MISMATCH`, `UNRESOLVABLE`, `INVALID_SPEC` |
+| `CURRENCY`       | Correct, but could be newer      | `OUTDATED_ACTION`, `STALE`, `UNPINNED`                                                                                                                                       |
+| `INFRASTRUCTURE` | The check could not run          | resolution failure, network abort                                                                                                                                            |
+
+<!-- markdownlint-enable MD013 -->
+
+`DEFECT` findings always count. `CURRENCY` findings are advisory unless
+the caller opts in via a `--verify-*` flag. `INFRASTRUCTURE` failures are
+never silently treated as a pass under enforcement.
+
+Note how cleanly this maps onto suppression (§7.4): `allow-list-pin-ok`
+suppresses `CURRENCY` findings and nothing else. The two mechanisms are
+the same distinction viewed from different ends.
+
+### 8.5 Exit codes
+
+Centralised in a new `exit_codes.py`. Existing behaviour for `0` and `1`
+is preserved.
+
+<!-- markdownlint-disable MD013 -->
+
+| Code | Name                    | Meaning                                                                         |
+| ---- | ----------------------- | ------------------------------------------------------------------------------- |
+| `0`  | `SUCCESS`               | No failing findings                                                             |
+| `1`  | `DEFECTS_FOUND`         | `DEFECT`-category findings, or files modified by any fixer (existing behaviour) |
+| `2`  | *reserved*              | Click/Typer CLI usage error — **do not assign**                                 |
+| `3`  | `ALLOW_LIST_STALE`      | `--verify-allow-list` and unsuppressed allow-list `CURRENCY` findings remain    |
+| `4`  | `ALLOW_LIST_UNRESOLVED` | `--verify-allow-list` and the latest release could not be resolved              |
+| `5`  | `ACTIONS_OUTDATED`      | `--verify-actions` and outdated action calls remain (§8.7)                      |
+
+<!-- markdownlint-enable MD013 -->
+
+Precedence: `4` > `3` > `5` > `1` > `0`. An infrastructure failure must
+never be reported as a clean-or-stale result, and a condition the caller
+specifically asked about must not be masked by the generic `1`.
+
+### 8.6 Confirmed bug: exit-code bypass in `run_linter`
+
+`cli.py` currently contains:
+
+```python
+if (
+    autofix.stale_actions_summary
+    and not config.auto_latest
+    and not options.quiet
+):
+    _display_stale_actions_from_summary(autofix.stale_actions_summary, options)
+    return 0                                   # <-- bypasses _determine_exit_code
+
+return _determine_exit_code(options, validation, autofix)
+```
+
+Three distinct defects in five lines:
+
+1. **Real failures are masked.** Whenever *any* outdated action exists,
+   the function returns `0` without consulting
+   `_determine_exit_code` — discarding unfixed validation errors *and*
+   the "files were modified" signal. A repository with a genuinely
+   invalid reference can exit `0` purely because something unrelated was
+   also outdated.
+2. **The exit code depends on verbosity.** The `not options.quiet` guard
+   means `lint .` and `lint . --quiet` can return different codes for
+   identical input. Presentation must never determine process status.
+3. **Text and JSON runs diverge.** `--format json` forces `quiet = True`,
+   so the JSON path takes the other branch. `action.yaml` runs the linter
+   **twice** — once for display, once for JSON — and can therefore observe
+   two different exit codes for one repository state.
+
+The fix, landing in Phase 0 alongside `exit_codes.py`:
+
+- Reporting and exit-code determination are fully separated. Rendering
+  the stale-actions block is unconditional on the code path; it never
+  returns.
+- `_determine_exit_code` becomes the single decision point, taking the
+  full finding set plus the verify flags, and returns a named constant.
+- Outdated actions become `OUTDATED_ACTION` findings in the `CURRENCY`
+  category, so they participate in the taxonomy rather than travelling
+  out-of-band in `stale_actions_summary`.
+- A regression test asserts that `lint`, `lint --quiet` and
+  `lint --format json` return **identical** exit codes for the same
+  fixture. That invariant is what was missing.
+
+This is a behaviour change: repositories that today exit `0` while
+carrying real errors will start exiting `1`. That is the correct
+outcome, but it should be called out prominently in the release notes,
+since CI that was accidentally green may go red on upgrade.
+
+### 8.7 `--verify-actions` (symmetry)
+
+Once `OUTDATED_ACTION` is a first-class finding, a `--verify-actions`
+flag falls out for free and makes the CLI symmetric:
+
+```console
+gha-workflow-linter lint --verify-actions      # fail if any action is outdated
+gha-workflow-linter lint --verify-allow-list   # fail if any pin is stale
+```
+
+Both follow identical semantics: promote `CURRENCY` findings in that
+domain to errors, with a dedicated exit code. **Included in Phase 0**,
+alongside the taxonomy work that makes it possible.
+
+## 9. CLI surface
+
+### 9.1 New flags on `lint`
+
+<!-- markdownlint-disable MD013 -->
+
+| Flag                           | Type | Default | Purpose                                                              |
+| ------------------------------ | ---- | ------- | -------------------------------------------------------------------- |
+| `--allow-list/--no-allow-list` | bool | enabled | Master switch for allow-list detection                               |
+| `--verify-allow-list`          | bool | off     | Promote allow-list currency findings to errors; exit `3`/`4`         |
+| `--update-allow-list`          | bool | off     | Rewrite stale pins in place (never suppressed ones)                  |
+| `--show-suppressed`            | bool | off     | Report suppressed pins as notices; never affects the exit code       |
+| `--allow-list-org TEXT`        | str  | auto    | Override the workflow org used for shorthand `@<sha>` resolution     |
+| `--multi-repo` / `-M`          | bool | off     | Treat `PATH` as a parent of repositories (§11)                       |
+| `--repo-depth INT`             | int  | `1`     | How deep under `PATH` to look for repositories                       |
+| `--verify-actions`             | bool | off     | Promote outdated action calls to errors; exit `5` (§8.7)             |
+
+<!-- markdownlint-enable MD013 -->
+
+The canonical spelling is hyphenated `allow-list` throughout, matching
+the `harden-runner-block-action` README, the `allow_list.txt` filename
+and issue #296's own prose. No alias is provided for the
+`--update-allowlist` spelling.
+
+`--allow-list-org` and `--repo-depth` are value-taking and **must** be
+added to `_preprocess_args_for_default_command.value_taking_options`,
+otherwise bare invocation (`gha-workflow-linter . --allow-list-org foo`)
+mis-detects the positional path. This is easy to miss and is called out
+as a checklist item in Phase 1.
+
+### 9.2 Renaming `--auto-latest` → `--update-actions`
+
+`--auto-latest` is ambiguous once a second updatable thing exists. The
+migration:
+
+- Add `--update-actions/--no-update-actions` as the canonical flag.
+- Keep `--auto-latest/--no-auto-latest` functional as a **deprecated
+  alias**, marked `hidden=False` initially so it stays discoverable in
+  `--help` with a `(deprecated)` prefix in the help text.
+- Emit a one-line deprecation warning to stderr when the old flag is
+  used — never to stdout, which must stay clean JSON under
+  `--format json`.
+- Config key `auto_latest` gains an alias `update_actions`; both load,
+  `update_actions` wins if both are present, and `auto_latest` in a
+  config file logs a deprecation notice.
+- Internally rename `Config.auto_latest` → `Config.update_actions` with a
+  pydantic alias so existing YAML keeps working.
+- **Removal is not part of this work.** Document a removal target of the
+  next major release and keep the alias until then.
+
+Symmetry check — after this change the two update switches read
+consistently:
+
+```console
+gha-workflow-linter lint --auto-fix --update-actions      # bump uses: pins
+gha-workflow-linter lint --update-allow-list              # bump allow-list pins
+```
+
+### 9.3 Behaviour matrix
+
+<!-- markdownlint-disable MD013 -->
+
+| Invocation                                                    | Stale pins found | Reported as | Files changed | Exit                                    |
+| ------------------------------------------------------------- | ---------------- | ----------- | ------------- | --------------------------------------- |
+| `lint` (default, pre-commit)                                  | yes              | warning     | no            | unchanged by allow-list                 |
+| `lint --no-allow-list`                                        | not checked      | —           | no            | unchanged                               |
+| `lint --verify-allow-list`                                    | yes              | error       | no            | `3`                                     |
+| `lint --verify-allow-list`                                    | no               | —           | no            | `0` (or `1` from defects)               |
+| `lint --verify-allow-list` (cannot resolve latest)            | unknown          | error       | no            | `4`                                     |
+| `lint --verify-allow-list` (all stale pins suppressed)        | suppressed       | —           | no            | `0`                                     |
+| `lint --verify-allow-list --show-suppressed` (all suppressed) | suppressed       | notice      | no            | `0`                                     |
+| `lint --update-allow-list`                                    | yes              | fixed       | yes           | `1` (consistent with existing auto-fix) |
+| `lint --update-allow-list` (all suppressed)                   | suppressed       | —           | **no**        | `0`                                     |
+| `lint --update-allow-list --verify-allow-list`                | some unfixable   | error       | partial       | `3`                                     |
+| `lint --update-allow-list` (nothing stale)                    | no               | —           | no            | `0`                                     |
+| any invocation, `INVALID_SPEC` present                        | n/a              | error       | no            | `1` (defect; not gated on `--verify-*`) |
+
+<!-- markdownlint-enable MD013 -->
+
+The two suppression rows are the load-bearing ones: a suppressed pin is
+invisible to both enforcement **and** remediation. `--show-suppressed`
+changes what is printed, never what is returned.
+
+### 9.4 Reporting
+
+Extend the existing Rich report with a dedicated section, styled after
+`_display_stale_actions_from_summary`:
+
+```text
+Stale allow-list pins ⚠️
+
+  .github/workflows/zizmor-sarif-publish.yaml
+    line 116   config: '@18d9c444…'  # v0.1.1
+               → '@bf6642f6…'  # v0.12.2   (lfreleng-actions/.github)
+    line 292   config: '@18d9c444…'  # v0.1.1
+               → '@bf6642f6…'  # v0.12.2
+    line 349   config: '@18d9c444…'  # v0.1.1
+               → '@bf6642f6…'  # v0.12.2
+
+  Run with --update-allow-list to apply these changes 💡
+```
+
+Findings are deduplicated by `(kind, current_sha, target_sha)` per file,
+mirroring `_print_deduplicated_action_refs`, so a workflow with fifteen
+identical pins produces a readable block rather than fifteen paragraphs.
+
+The `--format json` output gains a top-level `allow_list` object:
+
+```json
+{
+  "allow_list": {
+    "checked": true,
+    "resolved": true,
+    "hosts": {
+      "lfreleng-actions/.github": {
+        "latest_version": "v0.12.2",
+        "latest_sha": "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+      }
+    },
+    "findings": [
+      {
+        "file": ".github/workflows/zizmor-sarif-publish.yaml",
+        "line": 116,
+        "kind": "stale",
+        "severity": "warning",
+        "current_sha": "18d9c4446bea555d0783e850f6d295f844fe8f67",
+        "current_version": "v0.1.1",
+        "target_sha": "bf6642f68d58c1b81bbe993e676d6cc339ac3654",
+        "target_version": "v0.12.2",
+        "fixed": false
+      }
+    ],
+    "summary": {"stale": 3, "comment_mismatch": 0, "unpinned": 0, "fixed": 0}
+  }
+}
+```
+
+The `action.yaml` composite action gains matching inputs
+(`allow-list`, `verify-allow-list`, `update-allow-list`,
+`allow-list-org`) and outputs (`allow-list-stale`, `allow-list-fixed`),
+reading them out of this JSON with `jq`, exactly as it does today for
+`errors-found`.
+
+## 10. Remediation design
+
+### 10.1 The rewrite
+
+For a fixable finding, the new value preserves everything except the ref
+and the version comment:
+
+```text
+'lfreleng-actions//.github/harden-runner/…/allow_list.txt@<old>'  # v0.12.1
+                                                        ^^^^^        ^^^^^^^
+'lfreleng-actions//.github/harden-runner/…/allow_list.txt@<new>'  # v0.12.2
+```
+
+Rules:
+
+- Replace **only** the ref substring after the final `@` of the spec, and
+  the version comment. The source prefix, quoting style, indentation and
+  the key are untouched.
+- Preserve the original quote style. A single-quoted scalar stays single
+  quoted; SHAs and version tags never contain characters needing escapes,
+  so no re-quoting logic is required.
+- Preserve the original spacing before `#`. Unlike
+  `AutoFixer._build_fixed_line`, which normalises comment spacing via
+  `two_space_comments`, the allow-list fixer does a **surgical
+  substring replacement** on the existing line. Reformatting a
+  neighbouring comment is out of scope for a version bump and would
+  produce noisy diffs in the PRs this feature exists to generate.
+- If the line has no version comment, add one using
+  `two_space_comments` spacing (this *is* new content, so the config
+  preference applies).
+- **Preserve suppression directives and reason text** (§7.4) when
+  rewriting a comment. Only the version token changes; recognised
+  directives and any `-- reason` tail carry through verbatim.
+- **Never rewrite a suppressed pin.** Suppression is evaluated before the
+  fixer is consulted, not after.
+- Never touch multi-line scalars (`auto_fixable=False`).
+
+### 10.2 Atomic writes
+
+Introduce a shared writer in `file_edit.py`:
+
+```python
+def replace_lines(
+    path: Path,
+    replacements: Mapping[int, str],   # 1-based line -> new content
+) -> list[LineChange]:
+    """Rewrite specific lines atomically, preserving line endings."""
+```
+
+It reads with `newline=""` to detect and preserve the file's existing
+line endings, writes to a sibling temporary file, then `os.replace()`s
+it into position. This fixes three defects the audit found in
+`AutoFixer._apply_fixes_to_file` — non-atomic truncating write, no
+CRLF preservation, and an unconditional trailing newline on the last
+line.
+
+The allow-list fixer uses it from day one. **Migrating `AutoFixer` onto
+it is included as a Phase 3 task**, because two file-rewriting
+implementations in one tool is precisely the duplication this plan is
+meant to avoid.
+
+### 10.3 Interaction with `--update-actions`
+
+The two updaters are independent and may run in the same invocation.
+They touch disjoint lines (`uses:` values versus `config:`/`default:`
+values), so they compose safely. To guarantee that, both funnel their
+line replacements into a **single** `replace_lines` call per file, with
+an assertion that no line number is claimed twice. If it ever is, that is
+a bug and should fail loudly rather than silently lose an edit.
+
+## 11. Multi-repository mode
+
+`--multi-repo` treats `PATH` as a container of git repositories:
+
+```console
+gha-workflow-linter lint ~/Repositories/lfreleng-actions \
+  --multi-repo --update-allow-list
+```
+
+Semantics:
+
+- Discover candidate repositories: directories under `PATH` (to
+  `--repo-depth`, default `1`) that contain a `.git` entry (directory or
+  file, so worktrees and submodules both work).
+- Repositories are processed **sequentially**; the existing intra-repo
+  parallelism already saturates the API budget, and sequential
+  processing keeps the Rich progress output legible and per-repo failures
+  attributable.
+- **Shared state across repositories**: one `ValidationCache`, one
+  GitHub client, one allow-list resolution per host repo. Scanning
+  twenty repositories that all pin `lfreleng-actions/.github` costs
+  **one** latest-release lookup, not twenty. This is the main efficiency
+  argument for building multi-repo into the tool rather than looping in
+  a shell script.
+- **Per-repository state**: workflow org (§6.3) and Dependabot cooldown
+  (`dependabot.resolve_cooldown`) are resolved per repository, because
+  both are repository properties.
+- A failure in one repository is recorded and the run continues; the
+  aggregate exit code is the maximum by the precedence in §8.
+- Output gains a per-repository grouping header plus a final aggregate
+  table (repository, pins found, stale, fixed, status).
+- `--multi-repo` composes with everything else. In particular
+  `--multi-repo --verify-allow-list` is the org-wide audit
+  ("is anything stale anywhere?") and `--multi-repo --update-allow-list`
+  is the bulk remediation that generated the seven manual PRs described
+  in issue #296.
+
+Repository discovery lives in `multi_repo.py` with a clean interface, so
+the scheduled workflow can instead use a matrix of one-repo checkouts
+without duplicating logic.
+
+## 12. Module layout
+
+New modules, flat, following the existing `auto_fix*` prefix-grouping
+convention:
+
+<!-- markdownlint-disable MD013 -->
+
+| Module                   | Responsibility                                                                                                                                                                                   | Depends on                                              |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| `allow_list_spec.py`     | Pure parser/resolver for the config grammar. Port of `resolve_config_source.py` (parse/split/resolve only — no fetching, no sanitising). Also renders a spec back to source form.                | stdlib only                                             |
+| `directives.py`          | Suppression directive grammar (§7.4): preceding-line and inline forms, optional reason text, and which finding kinds each directive may suppress. Deliberately generic, not allow-list specific. | stdlib only                                             |
+| `allow_list_scanner.py`  | YAML-node-tree walk producing `AllowListPin` records with line/column anchors, plus the syntax-anchored recogniser predicate (no consumer registry).                                             | `allow_list_spec`, `yaml`, `scanner`                    |
+| `allow_list_resolver.py` | Latest-release → peeled commit SHA per host repo, across both backends, with caching and cooldown.                                                                                               | `github_api`, `git_validator`, `cache`, `version_utils` |
+| `allow_list_check.py`    | Orchestrator: pins + resolution + suppression → `AllowListFinding` list; severity assignment; summary construction.                                                                              | the four above                                          |
+| `allow_list_fix.py`      | Surgical line rewriting for fixable findings.                                                                                                                                                    | `file_edit`, `allow_list_spec`                          |
+| `allow_list_report.py`   | Rich text and JSON rendering.                                                                                                                                                                    | `console`, `models`                                     |
+| `file_edit.py`           | Shared atomic line-replacement writer.                                                                                                                                                           | stdlib                                                  |
+| `exit_codes.py`          | Centralised exit-code constants and the defect/currency decision (§8).                                                                                                                           | stdlib                                                  |
+| `multi_repo.py`          | Repository discovery and per-repo run aggregation.                                                                                                                                               | `paths`                                                 |
+
+<!-- markdownlint-enable MD013 -->
+
+Modified modules:
+
+- `models.py` — add `Severity`, `Category`, `AllowListFindingKind`,
+  `AllowListPin`, `AllowListFinding`, `ResolvedSpec`, `AllowListConfig`,
+  `Directive`, `SuppressionSource`; add `ANNOTATED_TAG_SHA`,
+  `SHA_COMMENT_MISMATCH` and `OUTDATED_ACTION` to the action-call result
+  taxonomy; add the new fields to `Config` and `CLIOptions`; rename
+  `auto_latest` → `update_actions` with a backwards-compatible alias.
+- `cli.py` — new flags, deprecation shim, `value_taking_options` update,
+  allow-list stage wiring, exit-code centralisation, **removal of the
+  `run_linter` early-return bypass (§8.6)**, multi-repo driver.
+- `config.py` — load/save the new keys; alias handling.
+- `github_api.py` — `resolve_latest_releases_batch`; distinguish tag
+  objects from commits so `ANNOTATED_TAG_SHA` can be reported.
+- `git_validator.py` — `_get_remote_tag_shas`; **fix the annotated-tag
+  false pass in `_validate_commit_shas_git` (§8.2)**.
+- `validator.py` — classify results into `DEFECT` / `CURRENCY`; emit the
+  three new issue kinds.
+- `scanner.py` — expose the composed YAML node tree (currently discarded
+  in `_is_valid_yaml`) so the file is parsed once, not twice.
+- `auto_fix.py` — migrate `_apply_fixes_to_file` onto `file_edit`.
+- `action.yaml`, `README.md`, `.pre-commit-hooks.yaml` (unchanged args,
+  but document that the hook never fails on allow-list findings).
+
+The layering is strictly one-directional:
+
+```mermaid
+graph TD
+    CLI[cli.py] --> CHECK[allow_list_check.py]
+    CLI --> MULTI[multi_repo.py]
+    CLI --> EXIT[exit_codes.py]
+    CHECK --> SCAN[allow_list_scanner.py]
+    CHECK --> RES[allow_list_resolver.py]
+    CHECK --> FIX[allow_list_fix.py]
+    CHECK --> REP[allow_list_report.py]
+    SCAN --> SPEC[allow_list_spec.py]
+    FIX --> SPEC
+    FIX --> EDIT[file_edit.py]
+    RES --> API[github_api.py]
+    RES --> GIT[git_validator.py]
+    RES --> CACHE[cache.py]
+    AF[auto_fix.py] --> EDIT
+```
+
+`allow_list_spec.py` has no project dependencies at all, which keeps the
+grammar port independently testable against the action's own cases.
+
+## 13. Shared/centralised helpers
+
+Deliberate consolidation opportunities this work should take, each of
+which removes an existing duplication rather than adding one:
+
+1. **`file_edit.replace_lines`** — one atomic, line-ending-preserving
+   writer used by both fixers (§10.2).
+2. **`exit_codes`** — replaces scattered `typer.Exit(1)` literals with
+   named constants; makes the documented contract enforceable in tests.
+3. **`git_validator._get_remote_tag_shas`** — one tag→commit map used by
+   the allow-list resolver *and* available to
+   `auto_fix_versions._get_latest_version_via_git`, which currently
+   re-derives the same information through a separate code path.
+4. **`version_utils`** — reused unchanged for version parsing,
+   specificity ranking and cooldown selection. No new version logic.
+5. **`cache.ValidationCache.{get,put}_latest_version`** — reused
+   unchanged for allow-list host repos. No new cache store.
+6. **`github_auth.get_github_token_with_fallback`** — reused unchanged.
+   No new token discovery.
+7. **Single YAML parse per file** — `scanner._is_valid_yaml` currently
+   parses and discards; expose the composed tree so the allow-list
+   scanner does not re-read and re-parse every workflow.
+8. **`Severity`** — introduced generically so the existing validator can
+   adopt it later (for example to downgrade `TEST_REFERENCE` properly,
+   which today is handled by an ad-hoc filter in `_determine_exit_code`).
+
+## 14. Configuration file surface
+
+```yaml
+# Rename of auto_latest; auto_latest still accepted (deprecated).
+update_actions: false
+
+allow_list:
+  # Master switch for allow-list pin detection.
+  enabled: true
+
+  # Promote findings to errors and fail with exit code 3.
+  verify: false
+
+  # Rewrite stale pins in place.
+  update: false
+
+  # Workflow org for resolving the '@<sha>' shorthand. When unset the
+  # tool infers it (see docs): GITHUB_REPOSITORY_OWNER, then the
+  # 'upstream' git remote, then 'origin'.
+  org: ""
+
+  # Conventional allow-list filename, used by the recogniser predicate
+  # for scalars whose key name gives no clue. There is deliberately no
+  # per-consumer registry — see section 5.4 of the design document.
+  filename: "allow_list.txt"
+
+  # Key-name patterns recognised as allow-list coordinates in
+  # 'workflow_call' input defaults and reusable-workflow 'with' blocks.
+  key_patterns:
+    - "*allow_list*"
+    - "*allowlist*"
+    - "*allow-list*"
+
+  # Extra globs scanned only by the allow-list checker (example callers
+  # live outside .github/workflows and are otherwise not discovered).
+  extra_globs:
+    - "examples/**/*.yaml"
+    - "examples/**/*.yml"
+
+  # Report suppressed pins as notices. Equivalent to --show-suppressed.
+  # Never affects the exit code.
+  show_suppressed: false
+```
+
+The suppression directive token itself is **not** configurable.
+A directive that varies per repository is not a convention, and
+grep-ability across the estate is worth more than flexibility here.
+
+`ConfigManager.save_default_config` currently emits a hand-built f-string
+covering only a subset of fields and omitting `git`, `cache`,
+`cooldown_days` and others. Rather than extend that drift, **replace it
+with `yaml.dump` over `Config.model_dump()`** plus a static header
+comment. This is a small, contained fix that guarantees the generated
+template stays complete as fields are added.
+
+## 15. Scheduled workflow and Slack notification
+
+Delivered in the `lfreleng-actions/.github` repository, modelled directly
+on `zizmor-sarif-publish.yaml` (issue #146).
+
+**`.github/workflows/allow-list-bump.yaml`**
+
+```yaml
+on:
+  schedule:
+    # Mondays at 05:00 UTC — ahead of the 06:00 weekday scanners.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      org:
+        description: 'Org to sweep'
+        required: false
+        default: ''
+      repo:
+        description: 'Single repo (name only)'
+        required: false
+        default: ''
+      dry-run:
+        description: 'Report only; raise no PRs'
+        type: boolean
+        default: false
+```
+
+Jobs:
+
+1. **`discover`** — reuses the existing `repo-discovery.yaml` reusable
+   workflow, so the sweep automatically honours
+   `.github/scan-scope.json` (archived/fork/template/private policy and
+   exclusions) and stays in step with the other org-wide jobs.
+
+   Scope follows the criticality tiering in §1.1 and issue #146's
+   `*-workflows` pattern:
+
+   <!-- markdownlint-disable MD013 -->
+
+| Tier         | Selection                                          | Action                                                                        |
+| ------------ | -------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Critical** | `extra-include: '*-workflows'`                     | PRs raised, included in the Slack digest                                      |
+| **Advisory** | `vars.ALLOW_LIST_ADVISORY_INCLUDE` (default empty) | Reported in the run summary only; PRs raised only when the var lists the repo |
+
+   <!-- markdownlint-enable MD013 -->
+
+   `.github` is deliberately **not** in the critical tier. Its pins are
+   the oldest in the estate, but its workflows do standard GitHub
+   plumbing whose endpoint needs are stable, so weekly PRs against it
+   would be pure review noise. It can be added to the advisory include
+   var when someone wants it tidied.
+
+   This keeps the weekly PR volume proportional to actual risk — roughly
+   eight `*-workflows` repositories rather than the whole org — which
+   matters a great deal for whether the PRs actually get reviewed.
+
+1. **`bump`** (matrix over discovered repos, `fail-fast: false`,
+   `max-parallel: 8`) —
+   harden-runner-block-action → harden-runner (block) → checkout target
+   repo → run
+   `gha-workflow-linter lint . --update-allow-list --no-auto-fix --format json`
+   → if the JSON reports fixes, create a branch and open a PR via
+   `peter-evans/create-pull-request` (SHA-pinned) → emit the PR URL as a
+   job output.
+
+   `--no-auto-fix` is important: this sweep must produce **allow-list-only
+   diffs**. Action-version bumps are Dependabot's job and mixing them
+   makes the PRs hard to review and hard to revert.
+
+   Commit message and PR title follow the org's Conventional Commits
+   rules with a capitalised type:
+
+   ```text
+   Chore: bump harden-runner allow-list to v0.12.2
+
+   The allow-list pins in this repository referenced <old> (<old
+   version>). The current lfreleng-actions/.github release is
+   <new version>, which adds the endpoints needed by ...
+
+   Raised automatically by gha-workflow-linter --update-allow-list.
+   ```
+
+   Idempotency: a fixed branch name per target version
+   (`chore/allow-list-<version>`) so a re-run updates the existing PR
+   rather than opening duplicates.
+
+2. **`notify`** — `if: always()`, collects the matrix PR URLs, posts one
+   Slack digest via `slackapi/slack-github-action` (`chat.postMessage`)
+   to `vars.SLACK_CHANNEL_ID` using `secrets.SLACK_BOT_TOKEN`, listing
+   each PR as a link plus a count of repositories already current. Skips
+   posting entirely when nothing changed and nothing failed, so a quiet
+   week is quiet.
+
+3. **`notify-failure`** — copied structurally from
+   `zizmor-sarif-publish.yaml`: `if: always() && github.event_name ==
+   'schedule' && (contains(needs.*.result, 'failure') ||
+   contains(needs.*.result, 'cancelled'))`, posting a failure block with
+   a link to the run.
+
+Security notes, matching prior art:
+
+- All jobs run in the `production` environment so environment-scoped
+  secrets satisfy zizmor's `secrets-outside-env`.
+- Cross-repo PR creation needs a PAT (`ALLOWLIST_BUMP_PAT`, scopes
+  `repo`, `read:org`); `GITHUB_TOKEN` cannot open PRs in other
+  repositories.
+- `permissions: {}` at workflow level, narrowed per job.
+- Every step pinned to a **commit** SHA with a trailing version comment —
+  never a tag object SHA, never a floating `v4`.
+- The workflow must pass a zizmor audit with the `auditor` persona and
+  **zero** findings before it is pushed.
+
+There is a satisfying closure here: the new workflow's own
+`harden-runner-block-action` pins become subject to the very check it
+runs, so the sweep keeps itself current.
+
+## 16. Test plan
+
+<!-- markdownlint-disable MD013 -->
+
+| Area                  | Coverage                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allow_list_spec`     | Conformance corpus **ported from the mirrored `tests/test_resolve_config_source.py`** in `harden-runner-block-action` / `python-audit-action` (§19); plus the shorthand `@<sha>`; bare `//`; filename-only subpath; explicit path; comment splitting including the `foo#bar` non-comment case and the newline-rejection case; every `ResolveError` branch (double `@`, double `//`, empty ref, bad org/repo/ref/segment, `..` traversal) |
+| `consumer neutrality` | A `harden-runner` pin and a `python-audit` pin are judged stale on identical conditions; a scalar naming an unknown family is handled with no code change; an unrelated `config:` value that is not a valid spec is skipped, not mis-resolved                                                                                                                                                                                            |
+| `allow_list_scanner`  | Real fixtures copied from `.github`, `java-workflows` and this repo; the `on` → `True` YAML-1.1 key gotcha; `${{ }}` expression skip; multi-line scalar marked unfixable; single vs double vs unquoted scalars; a file with no pins; a file that fails YAML parsing                                                                                                                                                                      |
+| `allow_list_resolver` | Annotated-tag peel (must return the commit, not the tag object); prerelease and draft filtering; cooldown selection; cache hit path costs zero API calls; git backend returns `None` under an active cooldown; both backends agree on a shared fixture                                                                                                                                                                                   |
+| `directives`          | Both forms parse; preceding-line form rejected when separated by a blank line or intervening content; indentation irrelevant; version token stays first in `# v0.5.1 allow-list-pin-ok`; optional `-- reason` captured; unrecognised trailing tokens preserved and ignored; directive found in an in-scalar comment as well as a YAML comment; both forms present is idempotent, not an error                                            |
+| `allow_list_check`    | Severity assignment per kind; `--verify-allow-list` promotion; `COMMENT_MISMATCH` where the SHA is current but the comment is not; `UNRESOLVABLE`; resolution-failure fail-open in default mode and fail-hard under verify; **suppression covers `STALE`/`UNPINNED` and does NOT cover `COMMENT_MISMATCH`/`UNRESOLVABLE`/`INVALID_SPEC`**; `--show-suppressed` changes output but never the exit code                                    |
+| `allow_list_fix`      | Byte-for-byte diff assertions: only the ref and comment change; quote style preserved; spacing before `#` preserved; comment added where absent; CRLF file stays CRLF; final line without a trailing newline does not gain one; unfixable pins untouched; **a suppressed pin is never rewritten**; **directives and reason text survive a rewrite triggered by a non-suppressible kind**                                                 |
+| `annotated_tag_sha`   | A tag-object SHA is reported as `ANNOTATED_TAG_SHA`, not `INVALID_REFERENCE`; **both backends agree** (regression test for the confirmed git false pass, §8.2); the message names the peeled commit; auto-fixed under plain `--auto-fix` without `--update-actions`; a real commit SHA is untouched                                                                                                                                      |
+| `file_edit`           | Atomicity (no partial file on simulated write failure); line-ending preservation; disjoint-line assertion fires on a double claim                                                                                                                                                                                                                                                                                                        |
+| `exit_codes`          | Table-driven test of every combination in the §9.3 behaviour matrix, asserting the exact integer; **`lint`, `lint --quiet` and `lint --format json` return identical codes for the same fixture** (regression test for §8.6); a defect plus an outdated action exits `1`, not `0`                                                                                                                                                        |
+| `cli`                 | New flags parse; `--allow-list-org`/`--repo-depth` survive bare invocation without an explicit `lint` subcommand; `--auto-latest` still works and warns; the warning goes to stderr, never stdout; `--format json` output stays valid JSON with the deprecated flag set                                                                                                                                                                  |
+| `multi_repo`          | Discovery at depth 1 and 2; `.git` file (worktree) as well as `.git` directory; per-repo org resolution; one failing repo does not abort the run; the shared resolver is called once for N repos                                                                                                                                                                                                                                         |
+| Regression            | Existing suite passes unchanged **except** the exit-code tests affected by §8.6, which are updated deliberately and called out in the commit body; a `lint` run with no allow-list pins produces byte-identical output to today                                                                                                                                                                                                          |
+
+<!-- markdownlint-enable MD013 -->
+
+Fixtures live under `tests/fixtures/allow_list/` and are copied from
+real workflows so the test suite tracks the estate's actual shapes.
+
+Coverage must not fall below the configured `--cov-fail-under=70`; the
+new modules should comfortably exceed it since the spec parser and fixer
+are pure functions.
+
+## 17. Documentation changes
+
+- **`README.md`** — a new "Allow-list pin checking" section covering what
+  the pins are, why Dependabot cannot see them, the default advisory
+  behaviour, the flags, the exit-code table, and worked examples
+  including multi-repo. A short note in the pre-commit section stating
+  explicitly that the hook never fails on allow-list findings.
+- **`README.md` migration note** — `--auto-latest` → `--update-actions`,
+  with the deprecation timeline.
+- **This document** — kept as the design record.
+- **`harden-runner-block-action` README** — a cross-reference pointing at
+  the linter as the way to keep pins current.
+- **`.github` repository README** — document the weekly sweep, the
+  `ALLOWLIST_BUMP_PAT` secret and the Slack channel.
+
+## 18. Delivery phases
+
+Each phase lands as its own conventional commit and can merge
+independently; the tool is never left in a half-working state.
+
+### Phase 0 — foundations and error-handling fixes
+
+User-visible only through corrected exit codes and better messages.
+
+- `exit_codes.py`; replace the scattered `typer.Exit(1)` literals.
+- **Fix the `run_linter` early-return bypass (§8.6)**, plus the
+  exit-code-invariance regression test across text/quiet/JSON.
+- `Severity` and `Category` enums; classify existing results into
+  `DEFECT` / `CURRENCY`.
+- `git_validator._get_remote_tag_shas`; **fix the annotated-tag false
+  pass (§8.2)** and add the `ANNOTATED_TAG_SHA` kind with its
+  peeled-commit remediation message.
+- `SHA_COMMENT_MISMATCH` and `OUTDATED_ACTION` as first-class kinds.
+- `--verify-actions` flag and exit code `5`.
+- `file_edit.py`; unit tests.
+- `directives.py` + grammar tests (needed by Phase 1, no dependencies).
+- Expose the composed YAML tree from `scanner._is_valid_yaml`.
+- `github_api.resolve_latest_releases_batch`.
+
+This phase stands alone and is worth shipping on its own merits: it fixes
+two confirmed bugs and materially improves reporting quality before any
+allow-list code exists.
+
+### Phase 1 — detection (warning-only)
+
+- `allow_list_spec.py` + grammar test suite.
+- `allow_list_scanner.py` + fixture tests.
+- `allow_list_resolver.py`, `allow_list_check.py`,
+  `allow_list_report.py`.
+- **Suppression wired end to end** (§7.4): both directive forms honoured,
+  applicability matrix enforced, summary line always emitted.
+- CLI: `--allow-list/--no-allow-list`, `--verify-allow-list`,
+  `--allow-list-org`, `--show-suppressed`; `value_taking_options`
+  update; exit codes `3`/`4`.
+- Config keys; README section.
+
+### Phase 2 — remediation
+
+- `allow_list_fix.py` + diff-assertion tests, including
+  directive-preservation and never-fix-suppressed.
+- CLI: `--update-allow-list`.
+- JSON output `allow_list` block (with `"suppressed"`);
+  `action.yaml` inputs/outputs.
+
+### Phase 3 — flag migration and consolidation
+
+- `--update-actions` canonical, `--auto-latest` deprecated alias.
+- `Config.update_actions` with pydantic alias for `auto_latest`.
+- Migrate `AutoFixer._apply_fixes_to_file` onto `file_edit`.
+- Replace the hand-built `save_default_config` template with
+  `yaml.dump`.
+
+### Phase 4 — multi-repository mode
+
+- `multi_repo.py`; `--multi-repo` / `--repo-depth`.
+- Shared cache and resolver across repositories; aggregate reporting and
+  exit-code precedence.
+
+### Phase 5 — scheduled workflow (in `lfreleng-actions/.github`)
+
+- `allow-list-bump.yaml` reusing `repo-discovery.yaml`, scoped to the
+  critical `*-workflows` tier (§15).
+- PR creation, Slack digest, Slack failure notification.
+- Zizmor `auditor` audit with zero findings before push.
+- `ALLOWLIST_BUMP_PAT` provisioned in the `production` environment.
+
+Phases 1–4 land in `gha-workflow-linter` and can proceed in parallel with
+nothing blocking them. Phase 5 depends on Phase 2 being released to PyPI
+(the workflow consumes the published tool via `uvx`).
+
+## 19. Risks, edge cases and open questions
+
+**Grammar drift.** `allow_list_spec.py` is a port of a file that is
+mirrored byte-for-byte between `harden-runner-block-action` and
+`python-audit-action`, enforced by a `sync-shared-resolver.yaml` workflow
+present in **both** repositories. Crucially, that sync covers not just
+`src/resolve_config_source.py` but also
+`tests/test_resolve_config_source.py` — there is an existing, mirrored
+test suite whose stated purpose is to "pin the shared `config` grammar".
+
+That is a gift rather than a threat, provided we use it:
+
+1. **Derive our test suite from theirs.** Port
+   `tests/test_resolve_config_source.py` as the conformance corpus for
+   `allow_list_spec.py`. Cases we invent ourselves are guesses; those
+   cases are the specification.
+2. **Register as a third consumer.** Add `gha-workflow-linter` to the
+   banner in the mirrored file listing repositories that must be updated
+   in the same change, so the next paired PR carries a visible reminder.
+3. **Consider extending the sync check.** The cleanest long-term answer
+   is for `sync-shared-resolver.yaml` to also assert that our port agrees
+   with the upstream corpus, making divergence a CI failure rather than a
+   silent behavioural drift discovered through false findings.
+
+Without at least (1) and (2), a grammar change lands as a paired PR
+across two repositories while our port quietly diverges.
+
+**False positives are expensive.** A linter that cries wolf on a valid
+pin will be switched off. The recogniser predicate (§5.1) is deliberately
+conservative, `${{ }}` values are skipped, and unparsable scalars that
+only matched on key name produce nothing. Default severity is `WARNING`
+precisely so early false positives cannot block anyone.
+
+**Fork resolution.** The `@<sha>` shorthand resolves against the workflow
+org. Contributors working from personal forks would resolve to a `.github`
+repository that does not exist. The `upstream`-before-`origin` remote
+precedence (§6.3) handles the LF workflow correctly, and
+`--allow-list-org` covers everything else. Worth flagging clearly in the
+README.
+
+**Rate limits.** One latest-release lookup per distinct host repo, cached
+with the existing TTL, means a typical run is a single query and repeat
+runs are free. Multi-repo mode shares the resolution across all
+repositories. The unauthenticated 60/hour limit is not a practical
+constraint at this volume, but the default advisory mode fails open if it
+is ever hit.
+
+**Pins that intentionally lag.** Resolved — suppression is now a
+compulsory part of the implementation (§7.4), with two directive forms
+and a precise applicability matrix. The residual risk is *silent* drift:
+a suppression added once and never revisited. Mitigated by the
+always-on suppression count, `--show-suppressed`, the optional reason
+text, and `"suppressed": true` in the JSON output. A future enhancement
+could add an expiry (`allow-list-pin-ok until: 2026-12-01`) — noted, not
+proposed.
+
+**Behaviour change on upgrade.** Fixing §8.6 means repositories that
+currently exit `0` while carrying real defects will start exiting `1`.
+This is the correct outcome, but CI that was accidentally green may go
+red. Needs prominent release notes and, ideally, a heads-up in
+`#releng-scm` before the release lands.
+
+**Consumer neutrality.** Resolved — there is no per-consumer registry
+(§5.4). Every allow-list consumer shares one grammar, one resolver, one
+host repository and one input name, and staleness never depends on the
+family. New consumers are covered on the day they appear, with no code
+change and no release. The earlier proposal to register consumers
+individually has been removed as an unnecessary re-encoding of a
+distinction the central design keeps out of the mechanism.
+
+**`--verify-actions` (§8.7).** Resolved — included in Phase 0 alongside
+the `OUTDATED_ACTION` taxonomy work that makes it possible.
+
+**Interaction with Dependabot.** The `uses:` pin of
+`harden-runner-block-action` *is* visible to Dependabot, so the action
+version and the allow-list version are bumped by different mechanisms on
+different schedules. That is fine — they are independent — but the PR
+descriptions should say so, or reviewers will wonder why only half the
+line changed.
+
+**Comment-only staleness.** A pin whose SHA is current but whose comment
+is wrong is not a functional problem, yet `--verify-allow-list` promotes
+it to an error and suppression deliberately does **not** cover it
+(§7.4). That is intentional — the comment is what humans read, and a
+lying comment is how the estate lost track of the internal workflows in
+the first place — but it means a repository can fail verification without
+any behavioural defect. Called out so it is a deliberate choice rather
+than a surprise.
+
+**Suppression scope creep.** `allow-list-pin-ok` is deliberately a single
+token with a fixed meaning. Resist requests to add per-kind variants
+(`allow-list-stale-ok`, `allow-list-unpinned-ok`) unless a concrete need
+appears; the value of the directive is that every reviewer knows exactly
+what it means without consulting documentation.

--- a/docs/ALLOW_LIST_FEATURE.md
+++ b/docs/ALLOW_LIST_FEATURE.md
@@ -760,17 +760,27 @@ is exactly the class of bug that erodes trust in a linter.
 
 ### 8.3 New issue kinds
 
-Add three kinds, all of which fall out of work already planned:
+Add `ANNOTATED_TAG_SHA` in this phase, and two further kinds in the
+later phases that emit them:
 
 ```python
-ANNOTATED_TAG_SHA   # pin is a tag object SHA; the commit SHA is <peeled>
+ANNOTATED_TAG_SHA    # pin is a tag object SHA; the commit SHA is <peeled>
 SHA_COMMENT_MISMATCH # pinned SHA is valid but '# vX.Y.Z' names another version
 OUTDATED_ACTION      # valid and correctly pinned, but a newer release exists
 ```
 
-`ANNOTATED_TAG_SHA` is the highest-value addition. `_get_remote_tag_shas`
-(Phase 0) gives both backends the tag-object → commit map, so the git
-backend stops false-passing **and** the message becomes actionable:
+`SHA_COMMENT_MISMATCH` and `OUTDATED_ACTION` are **deliberately not added
+until something emits them**. The condition behind each is already
+detected (`auto_fix` repairs comment mismatches; outdated actions travel
+via `stale_actions_summary`), but promoting them to first-class results
+means routing them through the validator, which belongs with the work
+that consumes them. Adding the enum members early would leave dead
+branches in the message table and summary counters.
+
+`ANNOTATED_TAG_SHA` is the highest-value addition and lands now.
+`_get_remote_tag_shas` gives both backends the tag-object to commit map,
+so the git backend stops false-passing **and** the message becomes
+actionable:
 
 ```text
 .github/workflows/build.yaml
@@ -822,14 +832,14 @@ is preserved.
 
 <!-- markdownlint-disable MD013 -->
 
-| Code | Name                    | Meaning                                                                         |
-| ---- | ----------------------- | ------------------------------------------------------------------------------- |
-| `0`  | `SUCCESS`               | No failing findings                                                             |
-| `1`  | `DEFECTS_FOUND`         | `DEFECT`-category findings, or files modified by any fixer (existing behaviour) |
-| `2`  | *reserved*              | Click/Typer CLI usage error — **do not assign**                                 |
-| `3`  | `ALLOW_LIST_STALE`      | `--verify-allow-list` and unsuppressed allow-list `CURRENCY` findings remain    |
-| `4`  | `ALLOW_LIST_UNRESOLVED` | `--verify-allow-list` and the latest release could not be resolved              |
-| `5`  | `ACTIONS_OUTDATED`      | `--verify-actions` and outdated action calls remain (§8.7)                      |
+| Code | Name                              | Meaning                                                                                                                                                                                                              |
+| ---- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | `SUCCESS`                         | No failing findings                                                                                                                                                                                                  |
+| `1`  | `DEFECTS_FOUND` / `RUNTIME_ERROR` | Defect findings, files modified by a fixer, or the run itself failed. The two share a value because the tool has always exited `1` for both; splitting them would break callers, so it is deferred to a future major |
+| `2`  | *reserved*                        | Click/Typer CLI usage error — **do not assign**                                                                                                                                                                      |
+| `3`  | `ALLOW_LIST_STALE`                | `--verify-allow-list` and unsuppressed allow-list `CURRENCY` findings remain                                                                                                                                         |
+| `4`  | `ALLOW_LIST_UNRESOLVED`           | `--verify-allow-list` and the latest release could not be resolved                                                                                                                                                   |
+| `5`  | `ACTIONS_OUTDATED`                | `--verify-actions` and outdated action calls remain (§8.7)                                                                                                                                                           |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,20 @@ line-ending = "auto"
 
 [tool.basedpyright]
 pythonVersion = "3.10"
-include = ["src"]
+# Every tracked Python location. This list governs editor/LSP checking
+# and bare `basedpyright` invocations; the pre-commit hook deliberately
+# carries no `files:` filter, so it checks every staged Python file
+# regardless of what appears here. Keep both in step: if a new
+# top-level Python directory appears, add it here too.
+include = ["src", "tests", "scripts", "examples"]
+# Build artefacts and caches are untracked, but exclude them explicitly
+# so a bare invocation never wanders into generated code.
+exclude = [
+    "**/__pycache__",
+    "**/.*",
+    "dist",
+    "htmlcov",
+]
 typeCheckingMode = "strict"
 reportMissingImports = "none"
 reportMissingTypeStubs = "none"

--- a/src/gha_workflow_linter/__init__.py
+++ b/src/gha_workflow_linter/__init__.py
@@ -3,9 +3,16 @@
 
 """GitHub Actions workflow linter."""
 
+# ``_version.py`` is generated at build time by hatch-vcs and is not in
+# version control, so a static analyser running against a bare checkout
+# (as the basedpyright pre-commit hook does) cannot resolve it. Binding
+# through an intermediate name with an explicit annotation gives the
+# public symbol a definite type either way.
 try:
-    from ._version import __version__
-except ImportError:
-    __version__ = "dev"
+    from ._version import __version__ as _generated_version
+except ImportError:  # pragma: no cover - only when not built
+    _generated_version = "dev"
+
+__version__: str = _generated_version
 
 __all__ = ["__version__"]

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -33,6 +33,7 @@ from rich.progress import (
 from rich.table import Table
 import typer
 
+from . import exit_codes
 from ._version import __version__
 from .auto_fix import AutoFixer
 from .cache import CachePrimeReport, ValidationCache
@@ -649,6 +650,15 @@ def lint(
         "--files",
         help="Specific files to scan (supports wildcards, can be specified multiple times)",
     ),
+    verify_actions: bool = typer.Option(
+        False,
+        "--verify-actions",
+        help=(
+            "Treat outdated action calls as errors and exit with status 5. "
+            "Without this flag outdated actions are reported but do not "
+            "fail the run"
+        ),
+    ),
     _help: bool = typer.Option(
         False,
         "--help",
@@ -789,6 +799,7 @@ def lint(
             fix_test_calls=fix_test_calls,
             cooldown=cooldown,
             files=files,
+            verify_actions=verify_actions,
         )
 
         # Apply CLI overrides to config
@@ -1270,9 +1281,25 @@ def _determine_exit_code(
     validation: _ValidationOutcome,
     autofix: _AutoFixOutcome,
 ) -> int:
-    """Compute the process exit code from fixes and validation errors."""
-    # If we auto-fixed files (not just skipped testing items), always exit
-    # with an error to indicate changes were made.
+    """Compute the process exit code from fixes and validation errors.
+
+    This is the single decision point for the process exit status. It is
+    deliberately independent of reporting: presentation flags such as
+    ``--quiet`` and ``--format json`` must never change the code a given
+    repository state produces.
+
+    Args:
+        options: Resolved CLI options.
+        validation: Outcome of the scan/validate stage.
+        autofix: Outcome of the auto-fix stage.
+
+    Returns:
+        A code from :mod:`gha_workflow_linter.exit_codes`.
+    """
+    codes: list[int] = []
+
+    # Files modified on disk are reported as a failure so a CI job or a
+    # pre-commit hook notices that the tree changed underneath it.
     if autofix.fixed_files:
         has_actual_fixes = any(
             change.get("skipped") != "true"
@@ -1280,10 +1307,10 @@ def _determine_exit_code(
             for change in changes
         )
         if has_actual_fixes:
-            return 1
+            codes.append(exit_codes.DEFECTS_FOUND)
 
-    # Otherwise, exit with error only if there are validation errors
-    # (excluding test references) and fail_on_error is enabled.
+    # Validation errors (excluding test references, which are advisory by
+    # convention) count when the caller has not disabled failure.
     if options.fail_on_error:
         actual_errors = [
             e
@@ -1291,9 +1318,29 @@ def _determine_exit_code(
             if not has_test_comment(e.action_call)
         ]
         if actual_errors:
-            return 1
+            codes.append(exit_codes.DEFECTS_FOUND)
 
-    return 0
+    # Outdated action calls are a CURRENCY finding: advisory unless the
+    # caller opted in with --verify-actions.
+    if options.verify_actions and _has_outdated_actions(autofix):
+        codes.append(exit_codes.ACTIONS_OUTDATED)
+
+    return exit_codes.combine(*codes) if codes else exit_codes.SUCCESS
+
+
+def _has_outdated_actions(autofix: _AutoFixOutcome) -> bool:
+    """Report whether any action call has a newer release available.
+
+    Args:
+        autofix: Outcome of the auto-fix stage.
+
+    Returns:
+        True when at least one outdated (but otherwise valid) action call
+        was detected.
+    """
+    return any(
+        items for items in autofix.stale_actions_summary.values() if items
+    )
 
 
 def run_linter(config: Config, options: CLIOptions) -> int:
@@ -1305,7 +1352,7 @@ def run_linter(config: Config, options: CLIOptions) -> int:
         options: CLI options
 
     Returns:
-        Exit code (0 for success, 1 for failure)
+        Exit code from :mod:`gha_workflow_linter.exit_codes`.
     """
     scanner = WorkflowScanner(config)
 
@@ -1329,9 +1376,11 @@ def run_linter(config: Config, options: CLIOptions) -> int:
 
     _emit_results(options, scanner, validation, autofix)
 
-    # When auto_fix is enabled but auto_latest is not, display outdated
-    # actions report (validation errors were fixed, but version updates are
-    # only reported).
+    # Report outdated actions when auto-fix repaired validation errors but
+    # version bumps were only detected, not applied. This is presentation
+    # only: it must not short-circuit exit-code determination, or a real
+    # defect elsewhere in the run would be masked (and the exit code would
+    # depend on --quiet, which also gates this block).
     if (
         autofix.stale_actions_summary
         and not config.auto_latest
@@ -1340,7 +1389,6 @@ def run_linter(config: Config, options: CLIOptions) -> int:
         _display_stale_actions_from_summary(
             autofix.stale_actions_summary, options
         )
-        return 0
 
     return _determine_exit_code(options, validation, autofix)
 

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 import json
 import logging
 from pathlib import Path
+import textwrap
 from typing import Any
 
 from rich.logging import RichHandler
@@ -57,6 +58,7 @@ from .models import (
     LogLevel,
     ValidationError,
     ValidationMethod,
+    ValidationResult,
 )
 from .scanner import WorkflowScanner
 from .system_utils import get_default_workers
@@ -752,7 +754,9 @@ def lint(
         console.print(
             "[red]Error: --verbose and --quiet cannot be used together[/red]"
         )
-        raise typer.Exit(1)
+        # Arguably a usage error (code 2), but this has always exited 1 and
+        # changing it would break callers; see exit_codes.RUNTIME_ERROR.
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     # JSON format implies quiet mode (suppress console output)
     if output_format == "json":
@@ -830,17 +834,17 @@ def lint(
     except ValidationAbortedError as e:
         # These errors should already be handled in run_linter, but catch here as fallback
         logger.error(f"Validation aborted: {e.message}")
-        raise typer.Exit(1) from None
+        raise typer.Exit(exit_codes.RUNTIME_ERROR) from None
     except (ValueError, ConfigurationError) as e:
         logger.error(f"Configuration error: {e}")
         if verbose:
             logger.exception("Full traceback:")
-        raise typer.Exit(1) from None
+        raise typer.Exit(exit_codes.RUNTIME_ERROR) from None
     except Exception as e:
         logger.error(f"Fatal error: {e}")
         if verbose:
             logger.exception("Full traceback:")
-        raise typer.Exit(1) from None
+        raise typer.Exit(exit_codes.RUNTIME_ERROR) from None
 
     raise typer.Exit(exit_code)
 
@@ -1661,6 +1665,12 @@ def _display_stale_actions_from_summary(
     )
 
 
+#: Results whose error message carries actionable remediation that the
+#: action reference alone does not convey. Messages for other results
+#: restate what the reader can already see, so they stay unrendered.
+_REMEDIABLE_RESULTS = frozenset({ValidationResult.ANNOTATED_TAG_SHA})
+
+
 def _print_deduplicated_action_refs(items: list[dict[str, Any]]) -> None:
     """
     Print a list of action references, collapsing duplicates per file.
@@ -1669,17 +1679,26 @@ def _print_deduplicated_action_refs(items: list[dict[str, Any]]) -> None:
     same ``action_ref`` appears more than once for a file, a single entry is
     printed annotated with the number of occurrences and the sorted set of
     distinct source line numbers, instead of repeating the same line N times.
+
+    An optional ``message`` key carrying remediation advice (for example the
+    peeled commit SHA behind an annotated tag object) is printed beneath the
+    reference. Only results whose message tells the reader something the
+    reference itself does not are rendered, so the common cases stay terse.
     """
     # Preserve first-seen order while grouping by action_ref. Use a set so
     # that repeated (ref, line) pairs collapse to a single line number, then
     # render in sorted order for stable output.
     grouped: dict[str, set[int]] = {}
     occurrences: dict[str, int] = {}
+    messages: dict[str, str] = {}
     for item in items:
         ref = item["action_ref"]
         line = item["line"]
         grouped.setdefault(ref, set()).add(line)
         occurrences[ref] = occurrences.get(ref, 0) + 1
+        message = item.get("message")
+        if message and item.get("result") in _REMEDIABLE_RESULTS:
+            messages.setdefault(ref, message)
 
     for ref, line_set in grouped.items():
         count = occurrences[ref]
@@ -1693,6 +1712,18 @@ def _print_deduplicated_action_refs(items: list[dict[str, Any]]) -> None:
                 f"   {ref} [dim](x{count})[/dim] "
                 f"[dim][{label} {line_list}][/dim]"
             )
+        remediation = messages.get(ref)
+        if remediation:
+            # Wrap explicitly with a hanging indent: letting the console
+            # wrap a long single-line message flushes continuations to
+            # column 0, which reads as unrelated output.
+            for text in textwrap.wrap(
+                " ".join(remediation.split()),
+                width=72,
+                initial_indent="     ",
+                subsequent_indent="     ",
+            ):
+                console.print(f"[yellow]{text}[/yellow]")
 
 
 def output_text_results(
@@ -1785,6 +1816,7 @@ def output_text_results(
                 "action_ref": action_ref,
                 "line": error.action_call.line_number,
                 "result": error.result,
+                "message": error.error_message,
             }
 
             # Check if this is a test reference based on comment

--- a/src/gha_workflow_linter/directives.py
+++ b/src/gha_workflow_linter/directives.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Parsing of in-workflow linter-suppression directives.
+
+A repository may declare that a pinned reference is deliberately held at
+an older version, so that the linter does not report it. Two authoring
+forms are supported.
+
+Form 1 -- a directive on the *immediately* preceding line::
+
+    - uses: owner/repo@6db537b3...  # v0.2.1
+      with:
+        # gha-workflow-linter: allow-list-pin-ok
+        config: '@8f4f0cf8...'  # v0.5.1
+
+Form 2 -- an inline keyword appended after the version token in the
+trailing comment::
+
+    config: '@8f4f0cf8...'  # v0.5.1 allow-list-pin-ok
+
+Either form accepts an optional free-text reason, introduced by a ``--``
+token surrounded by whitespace::
+
+    config: '@8f4f0cf8...'  # v0.5.1 allow-list-pin-ok -- upstream is broken
+    # gha-workflow-linter: allow-list-pin-ok -- waiting for a release
+
+The grammar implemented here is::
+
+    <preceding>  ::= <ws>* "#" <ws>* "gha-workflow-linter:" <ws>+ <body>
+    <inline>     ::= <version-token> <ws>+ <body>
+    <body>       ::= <directives> [ <reason> ]
+    <directives> ::= <directive> ( <ws>+ <directive> )*
+    <directive>  ::= "allow-list-pin-ok"
+    <reason>     ::= <ws>+ "--" <ws>+ <free text>
+
+Tokens that are neither the version nor a recognised directive are kept
+verbatim so that a rewrite of the comment (see :func:`render_comment`)
+never discards author content.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+
+__all__ = [
+    "Directive",
+    "ParsedComment",
+    "Suppression",
+    "SuppressionSource",
+    "find_suppression",
+    "parse_preceding_directive",
+    "parse_trailing_comment",
+    "render_comment",
+]
+
+
+class Directive(str, Enum):
+    """A recognised linter-suppression directive."""
+
+    ALLOW_LIST_PIN_OK = "allow-list-pin-ok"
+
+
+class SuppressionSource(str, Enum):
+    """Where a directive was authored."""
+
+    PRECEDING_LINE = "preceding_line"
+    INLINE_COMMENT = "inline_comment"
+
+
+@dataclass(frozen=True)
+class ParsedComment:
+    """A trailing comment split into version, directives and reason."""
+
+    version: str | None
+    directives: frozenset[Directive]
+    reason: str | None
+    unrecognised: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Suppression:
+    """An effective suppression resolved for a single pinned line."""
+
+    directives: frozenset[Directive]
+    source: SuppressionSource
+    reason: str | None
+
+
+#: Marker introducing a preceding-line directive comment. Matched
+#: case-sensitively, at any indentation.
+_PRECEDING_RE = re.compile(
+    r"^\s*#\s*gha-workflow-linter:\s+(?P<body>.*)$",
+)
+
+#: A ``--`` token acting as the reason introducer. Both sides must be
+#: whitespace, so ``--fix`` or ``a--b`` remain ordinary tokens.
+_REASON_RE = re.compile(r"\s--\s")
+
+#: Lookup from directive keyword to enum member.
+_DIRECTIVES_BY_VALUE: dict[str, Directive] = {
+    directive.value: directive for directive in Directive
+}
+
+
+def _strip_comment_markers(comment: str) -> str:
+    """Remove leading ``#`` characters and surrounding whitespace.
+
+    Accepts a comment body with or without its leading marker, so that
+    ``"# v0.5.1"``, ``"## v0.5.1"`` and ``"v0.5.1"`` are equivalent.
+
+    Args:
+        comment: Raw comment text.
+
+    Returns:
+        The comment text with every leading ``#`` and any surrounding
+        whitespace removed.
+    """
+    text = comment.strip()
+    while text.startswith("#"):
+        text = text[1:].strip()
+    return text
+
+
+def _split_reason(text: str) -> tuple[str, str | None]:
+    """Split a body into its token portion and its optional reason.
+
+    Only the first whitespace-delimited ``--`` introduces the reason, so
+    a reason may itself contain ``--``. A trailing ``--`` with no text
+    after it is not a reason introducer and is left as a token.
+
+    Args:
+        text: Comment body with any comment markers already removed.
+
+    Returns:
+        A ``(tokens_text, reason)`` tuple. ``reason`` is ``None`` when
+        the body carries no reason.
+    """
+    match = _REASON_RE.search(text)
+    if match is None:
+        return text, None
+    reason = text[match.end() :].strip()
+    if not reason:
+        return text, None
+    return text[: match.start()], reason
+
+
+def _classify_tokens(
+    tokens: list[str],
+) -> tuple[frozenset[Directive], tuple[str, ...]]:
+    """Partition tokens into recognised directives and everything else.
+
+    Args:
+        tokens: Whitespace-separated tokens from a comment body.
+
+    Returns:
+        A ``(directives, unrecognised)`` tuple. ``unrecognised`` keeps
+        the original order and spelling of the tokens it holds.
+    """
+    directives: set[Directive] = set()
+    unrecognised: list[str] = []
+    for token in tokens:
+        directive = _DIRECTIVES_BY_VALUE.get(token)
+        if directive is not None:
+            directives.add(directive)
+        else:
+            unrecognised.append(token)
+    return frozenset(directives), tuple(unrecognised)
+
+
+def parse_trailing_comment(comment: str | None) -> ParsedComment:
+    """Parse a trailing comment body (with or without a leading ``#``).
+
+    The version token, when present, is always the first token; a
+    comment consisting solely of directives therefore has no version.
+
+    Args:
+        comment: Trailing comment text, or ``None`` when the line
+            carries no comment.
+
+    Returns:
+        The parsed comment. Absent parts are ``None`` or empty.
+    """
+    if comment is None:
+        return ParsedComment(
+            version=None,
+            directives=frozenset(),
+            reason=None,
+            unrecognised=(),
+        )
+
+    text = _strip_comment_markers(comment)
+    body, reason = _split_reason(text)
+    tokens = body.split()
+
+    version: str | None = None
+    if tokens and tokens[0] not in _DIRECTIVES_BY_VALUE:
+        version = tokens[0]
+        tokens = tokens[1:]
+
+    directives, unrecognised = _classify_tokens(tokens)
+    return ParsedComment(
+        version=version,
+        directives=directives,
+        reason=reason,
+        unrecognised=unrecognised,
+    )
+
+
+def parse_preceding_directive(line: str) -> Suppression | None:
+    """Parse a standalone ``# gha-workflow-linter: ...`` comment line.
+
+    Indentation is irrelevant: the comment may sit at any column. The
+    marker is matched case-sensitively.
+
+    Args:
+        line: The complete source line to inspect.
+
+    Returns:
+        The suppression the line declares, or ``None`` when the line is
+        not a directive comment or declares no recognised directive.
+    """
+    match = _PRECEDING_RE.match(line)
+    if match is None:
+        return None
+
+    body, reason = _split_reason(match.group("body").strip())
+    directives, _unrecognised = _classify_tokens(body.split())
+    if not directives:
+        return None
+
+    return Suppression(
+        directives=directives,
+        source=SuppressionSource.PRECEDING_LINE,
+        reason=reason,
+    )
+
+
+def find_suppression(
+    *, comment: str | None, preceding_line: str | None
+) -> Suppression | None:
+    """Resolve the effective suppression for a pinned line.
+
+    The preceding-line form is only honoured when ``preceding_line`` is
+    the *immediately* preceding line. Callers are responsible for
+    supplying it (or ``None`` when the previous line is blank or is not
+    a comment).
+
+    Both forms may be present; that is not an error. The directive sets
+    are unioned, the source is reported as
+    :attr:`SuppressionSource.INLINE_COMMENT`, and the inline reason wins
+    when both carry one.
+
+    Args:
+        comment: Trailing comment on the pinned line, if any.
+        preceding_line: The immediately preceding source line, if any.
+
+    Returns:
+        The effective suppression, or ``None`` when neither form
+        declares a recognised directive.
+    """
+    inline = parse_trailing_comment(comment)
+    preceding = (
+        parse_preceding_directive(preceding_line)
+        if preceding_line is not None
+        else None
+    )
+
+    if inline.directives and preceding is not None:
+        reason = inline.reason
+        if reason is None:
+            reason = preceding.reason
+        return Suppression(
+            directives=inline.directives | preceding.directives,
+            source=SuppressionSource.INLINE_COMMENT,
+            reason=reason,
+        )
+    if inline.directives:
+        return Suppression(
+            directives=inline.directives,
+            source=SuppressionSource.INLINE_COMMENT,
+            reason=inline.reason,
+        )
+    return preceding
+
+
+def render_comment(parsed: ParsedComment, *, version: str | None) -> str:
+    """Re-render a parsed comment with a (possibly new) version token.
+
+    Preserves directives, unrecognised tokens and reason text, so a
+    version bump never loses author content. Parts are emitted in the
+    order ``<version> <directives...> <unrecognised...> -- <reason>``,
+    separated by single spaces, with absent parts omitted. Directives
+    render in alphabetical order of their keyword, for stable output.
+
+    Args:
+        parsed: The previously parsed comment.
+        version: Version token to emit, or ``None`` to emit none.
+
+    Returns:
+        The comment body, without the leading ``#``.
+    """
+    parts: list[str] = []
+    if version is not None:
+        parts.append(version)
+    parts.extend(sorted(directive.value for directive in parsed.directives))
+    parts.extend(parsed.unrecognised)
+    if parsed.reason is not None:
+        parts.append("--")
+        parts.append(parsed.reason)
+    return " ".join(parts)

--- a/src/gha_workflow_linter/exit_codes.py
+++ b/src/gha_workflow_linter/exit_codes.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Centralised process exit codes and the rules that select them.
+
+The linter distinguishes three kinds of finding (see
+:class:`~gha_workflow_linter.models.Category`):
+
+* ``DEFECT`` -- wrong now; always counts towards the exit code.
+* ``CURRENCY`` -- correct but could be newer; advisory unless the caller
+  opts in with a ``--verify-*`` flag.
+* ``INFRASTRUCTURE`` -- the check could not run; never reported as a
+  pass when enforcement was requested.
+
+Exit codes:
+
+===== ========================= ================================================
+Code  Name                      Meaning
+===== ========================= ================================================
+0     SUCCESS                   No failing findings.
+1     DEFECTS_FOUND             Defect findings, or files modified by a fixer.
+2     *reserved*                Click/Typer CLI usage error. Never assigned.
+3     ALLOW_LIST_STALE          ``--verify-allow-list`` and stale pins remain.
+4     ALLOW_LIST_UNRESOLVED     ``--verify-allow-list`` and no latest release.
+5     ACTIONS_OUTDATED          ``--verify-actions`` and outdated calls remain.
+===== ========================= ================================================
+
+Precedence is ``4 > 3 > 5 > 1 > 0``. An infrastructure failure must never
+be reported as a clean-or-stale result, and a condition the caller
+specifically asked about must not be masked by the generic ``1``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SUCCESS: Final = 0
+"""No failing findings."""
+
+DEFECTS_FOUND: Final = 1
+"""Defect findings were reported, or a fixer modified files."""
+
+CLI_USAGE_ERROR: Final = 2
+"""Reserved by Click/Typer for command-line usage errors.
+
+Never assign this value; it is declared so the reservation is explicit
+and testable.
+"""
+
+ALLOW_LIST_STALE: Final = 3
+"""``--verify-allow-list`` was requested and stale pins remain."""
+
+ALLOW_LIST_UNRESOLVED: Final = 4
+"""``--verify-allow-list`` was requested but the latest release of the
+allow-list host repository could not be resolved."""
+
+ACTIONS_OUTDATED: Final = 5
+"""``--verify-actions`` was requested and outdated action calls remain."""
+
+
+# Ordered most to least significant. The first condition that holds
+# decides the exit code.
+_PRECEDENCE: Final[tuple[int, ...]] = (
+    ALLOW_LIST_UNRESOLVED,
+    ALLOW_LIST_STALE,
+    ACTIONS_OUTDATED,
+    DEFECTS_FOUND,
+    SUCCESS,
+)
+
+
+def combine(*codes: int) -> int:
+    """Combine exit codes according to the documented precedence.
+
+    Args:
+        *codes: Exit codes contributed by individual stages. Values of
+            ``SUCCESS`` are ignored unless every code is ``SUCCESS``.
+
+    Returns:
+        The most significant exit code, or ``SUCCESS`` when no code
+        indicates a failure.
+
+    Raises:
+        ValueError: If any code is not a recognised exit code.
+    """
+    unknown = [code for code in codes if code not in _PRECEDENCE]
+    if unknown:
+        raise ValueError(f"Unknown exit code(s): {sorted(set(unknown))}")
+
+    for candidate in _PRECEDENCE:
+        if candidate in codes:
+            return candidate
+    return SUCCESS
+
+
+def describe(code: int) -> str:
+    """Return a short human-readable description of an exit code.
+
+    Args:
+        code: The exit code to describe.
+
+    Returns:
+        A one-line description, or a generic string for unknown codes.
+    """
+    return _DESCRIPTIONS.get(code, f"Unknown exit code {code}")
+
+
+_DESCRIPTIONS: Final[dict[int, str]] = {
+    SUCCESS: "Success",
+    DEFECTS_FOUND: "Defects found, or files modified",
+    CLI_USAGE_ERROR: "Command-line usage error",
+    ALLOW_LIST_STALE: "Stale allow-list pins",
+    ALLOW_LIST_UNRESOLVED: "Allow-list latest release unresolved",
+    ACTIONS_OUTDATED: "Outdated action calls",
+}
+
+
+__all__ = [
+    "ACTIONS_OUTDATED",
+    "ALLOW_LIST_STALE",
+    "ALLOW_LIST_UNRESOLVED",
+    "CLI_USAGE_ERROR",
+    "DEFECTS_FOUND",
+    "SUCCESS",
+    "combine",
+    "describe",
+]

--- a/src/gha_workflow_linter/exit_codes.py
+++ b/src/gha_workflow_linter/exit_codes.py
@@ -40,6 +40,18 @@ SUCCESS: Final = 0
 DEFECTS_FOUND: Final = 1
 """Defect findings were reported, or a fixer modified files."""
 
+RUNTIME_ERROR: Final = DEFECTS_FOUND
+"""The run itself failed: bad configuration, aborted validation, or an
+unexpected exception.
+
+Shares the value of :data:`DEFECTS_FOUND` because the tool has always
+exited ``1`` for both conditions. Separating them would break callers
+that test for ``1``, so the split is deferred to a future major release.
+The distinct name exists so call sites state which condition they mean,
+and so the eventual split is a one-line change here rather than an audit
+of every ``raise``.
+"""
+
 CLI_USAGE_ERROR: Final = 2
 """Reserved by Click/Typer for command-line usage errors.
 
@@ -121,6 +133,7 @@ __all__ = [
     "ALLOW_LIST_UNRESOLVED",
     "CLI_USAGE_ERROR",
     "DEFECTS_FOUND",
+    "RUNTIME_ERROR",
     "SUCCESS",
     "combine",
     "describe",

--- a/src/gha_workflow_linter/file_edit.py
+++ b/src/gha_workflow_linter/file_edit.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Atomic, byte-faithful replacement of individual lines in a text file.
+
+Rewriting a user's workflow file in place is deceptively easy to get
+wrong. The naive approach -- read the file with ``readlines()``, mutate a
+few entries, then reopen the same path with ``open(path, "w")`` -- has
+three distinct defects:
+
+1. It is not atomic. Truncating the original before the replacement
+   content is durable means an interrupted process (a crash, a signal, a
+   full filesystem) leaves the file empty or half written.
+2. It loses line endings. Text mode enables universal newlines, so a
+   CRLF file is read as if it were LF and written back as LF, producing a
+   diff on every line of the file.
+3. It invents a trailing newline. Appending ``"\\n"`` to every rewritten
+   line adds a final newline to a file that deliberately lacked one.
+
+:func:`replace_lines` is the shared, correct alternative. It preserves
+each line's own terminator, the file's trailing-newline state, a UTF-8
+BOM, and the original file mode, and it publishes the result with a
+single :func:`os.replace` so a reader sees either the old file or the new
+one and never a partial write.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+import os
+import shutil
+import tempfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+__all__ = ["LineChange", "replace_lines"]
+
+# UTF-8 byte order mark. Some editors (and most Windows tooling) prefix
+# files with it; ``utf-8-sig`` strips it on read and re-emits it on write,
+# keeping it out of the line content reported back to callers.
+_UTF8_BOM = b"\xef\xbb\xbf"
+
+# Ordered longest-first so ``\r\n`` is never mistaken for a bare ``\r``.
+_LINE_TERMINATORS: tuple[str, ...] = ("\r\n", "\n", "\r")
+
+# Characters that Python's universal newline handling treats as line
+# boundaries, and which therefore may not appear inside a replacement.
+_NEWLINE_CHARACTERS: tuple[str, ...] = ("\n", "\r")
+
+
+@dataclass(frozen=True)
+class LineChange:
+    """A single line rewritten by :func:`replace_lines`.
+
+    Attributes:
+        line_number: 1-based number of the replaced line.
+        old_line: Previous content of the line, without its terminator.
+        new_line: Replacement content, without its terminator.
+    """
+
+    line_number: int
+    old_line: str
+    new_line: str
+
+
+def replace_lines(
+    path: Path,
+    replacements: Mapping[int, str],
+) -> list[LineChange]:
+    """Rewrite specific lines atomically, preserving each terminator.
+
+    The file is read whole, the requested lines are substituted, and the
+    result is written to a temporary file in the same directory before
+    being moved over the original with :func:`os.replace`. Should any
+    step fail, the temporary file is removed and the original is left
+    byte-for-byte unchanged.
+
+    Every replaced line keeps the terminator it already had (``\\r\\n``,
+    ``\\n``, ``\\r``, or none at all for a final line without one), so a
+    CRLF file stays CRLF, a mixed-ending file survives intact, and a file
+    without a trailing newline does not gain one.
+
+    Args:
+        path: File to rewrite.
+        replacements: Mapping of 1-based line number to the replacement
+            content for that line, excluding any line terminator. An
+            empty mapping is a no-op: the file is not opened or touched.
+
+    Returns:
+        One :class:`LineChange` per entry in ``replacements``, sorted by
+        line number, with terminators excluded from both the old and the
+        new content. A replacement whose content matches the existing
+        line is still reported.
+
+    Raises:
+        ValueError: If a replacement contains an embedded line
+            terminator, or if a line number is below 1 or beyond the last
+            line of the file.
+        OSError: If the file cannot be read, or the replacement cannot be
+            written or moved into place.
+    """
+    if not replacements:
+        return []
+
+    _validate_replacement_content(replacements)
+
+    encoding = _detect_encoding(path)
+    with open(path, encoding=encoding, newline="") as handle:
+        lines = handle.readlines()
+
+    _validate_line_numbers(replacements, len(lines))
+
+    changes: list[LineChange] = []
+    for line_number in sorted(replacements):
+        old_line, terminator = _split_terminator(lines[line_number - 1])
+        new_line = replacements[line_number]
+        lines[line_number - 1] = new_line + terminator
+        changes.append(
+            LineChange(
+                line_number=line_number,
+                old_line=old_line,
+                new_line=new_line,
+            )
+        )
+
+    _write_atomically(path, lines, encoding)
+    return changes
+
+
+def _validate_replacement_content(replacements: Mapping[int, str]) -> None:
+    """Reject replacements that span more than a single line.
+
+    Args:
+        replacements: Mapping of 1-based line number to replacement
+            content.
+
+    Raises:
+        ValueError: If any replacement contains ``\\n`` or ``\\r``.
+    """
+    for line_number in sorted(replacements):
+        new_line = replacements[line_number]
+        if any(char in new_line for char in _NEWLINE_CHARACTERS):
+            raise ValueError(
+                f"Replacement for line {line_number} contains an embedded "
+                "line terminator; each replacement must be exactly one line"
+            )
+
+
+def _validate_line_numbers(
+    replacements: Mapping[int, str],
+    line_count: int,
+) -> None:
+    """Check that every requested line exists in the file.
+
+    Args:
+        replacements: Mapping of 1-based line number to replacement
+            content.
+        line_count: Number of lines the file actually contains.
+
+    Raises:
+        ValueError: If a line number is below 1 or above ``line_count``.
+    """
+    for line_number in sorted(replacements):
+        if line_number < 1 or line_number > line_count:
+            raise ValueError(
+                f"Line number {line_number} is out of range for a file "
+                f"with {line_count} line(s)"
+            )
+
+
+def _detect_encoding(path: Path) -> str:
+    """Return the codec that round-trips the file's BOM state.
+
+    Args:
+        path: File to inspect.
+
+    Returns:
+        ``"utf-8-sig"`` when the file starts with a UTF-8 byte order
+        mark, otherwise ``"utf-8"``. Both read and write use the returned
+        codec, so a BOM is preserved and one is never introduced.
+
+    Raises:
+        OSError: If the file cannot be opened or read.
+    """
+    with open(path, "rb") as handle:
+        prefix = handle.read(len(_UTF8_BOM))
+    return "utf-8-sig" if prefix == _UTF8_BOM else "utf-8"
+
+
+def _split_terminator(line: str) -> tuple[str, str]:
+    """Separate a line's content from its terminator.
+
+    Args:
+        line: Line as read with ``newline=""``, so its terminator (if
+            any) is present and untranslated.
+
+    Returns:
+        A ``(content, terminator)`` tuple. ``terminator`` is the empty
+        string for a final line that ends without one.
+    """
+    for terminator in _LINE_TERMINATORS:
+        if line.endswith(terminator):
+            return line[: -len(terminator)], terminator
+    return line, ""
+
+
+def _write_atomically(
+    path: Path,
+    lines: list[str],
+    encoding: str,
+) -> None:
+    """Publish new file content with a single atomic rename.
+
+    The temporary file is created in the same directory as ``path`` so
+    that :func:`os.replace` stays within one filesystem and is therefore
+    atomic. The original's permission bits are copied onto the temporary
+    file first, because replacing the path with a freshly created
+    ``mkstemp`` file would otherwise reset the mode to ``0o600``.
+
+    Args:
+        path: File to overwrite.
+        lines: Complete file content, each element carrying its own
+            terminator.
+        encoding: Codec to write with, as chosen by
+            :func:`_detect_encoding`.
+
+    Raises:
+        OSError: If the temporary file cannot be written, have its mode
+            copied, or be moved into place. The temporary file is removed
+            and ``path`` is left unchanged.
+    """
+    descriptor, temporary_path = tempfile.mkstemp(
+        dir=os.fspath(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(
+            descriptor, "w", encoding=encoding, newline=""
+        ) as handle:
+            handle.writelines(lines)
+            handle.flush()
+            os.fsync(handle.fileno())
+        shutil.copymode(path, temporary_path)
+        os.replace(temporary_path, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(temporary_path)
+        raise

--- a/src/gha_workflow_linter/git_refs.py
+++ b/src/gha_workflow_linter/git_refs.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Parsing of ``git ls-remote`` output, including annotated tag peeling.
+
+``git ls-remote --tags`` advertises two lines for an annotated tag: an
+unpeeled line carrying the SHA of the *tag object*, and a ``^{}`` peeled
+line carrying the SHA of the *commit* that tag points at. For example::
+
+    8f363565...  refs/tags/v0.12.2      # the tag object
+    bf6642f6...  refs/tags/v0.12.2^{}   # the commit
+
+GitHub Actions cannot check out a tag object, so a workflow pinned to the
+unpeeled SHA fails at run time. Treating both SHAs as interchangeable
+therefore produces a false pass on a broken reference, which is why this
+module keeps them apart.
+
+The helpers here are pure parsing plus thin ``git`` invocations, kept
+separate from :mod:`gha_workflow_linter.git_validator` so both the
+validation path and the version-resolution path share one definition of
+how refs are read.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import subprocess
+from typing import TYPE_CHECKING
+
+from .exceptions import GitError
+
+if TYPE_CHECKING:
+    from .models import GitConfig
+
+logger = logging.getLogger(__name__)
+
+#: Prefix every tag reference carries in ``git ls-remote`` output.
+_TAG_REF_PREFIX = "refs/tags/"
+
+#: Suffix Git appends to the *peeled* line it emits for an annotated tag.
+_PEELED_TAG_SUFFIX = "^{}"
+
+
+@dataclasses.dataclass(frozen=True)
+class AnnotatedTagPeel:
+    """The tag and commit behind an annotated tag object.
+
+    ``git ls-remote --tags`` emits two lines for an annotated tag: an
+    unpeeled line carrying the SHA of the *tag object*, and a ``^{}``
+    peeled line carrying the SHA of the *commit* the tag points at.
+    GitHub Actions cannot check out a tag object, so a workflow pinned to
+    the tag-object SHA fails at run time. This record carries the
+    information needed to tell a user what to use instead.
+
+    Attributes:
+        tag: Tag name, without the ``refs/tags/`` prefix or ``^{}`` suffix.
+        commit_sha: SHA of the commit the annotated tag peels to.
+    """
+
+    tag: str
+    commit_sha: str
+
+
+@dataclasses.dataclass(frozen=True)
+class RemoteRefShas:
+    """Remote ref SHAs split by the kind of object they name.
+
+    Attributes:
+        commit_shas: SHAs naming real commits; these are checkout-able.
+        tag_objects: Mapping of annotated tag-object SHA to the tag name
+            and peeled commit SHA behind it. Keys are disjoint from
+            ``commit_shas``.
+    """
+
+    commit_shas: frozenset[str]
+    tag_objects: dict[str, AnnotatedTagPeel]
+
+
+def _parse_ls_remote_lines(stdout: str) -> list[tuple[str, str]]:
+    """
+    Parse ``git ls-remote`` output into ``(sha, ref)`` pairs.
+
+    Malformed lines (blank, or not exactly two tab-separated columns) are
+    skipped rather than raising, so partial or unexpected output degrades
+    to fewer refs instead of an error.
+
+    Args:
+        stdout: Raw standard output of a ``git ls-remote`` invocation
+
+    Returns:
+        List of ``(sha, ref)`` pairs, in output order. The ``ref`` retains
+        any ``^{}`` peel suffix.
+    """
+    pairs: list[tuple[str, str]] = []
+
+    for line in stdout.strip().split("\n"):
+        if not line:
+            continue
+        # Format: "sha\tref_name"
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        sha = parts[0].strip()
+        ref = parts[1].strip()
+        if not sha or not ref:
+            continue
+        pairs.append((sha, ref))
+
+    return pairs
+
+
+def _split_tag_ref_shas(
+    pairs: list[tuple[str, str]],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """
+    Split ``ls-remote`` pairs into unpeeled and peeled tag SHA maps.
+
+    Non-tag refs (e.g. ``refs/heads/...``) are ignored.
+
+    Args:
+        pairs: ``(sha, ref)`` pairs as returned by
+            :func:`_parse_ls_remote_lines`
+
+    Returns:
+        Two-tuple of ``(unpeeled, peeled)`` dictionaries, each mapping a
+        tag name to the SHA on the corresponding line. For an annotated
+        tag the unpeeled SHA names the tag object and the peeled SHA names
+        the commit; a lightweight tag has an unpeeled entry only.
+    """
+    unpeeled: dict[str, str] = {}
+    peeled: dict[str, str] = {}
+
+    for sha, ref in pairs:
+        if not ref.startswith(_TAG_REF_PREFIX):
+            continue
+        tag = ref[len(_TAG_REF_PREFIX) :]
+        if tag.endswith(_PEELED_TAG_SUFFIX):
+            tag = tag[: -len(_PEELED_TAG_SUFFIX)]
+            if tag:
+                peeled[tag] = sha
+        elif tag:
+            unpeeled[tag] = sha
+
+    return unpeeled, peeled
+
+
+def _annotated_tag_peels(
+    unpeeled: dict[str, str], peeled: dict[str, str]
+) -> dict[str, AnnotatedTagPeel]:
+    """
+    Identify annotated tags from the unpeeled/peeled SHA maps.
+
+    A tag is annotated when ``ls-remote`` advertises both an unpeeled line
+    and a ``^{}`` peeled line whose SHAs differ; the unpeeled SHA is then
+    the tag object. A lightweight tag has no peeled line at all.
+
+    Args:
+        unpeeled: Mapping of tag name to unpeeled SHA
+        peeled: Mapping of tag name to peeled (``^{}``) SHA
+
+    Returns:
+        Dictionary mapping tag-object SHA to its :class:`AnnotatedTagPeel`
+    """
+    peels: dict[str, AnnotatedTagPeel] = {}
+
+    for tag, commit_sha in peeled.items():
+        tag_object_sha = unpeeled.get(tag)
+        if tag_object_sha is not None and tag_object_sha != commit_sha:
+            peels[tag_object_sha] = AnnotatedTagPeel(
+                tag=tag, commit_sha=commit_sha
+            )
+
+    return peels
+
+
+def _run_ls_remote_tags(url: str, config: GitConfig) -> list[tuple[str, str]]:
+    """
+    Run ``git ls-remote --tags`` and return its parsed lines.
+
+    Args:
+        url: Git repository URL
+        config: Git configuration
+
+    Returns:
+        List of ``(sha, ref)`` pairs; ``ref`` retains any ``^{}`` suffix
+
+    Raises:
+        GitError: If operation fails
+    """
+    cmd = ["git", "ls-remote", "--tags", url]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=config.timeout_seconds,
+            check=True,
+        )
+
+        return _parse_ls_remote_lines(result.stdout)
+
+    except subprocess.TimeoutExpired:
+        raise GitError(f"Git ls-remote (tags) timed out for {url}") from None
+    except subprocess.CalledProcessError as e:
+        raise GitError(
+            f"Git ls-remote (tags) failed for {url}: {e.stderr}"
+        ) from e
+    except Exception as e:
+        raise GitError(f"Git ls-remote (tags) failed for {url}: {e}") from e
+
+
+def get_remote_tag_shas(url: str, config: GitConfig) -> dict[str, str]:
+    """
+    Map tag name to the commit SHA it ultimately points at.
+
+    The peeled ``^{}`` line is preferred over the unpeeled one, so an
+    annotated tag resolves to its commit rather than to the tag object. A
+    lightweight tag has only one line and resolves to that SHA.
+
+    Args:
+        url: Git repository URL
+        config: Git configuration
+
+    Returns:
+        Dictionary mapping tag name to commit SHA
+
+    Raises:
+        GitError: If operation fails
+    """
+    unpeeled, peeled = _split_tag_ref_shas(_run_ls_remote_tags(url, config))
+
+    # Peeled entries win: for an annotated tag they name the commit.
+    return {**unpeeled, **peeled}
+
+
+def get_annotated_tag_peels(
+    url: str, config: GitConfig
+) -> dict[str, AnnotatedTagPeel]:
+    """
+    Map tag-object SHA to its tag name and peeled commit SHA.
+
+    This is the lookup behind the ``ANNOTATED_TAG_SHA`` remediation
+    message: given the SHA a workflow is pinned to, it yields both the tag
+    that SHA belongs to and the commit SHA to use instead.
+
+    Args:
+        url: Git repository URL
+        config: Git configuration
+
+    Returns:
+        Dictionary mapping tag-object SHA to :class:`AnnotatedTagPeel`.
+        Lightweight tags never appear, since they have no tag object.
+
+    Raises:
+        GitError: If operation fails
+    """
+    unpeeled, peeled = _split_tag_ref_shas(_run_ls_remote_tags(url, config))
+
+    return _annotated_tag_peels(unpeeled, peeled)
+
+
+def get_remote_tag_object_shas(url: str, config: GitConfig) -> dict[str, str]:
+    """
+    Map tag-object SHA to tag name, for annotated tags only.
+
+    A tag is annotated when ls-remote emits both an unpeeled line and a
+    ``^{}`` peeled line whose SHAs differ.
+
+    Args:
+        url: Git repository URL
+        config: Git configuration
+
+    Returns:
+        Dictionary mapping tag-object SHA to tag name
+
+    Raises:
+        GitError: If operation fails
+    """
+    return {
+        tag_object_sha: peel.tag
+        for tag_object_sha, peel in get_annotated_tag_peels(url, config).items()
+    }
+
+
+def get_remote_ref_shas(url: str, config: GitConfig) -> RemoteRefShas:
+    """
+    Get remote ref SHAs, split into commits and annotated tag objects.
+
+    ``git ls-remote --heads --tags`` advertises a tag object *and* the
+    commit it peels to for every annotated tag. Collecting both into one
+    set makes a tag-object SHA look like a valid commit, so they are kept
+    apart here.
+
+    Args:
+        url: Git repository URL
+        config: Git configuration
+
+    Returns:
+        :class:`RemoteRefShas` with disjoint commit and tag-object SHAs
+
+    Raises:
+        GitError: If operation fails
+    """
+    cmd = ["git", "ls-remote", "--heads", "--tags", url]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=config.timeout_seconds,
+            check=True,
+        )
+
+        pairs = _parse_ls_remote_lines(result.stdout)
+        unpeeled, peeled = _split_tag_ref_shas(pairs)
+        tag_objects = _annotated_tag_peels(unpeeled, peeled)
+        commit_shas = frozenset(sha for sha, _ in pairs) - set(tag_objects)
+
+        return RemoteRefShas(commit_shas=commit_shas, tag_objects=tag_objects)
+
+    except subprocess.TimeoutExpired:
+        raise GitError(f"Git ls-remote timed out for {url}") from None
+    except subprocess.CalledProcessError as e:
+        raise GitError(f"Git ls-remote failed for {url}: {e.stderr}") from e
+    except Exception as e:
+        raise GitError(f"Git ls-remote failed for {url}: {e}") from e
+
+
+def get_all_remote_refs(url: str, config: GitConfig) -> set[str]:
+    """
+    Get all SHAs from remote refs (heads and tags).
+
+    Note the returned set includes annotated tag-object SHAs alongside
+    commit SHAs, which is why it is unsafe for deciding whether a pinned
+    SHA is checkout-able; use :func:`get_remote_ref_shas` for that.
+
+    Args:
+        url: Git repository URL
+        config: Git configuration
+
+    Returns:
+        Set of SHAs
+
+    Raises:
+        GitError: If operation fails
+    """
+    remote_refs = get_remote_ref_shas(url, config)
+
+    return set(remote_refs.commit_shas) | set(remote_refs.tag_objects)
+
+
+__all__ = [
+    "AnnotatedTagPeel",
+    "RemoteRefShas",
+    "get_all_remote_refs",
+    "get_annotated_tag_peels",
+    "get_remote_ref_shas",
+    "get_remote_tag_object_shas",
+    "get_remote_tag_shas",
+]

--- a/src/gha_workflow_linter/git_validator.py
+++ b/src/gha_workflow_linter/git_validator.py
@@ -16,6 +16,9 @@ from typing import TYPE_CHECKING
 from .exceptions import (
     GitError,
 )
+from .git_refs import (
+    get_remote_ref_shas,
+)
 from .models import APICallStats, GitConfig, ReferenceType, ValidationResult
 from .paths import action_subpath, action_subpath_candidates
 from .paths import base_repository as _shared_base_repository
@@ -510,6 +513,12 @@ def _validate_commit_shas_git(
     """
     Validate commit SHAs by checking if they exist in remote refs.
 
+    A SHA that names an annotated *tag object* rather than a commit is
+    reported as ``ANNOTATED_TAG_SHA``: ``git ls-remote`` advertises it, but
+    GitHub Actions cannot check it out, so treating it as valid is a false
+    pass. Use :func:`_get_annotated_tag_peels` to recover the commit SHA to
+    recommend in its place.
+
     Args:
         url: Git repository URL
         commit_shas: List of commit SHAs to validate
@@ -521,11 +530,14 @@ def _validate_commit_shas_git(
     results = {}
 
     try:
-        # Get all remote refs (heads and tags) to find commit SHAs
-        remote_refs = _get_all_remote_refs(url, config)
+        # Get all remote refs (heads and tags), keeping annotated tag
+        # objects distinguishable from the commits they peel to.
+        remote_refs = get_remote_ref_shas(url, config)
 
         for sha in commit_shas:
-            if sha in remote_refs:
+            if sha in remote_refs.tag_objects:
+                results[sha] = ValidationResult.ANNOTATED_TAG_SHA
+            elif sha in remote_refs.commit_shas:
                 results[sha] = ValidationResult.VALID
             else:
                 results[sha] = ValidationResult.INVALID_REFERENCE
@@ -726,52 +738,6 @@ def _commit_exists_in_repo(
 
     except Exception:
         return False
-
-
-def _get_all_remote_refs(url: str, config: GitConfig) -> set[str]:
-    """
-    Get all commit SHAs from remote refs (heads and tags).
-
-    Args:
-        url: Git repository URL
-        config: Git configuration
-
-    Returns:
-        Set of commit SHAs
-
-    Raises:
-        GitError: If operation fails
-    """
-    import subprocess
-
-    cmd = ["git", "ls-remote", "--heads", "--tags", url]
-
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=config.timeout_seconds,
-            check=True,
-        )
-
-        shas = set()
-        for line in result.stdout.strip().split("\n"):
-            if line:
-                # Format: "commit_sha\tref_name"
-                parts = line.split("\t")
-                if len(parts) == 2:
-                    commit_sha = parts[0]
-                    shas.add(commit_sha)
-
-        return shas
-
-    except subprocess.TimeoutExpired:
-        raise GitError(f"Git ls-remote timed out for {url}") from None
-    except subprocess.CalledProcessError as e:
-        raise GitError(f"Git ls-remote failed for {url}: {e.stderr}") from e
-    except Exception as e:
-        raise GitError(f"Git ls-remote failed for {url}: {e}") from e
 
 
 def _get_remote_branches(url: str, config: GitConfig) -> set[str]:

--- a/src/gha_workflow_linter/git_validator.py
+++ b/src/gha_workflow_linter/git_validator.py
@@ -11,12 +11,14 @@ import logging
 import os
 import re
 import tempfile
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 from .exceptions import (
     GitError,
 )
 from .git_refs import (
+    AnnotatedTagPeel,
     get_remote_ref_shas,
 )
 from .models import APICallStats, GitConfig, ReferenceType, ValidationResult
@@ -24,6 +26,7 @@ from .paths import action_subpath, action_subpath_candidates
 from .paths import base_repository as _shared_base_repository
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -60,6 +63,7 @@ class GitValidationClient:
         self.config = config
         self.logger = logging.getLogger(__name__)
         self.api_stats = APICallStats()
+        self._annotated_tag_peels: dict[tuple[str, str], AnnotatedTagPeel] = {}
 
         # Determine optimal worker count
         if config.max_parallel_operations:
@@ -72,6 +76,25 @@ class GitValidationClient:
         self.logger.debug(
             f"Git client initialized with {self._max_workers} max workers"
         )
+
+    @property
+    def annotated_tag_peels(
+        self,
+    ) -> Mapping[tuple[str, str], AnnotatedTagPeel]:
+        """Annotated tag peels discovered while validating references.
+
+        ``validate_references_batch`` already runs ``git ls-remote``, which
+        advertises both the tag object and the commit it peels to, so the
+        remediation for an ``ANNOTATED_TAG_SHA`` verdict is recorded as a
+        side effect of that batch rather than costing a second network
+        round trip. Entries accumulate over the client's lifetime.
+
+        Returns:
+            Read-only mapping of ``(repository, reference)`` to the peel
+            behind that reference. Only references reported as
+            ``ANNOTATED_TAG_SHA`` are present.
+        """
+        return MappingProxyType(self._annotated_tag_peels)
 
     async def validate_repositories_batch(
         self, repositories: list[str]
@@ -160,6 +183,10 @@ class GitValidationClient:
 
         Returns:
             Dictionary mapping (repository, reference) tuples to validation results
+
+        Side effects:
+            Records any annotated tag peels discovered by the underlying
+            ``ls-remote`` calls; see :attr:`annotated_tag_peels`.
         """
         if not repo_refs:
             return {}
@@ -201,7 +228,7 @@ class GitValidationClient:
                 self.logger.error(
                     f"Unexpected error in reference validation: {e}"
                 )
-                validation_results = [{}] * len(futures)
+                validation_results = [({}, {})] * len(futures)
 
             for (repo, refs), repo_results in zip(
                 repo_ref_list, validation_results, strict=True
@@ -214,12 +241,16 @@ class GitValidationClient:
                     for ref in refs:
                         results[(repo, ref)] = ValidationResult.NETWORK_ERROR
                         self.api_stats.increment_failed_call()
-                elif isinstance(repo_results, dict):
+                elif isinstance(repo_results, tuple):
                     # Map results back to the expected format
+                    ref_results, peels = repo_results
                     for ref in refs:
-                        results[(repo, ref)] = repo_results.get(
+                        results[(repo, ref)] = ref_results.get(
                             ref, ValidationResult.INVALID_REFERENCE
                         )
+                        peel = peels.get(ref)
+                        if peel is not None:
+                            self._annotated_tag_peels[(repo, ref)] = peel
                         self.api_stats.increment_git()
 
                     self.api_stats.git_clone_operations += 1
@@ -391,7 +422,7 @@ def _validate_repository_exists(
 
 def _validate_repository_references(
     repository: str, references: list[str], config: GitConfig
-) -> dict[str, ValidationResult]:
+) -> tuple[dict[str, ValidationResult], dict[str, AnnotatedTagPeel]]:
     """
     Validate multiple references for a single repository.
 
@@ -403,9 +434,12 @@ def _validate_repository_references(
         config: Git configuration
 
     Returns:
-        Dictionary mapping references to validation results
+        Tuple of (results, peels): results maps each reference to its
+        validation result, and peels maps each reference reported as
+        ``ANNOTATED_TAG_SHA`` to the tag and commit behind it.
     """
     results = {}
+    peels: dict[str, AnnotatedTagPeel] = {}
 
     # Try both HTTPS and SSH URLs
     # Strip any action subpath (e.g. anchore/scan-action/download-grype)
@@ -435,10 +469,11 @@ def _validate_repository_references(
     for url in [https_url, ssh_url]:
         try:
             if commit_shas:
-                sha_results = _validate_commit_shas_git(
+                sha_results, sha_peels = _validate_commit_shas_with_peels(
                     url, commit_shas, config
                 )
                 results.update(sha_results)
+                peels.update(sha_peels)
 
             if branches:
                 branch_results = _validate_branches_git(url, branches, config)
@@ -468,7 +503,7 @@ def _validate_repository_references(
         if ref not in results:
             results[ref] = ValidationResult.INVALID_REFERENCE
 
-    return results
+    return results, peels
 
 
 def _run_git_ls_remote(url: str, config: GitConfig) -> bool:
@@ -516,8 +551,8 @@ def _validate_commit_shas_git(
     A SHA that names an annotated *tag object* rather than a commit is
     reported as ``ANNOTATED_TAG_SHA``: ``git ls-remote`` advertises it, but
     GitHub Actions cannot check it out, so treating it as valid is a false
-    pass. Use :func:`_get_annotated_tag_peels` to recover the commit SHA to
-    recommend in its place.
+    pass. Use :func:`_validate_commit_shas_with_peels` when the commit SHA
+    to recommend in its place is needed too.
 
     Args:
         url: Git repository URL
@@ -527,7 +562,32 @@ def _validate_commit_shas_git(
     Returns:
         Dictionary mapping commit SHAs to validation results
     """
+    return _validate_commit_shas_with_peels(url, commit_shas, config)[0]
+
+
+def _validate_commit_shas_with_peels(
+    url: str, commit_shas: list[str], config: GitConfig
+) -> tuple[dict[str, ValidationResult], dict[str, AnnotatedTagPeel]]:
+    """
+    Validate commit SHAs, keeping the peel behind any tag-object SHA.
+
+    The single ``ls-remote`` this performs already carries the peeled
+    commit for every annotated tag, so the remediation for an
+    ``ANNOTATED_TAG_SHA`` verdict is returned alongside the verdict rather
+    than re-fetched later.
+
+    Args:
+        url: Git repository URL
+        commit_shas: List of commit SHAs to validate
+        config: Git configuration
+
+    Returns:
+        Tuple of (results, peels): results maps each SHA to its validation
+        result, and peels maps each tag-object SHA to the tag name and
+        commit SHA behind it.
+    """
     results = {}
+    peels: dict[str, AnnotatedTagPeel] = {}
 
     try:
         # Get all remote refs (heads and tags), keeping annotated tag
@@ -535,8 +595,10 @@ def _validate_commit_shas_git(
         remote_refs = get_remote_ref_shas(url, config)
 
         for sha in commit_shas:
-            if sha in remote_refs.tag_objects:
+            peel = remote_refs.tag_objects.get(sha)
+            if peel is not None:
                 results[sha] = ValidationResult.ANNOTATED_TAG_SHA
+                peels[sha] = peel
             elif sha in remote_refs.commit_shas:
                 results[sha] = ValidationResult.VALID
             else:
@@ -547,8 +609,9 @@ def _validate_commit_shas_git(
         # Mark all SHAs as invalid
         for sha in commit_shas:
             results[sha] = ValidationResult.INVALID_REFERENCE
+        peels.clear()
 
-    return results
+    return results, peels
 
 
 def _validate_branches_git(

--- a/src/gha_workflow_linter/github_api.py
+++ b/src/gha_workflow_linter/github_api.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 import time
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import httpx
@@ -21,6 +22,7 @@ from .exceptions import (
     RateLimitError,
     TemporaryAPIError,
 )
+from .git_refs import AnnotatedTagPeel
 from .models import (
     APICallStats,
     GitHubAPIConfig,
@@ -69,11 +71,35 @@ class GitHubGraphQLClient:
         # Cache for subdirectory-action subpath existence, keyed by
         # (full action identifier including subpath, ref).
         self._subpath_cache: dict[tuple[str, str], bool] = {}
+        # Peels behind any reference resolved to an annotated tag object,
+        # keyed by (repo_key, reference); see annotated_tag_peels.
+        self._annotated_tag_peels: dict[tuple[str, str], AnnotatedTagPeel] = {}
 
         # Parallel workers for concurrent operations (set by validator)
         self.parallel_workers: int = (
             get_default_workers()
         )  # Default, will be overridden
+
+    @property
+    def annotated_tag_peels(
+        self,
+    ) -> Mapping[tuple[str, str], AnnotatedTagPeel]:
+        """Annotated tag peels discovered while validating references.
+
+        A pinned SHA that resolves to a ``Tag`` object rather than a
+        ``Commit`` is not checkout-able by GitHub Actions. The commit-SHA
+        query peels such objects in the same request, so the remediation is
+        recorded here as a side effect instead of costing a second query.
+        Mirrors :attr:`GitValidationClient.annotated_tag_peels` so both
+        backends report the same verdict with the same context. Entries
+        accumulate over the client's lifetime.
+
+        Returns:
+            Read-only mapping of ``(repo_key, reference)`` to the peel
+            behind that reference. Only references naming a tag object are
+            present.
+        """
+        return MappingProxyType(self._annotated_tag_peels)
 
     async def __aenter__(self) -> GitHubGraphQLClient:
         """Async context manager entry."""
@@ -471,6 +497,10 @@ class GitHubGraphQLClient:
 
         Returns:
             Dictionary mapping references to validation results
+
+        Side effects:
+            Records any reference that resolves to an annotated tag object;
+            see :attr:`annotated_tag_peels`.
         """
         try:
             owner, name = repo_key.split("/", 1)
@@ -494,10 +524,14 @@ class GitHubGraphQLClient:
         results = {}
 
         if commit_shas:
-            sha_results = await self._validate_commit_shas_graphql(
+            sha_results, peels = await self._resolve_commit_shas_graphql(
                 owner, base_name, commit_shas
             )
             results.update(sha_results)
+            # Key peels by the caller's repo_key, which may carry an action
+            # subpath that base_name has stripped.
+            for sha, peel in peels.items():
+                self._annotated_tag_peels[(repo_key, sha)] = peel
 
         if branch_tag_names:
             ref_results = await self._validate_branch_tag_names_graphql(
@@ -521,6 +555,34 @@ class GitHubGraphQLClient:
         Returns:
             Dictionary mapping SHAs to validation results
         """
+        results, _peels = await self._resolve_commit_shas_graphql(
+            owner, name, shas
+        )
+        return results
+
+    async def _resolve_commit_shas_graphql(
+        self, owner: str, name: str, shas: list[str]
+    ) -> tuple[dict[str, bool], dict[str, AnnotatedTagPeel]]:
+        """
+        Resolve commit SHAs, distinguishing commits from tag objects.
+
+        ``object(oid: ...)`` resolves any Git object, so a SHA naming an
+        annotated tag object resolves successfully but is not checkout-able
+        by GitHub Actions. Narrowing on ``Tag`` as well as ``Commit`` peels
+        it in the same request, which lets this backend agree with the Git
+        backend on both the verdict (invalid) and the remediation (use the
+        peeled commit).
+
+        Args:
+            owner: Repository owner
+            name: Repository name
+            shas: List of commit SHAs
+
+        Returns:
+            Tuple of (results, peels): results maps each SHA to whether it
+            names a real commit, and peels maps each SHA naming an
+            annotated tag object to the tag and commit behind it.
+        """
         query_parts = []
         aliases = {}
 
@@ -530,8 +592,15 @@ class GitHubGraphQLClient:
 
             query_parts.append(f"""
                 {alias}: object(oid: "{sha}") {{
+                    __typename
                     ... on Commit {{
                         oid
+                    }}
+                    ... on Tag {{
+                        name
+                        target {{
+                            oid
+                        }}
                     }}
                 }}
             """)
@@ -546,20 +615,57 @@ class GitHubGraphQLClient:
 
         response_data = await self._execute_graphql_query(query)
 
-        results = {}
+        results: dict[str, bool] = {}
+        peels: dict[str, AnnotatedTagPeel] = {}
         response_root = response_data.get("data") or {}
         repo_data = response_root.get("repository") or {}
 
         for alias, sha in aliases.items():
             commit_data = repo_data.get(alias)
-            results[sha] = commit_data is not None
+            peel = self._annotated_tag_peel(commit_data)
 
-            if commit_data:
+            if peel is not None:
+                results[sha] = False
+                peels[sha] = peel
+                self.logger.debug(
+                    f"SHA names an annotated tag object: "
+                    f"{owner}/{name}@{sha} -> {peel.tag} ({peel.commit_sha})"
+                )
+            elif commit_data:
+                results[sha] = True
                 self.logger.debug(f"Commit SHA exists: {owner}/{name}@{sha}")
             else:
+                results[sha] = False
                 self.logger.debug(f"Commit SHA not found: {owner}/{name}@{sha}")
 
-        return results
+        return results, peels
+
+    @staticmethod
+    def _annotated_tag_peel(object_data: Any) -> AnnotatedTagPeel | None:
+        """Extract the peel from a GraphQL ``Tag`` object payload.
+
+        Args:
+            object_data: The ``object(oid: ...)`` payload, or None when the
+                SHA resolved to nothing.
+
+        Returns:
+            The tag and commit behind an annotated tag object, or None when
+            the payload is absent, is not a tag, or lacks a peeled target.
+        """
+        if not isinstance(object_data, dict):
+            return None
+        if object_data.get("__typename") != "Tag":
+            return None
+
+        target = object_data.get("target") or {}
+        commit_sha = target.get("oid") if isinstance(target, dict) else None
+        if not commit_sha:
+            return None
+
+        return AnnotatedTagPeel(
+            tag=str(object_data.get("name") or ""),
+            commit_sha=str(commit_sha),
+        )
 
     async def _validate_branch_tag_names_graphql(
         self, owner: str, name: str, refs: list[str]

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -44,8 +44,6 @@ class ValidationResult(str, Enum):
     NOT_PINNED_TO_SHA = "not_pinned_to_sha"
     TEST_REFERENCE = "test_reference"
     ANNOTATED_TAG_SHA = "annotated_tag_sha"
-    SHA_COMMENT_MISMATCH = "sha_comment_mismatch"
-    OUTDATED_ACTION = "outdated_action"
 
 
 class Severity(str, Enum):
@@ -84,9 +82,7 @@ _RESULT_CATEGORIES: dict[ValidationResult, Category] = {
     ValidationResult.INVALID_PATH: Category.DEFECT,
     ValidationResult.INVALID_SYNTAX: Category.DEFECT,
     ValidationResult.ANNOTATED_TAG_SHA: Category.DEFECT,
-    ValidationResult.SHA_COMMENT_MISMATCH: Category.DEFECT,
     ValidationResult.NOT_PINNED_TO_SHA: Category.CURRENCY,
-    ValidationResult.OUTDATED_ACTION: Category.CURRENCY,
     ValidationResult.TEST_REFERENCE: Category.CURRENCY,
     ValidationResult.NETWORK_ERROR: Category.INFRASTRUCTURE,
     ValidationResult.TIMEOUT: Category.INFRASTRUCTURE,

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -43,6 +43,67 @@ class ValidationResult(str, Enum):
     TIMEOUT = "timeout"
     NOT_PINNED_TO_SHA = "not_pinned_to_sha"
     TEST_REFERENCE = "test_reference"
+    ANNOTATED_TAG_SHA = "annotated_tag_sha"
+    SHA_COMMENT_MISMATCH = "sha_comment_mismatch"
+    OUTDATED_ACTION = "outdated_action"
+
+
+class Severity(str, Enum):
+    """Reporting severity for a linter finding.
+
+    Severity governs presentation. Whether a finding fails the run is
+    decided by its :class:`Category` together with the relevant
+    ``--verify-*`` flag; see :mod:`gha_workflow_linter.exit_codes`.
+    """
+
+    ERROR = "error"
+    WARNING = "warning"
+    NOTICE = "notice"
+
+
+class Category(str, Enum):
+    """Whether a finding reports breakage, staleness, or a failed check.
+
+    ``DEFECT`` findings are wrong *now* and always count towards the exit
+    code. ``CURRENCY`` findings are correct but could be newer, and are
+    advisory unless the caller opts in with a ``--verify-*`` flag.
+    ``INFRASTRUCTURE`` means the check itself could not run, which must
+    never be silently reported as a pass.
+    """
+
+    DEFECT = "defect"
+    CURRENCY = "currency"
+    INFRASTRUCTURE = "infrastructure"
+
+
+# Classification of every validation result. Results absent from this
+# mapping (only VALID) are not findings at all.
+_RESULT_CATEGORIES: dict[ValidationResult, Category] = {
+    ValidationResult.INVALID_REPOSITORY: Category.DEFECT,
+    ValidationResult.INVALID_REFERENCE: Category.DEFECT,
+    ValidationResult.INVALID_PATH: Category.DEFECT,
+    ValidationResult.INVALID_SYNTAX: Category.DEFECT,
+    ValidationResult.ANNOTATED_TAG_SHA: Category.DEFECT,
+    ValidationResult.SHA_COMMENT_MISMATCH: Category.DEFECT,
+    ValidationResult.NOT_PINNED_TO_SHA: Category.CURRENCY,
+    ValidationResult.OUTDATED_ACTION: Category.CURRENCY,
+    ValidationResult.TEST_REFERENCE: Category.CURRENCY,
+    ValidationResult.NETWORK_ERROR: Category.INFRASTRUCTURE,
+    ValidationResult.TIMEOUT: Category.INFRASTRUCTURE,
+}
+
+
+def result_category(result: ValidationResult) -> Category | None:
+    """Return the category of a validation result.
+
+    Args:
+        result: The validation result to classify.
+
+    Returns:
+        The finding category, or None when the result is not a finding
+        (that is, ``ValidationResult.VALID``).
+    """
+    return _RESULT_CATEGORIES.get(result)
 
 
 class ActionCallType(str, Enum):
@@ -529,6 +590,13 @@ class CLIOptions(BaseModel):
     )
     files: list[str] | None = Field(
         default=None, description="Specific files to scan (supports wildcards)"
+    )
+    verify_actions: bool = Field(
+        default=False,
+        description=(
+            "Treat outdated action calls as errors and exit with the "
+            "ACTIONS_OUTDATED status"
+        ),
     )
 
     @field_validator("output_format")

--- a/src/gha_workflow_linter/scanner.py
+++ b/src/gha_workflow_linter/scanner.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -19,6 +19,20 @@ if TYPE_CHECKING:
 import yaml
 
 from .patterns import ActionCallPatterns
+
+
+class _ComposeResult(NamedTuple):
+    """
+    Outcome of composing a single YAML document.
+
+    Attributes:
+        valid: True when the document parsed without a YAML error.
+        node: Root of the composed node tree, or None when the document
+            was invalid or empty.
+    """
+
+    valid: bool
+    node: yaml.nodes.Node | None
 
 
 class WorkflowScanner:
@@ -230,6 +244,52 @@ class WorkflowScanner:
 
         return action_calls
 
+    def compose_workflow_file(self, file_path: Path) -> yaml.nodes.Node | None:
+        """
+        Return the composed YAML node tree for a workflow file.
+
+        Where :meth:`parse_workflow_file` returns action calls recovered
+        by the line-oriented pattern matcher, this returns PyYAML's node
+        tree. Every node carries ``start_mark`` and ``end_mark`` with
+        0-based ``line`` and ``column`` attributes, so a caller can map
+        document structure back onto source positions without reading and
+        parsing the workflow a second time.
+
+        Composition uses ``yaml.SafeLoader``, so no arbitrary Python
+        objects are constructed from the document.
+
+        Note:
+            An empty document composes to ``None``. That is
+            indistinguishable from the failure result, so a caller that
+            must tell the two apart has to check the file separately.
+
+        Note:
+            Comments are lexical, not structural: PyYAML discards them
+            while scanning, and they are absent from the returned tree.
+            Version-pin comments such as ``# v5.0.0`` cannot be recovered
+            from these nodes.
+
+        Note:
+            Under YAML 1.1 resolution, which ``SafeLoader`` implements, a
+            bare ``on:`` key resolves to the boolean ``True`` rather than
+            the string ``"on"``. Callers walking a workflow's top-level
+            mapping must accept both.
+
+        Args:
+            file_path: Path to the workflow file
+
+        Returns:
+            Root node of the composed tree, or None when the file cannot
+            be read, is not valid YAML, or is empty. Never raises.
+        """
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            self.logger.warning(f"Error reading file {file_path}: {e}")
+            return None
+
+        return self._compose(content, file_path).node
+
     def _is_valid_yaml(self, content: str, file_path: Path) -> bool:
         """
         Validate YAML syntax of workflow file.
@@ -241,12 +301,39 @@ class WorkflowScanner:
         Returns:
             True if valid YAML, False otherwise
         """
+        return self._compose(content, file_path).valid
+
+    def _compose(self, content: str, file_path: Path) -> _ComposeResult:
+        """
+        Compose already-read content into a YAML node tree.
+
+        Shared by the syntax gate in :meth:`parse_workflow_file` and by
+        :meth:`compose_workflow_file`, so content that has already been
+        read is parsed once rather than once per concern.
+
+        Composing stops after the resolution stage, so unlike
+        ``yaml.safe_load`` it never reports construction failures (an
+        unknown ``!!tag``, for example). Workflow files carry no custom
+        tags, and every syntax error a workflow can realistically hold is
+        raised by the scanner, parser or composer this does run.
+
+        Args:
+            content: File content
+            file_path: Path to file (for logging)
+
+        Returns:
+            The validity verdict paired with the composed tree, which is
+            None for an empty or invalid document.
+        """
         try:
-            yaml.safe_load(content)
-            return True
+            node = yaml.compose(content, Loader=yaml.SafeLoader)
         except yaml.YAMLError as e:
             self.logger.warning(f"Invalid YAML in {file_path}: {e}")
-            return False
+            return _ComposeResult(valid=False, node=None)
+
+        return _ComposeResult(
+            valid=True, node=cast("yaml.nodes.Node | None", node)
+        )
 
     def scan_directory(
         self,

--- a/src/gha_workflow_linter/validator.py
+++ b/src/gha_workflow_linter/validator.py
@@ -1015,6 +1015,16 @@ class ActionCallValidator:
             ValidationResult.TIMEOUT: "Timeout during validation",
             ValidationResult.NOT_PINNED_TO_SHA: "Action not pinned to commit SHA",
             ValidationResult.TEST_REFERENCE: "Test action reference",
+            ValidationResult.ANNOTATED_TAG_SHA: (
+                "Reference is an annotated tag object SHA, not a commit; "
+                "GitHub Actions cannot check this out"
+            ),
+            ValidationResult.SHA_COMMENT_MISMATCH: (
+                "Pinned SHA does not match the version named in its comment"
+            ),
+            ValidationResult.OUTDATED_ACTION: (
+                "A newer release of this action is available"
+            ),
         }
 
         return messages.get(result, "Unknown validation error")
@@ -1049,6 +1059,9 @@ class ActionCallValidator:
             "timeouts": 0,
             "test_references": 0,
             "not_pinned_to_sha": 0,
+            "annotated_tag_shas": 0,
+            "sha_comment_mismatches": 0,
+            "outdated_actions": 0,
             # API call statistics
             "api_calls_total": self.api_stats.total_calls,
             "api_calls_graphql": self.api_stats.graphql_calls,
@@ -1078,6 +1091,12 @@ class ActionCallValidator:
                 summary["timeouts"] += 1
             elif error.result == ValidationResult.NOT_PINNED_TO_SHA:
                 summary["not_pinned_to_sha"] += 1
+            elif error.result == ValidationResult.ANNOTATED_TAG_SHA:
+                summary["annotated_tag_shas"] += 1
+            elif error.result == ValidationResult.SHA_COMMENT_MISMATCH:
+                summary["sha_comment_mismatches"] += 1
+            elif error.result == ValidationResult.OUTDATED_ACTION:
+                summary["outdated_actions"] += 1
 
         return summary
 

--- a/src/gha_workflow_linter/validator.py
+++ b/src/gha_workflow_linter/validator.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+import dataclasses
 import logging
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -30,18 +31,46 @@ from .github_auth import get_github_token_with_fallback
 from .models import (
     ActionCall,
     APICallStats,
+    Category,
     Config,
-    ReferenceType,
     ValidationError,
     ValidationMethod,
     ValidationResult,
+    result_category,
 )
-from .paths import (
-    action_subpath,
-    base_repository,
-    has_action_subpath,
-)
+from .paths import has_action_subpath
 from .utils import has_test_comment
+from .validator_findings import (
+    ReferenceFinding,
+    build_validation_errors,
+    cache_verdict,
+    client_peels,
+    get_error_message,
+    merge_cached_findings,
+    peel_findings,
+    specific_ref_result,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _StageResults:
+    """Combined output of the repository, reference and subpath stages.
+
+    Attributes:
+        repo_results: Whether each repository exists.
+        ref_results: Whether each ``(repo, ref)`` pair resolves.
+        ref_findings: Specific verdicts and remediation context for refs
+            that did not resolve cleanly.
+        subpath_results: Whether each subdirectory action path exists.
+        inconclusive_subpaths: Subpath checks that failed transiently and
+            so must not be cached as a verdict.
+    """
+
+    repo_results: dict[str, bool]
+    ref_results: dict[tuple[str, str], bool]
+    ref_findings: dict[tuple[str, str], ReferenceFinding]
+    subpath_results: dict[tuple[str, str], bool]
+    inconclusive_subpaths: set[tuple[str, str]]
 
 
 class ActionCallValidator:
@@ -272,6 +301,89 @@ class ActionCallValidator:
             cache_misses, progress, task_id
         )
 
+        stages = await self._run_validation_stages(
+            repos_to_validate,
+            refs_to_validate,
+            cached_results,
+            progress,
+            task_id,
+            use_github_api,
+        )
+
+        cache_entries_to_store = self._build_cache_entries(
+            refs_to_validate,
+            stages.inconclusive_subpaths,
+            stages.repo_results,
+            stages.ref_results,
+            stages.subpath_results,
+            use_github_api,
+            stages.ref_findings,
+        )
+        if cache_entries_to_store:
+            self._cache.put_batch(cache_entries_to_store)
+
+        all_repo_results, all_ref_results, all_subpath_results = (
+            self._merge_all_results(
+                stages.repo_results,
+                stages.ref_results,
+                stages.subpath_results,
+                cached_results,
+            )
+        )
+
+        validation_results = self._combine_validation_results(
+            unique_calls,
+            all_repo_results,
+            all_ref_results,
+            all_subpath_results,
+            stages.ref_findings,
+        )
+
+        errors = build_validation_errors(
+            validation_results,
+            call_locations,
+            unique_calls,
+            self._ref_key,
+            self.config.require_pinned_sha,
+            stages.ref_findings,
+        )
+
+        self.logger.debug(
+            f"Validation complete: {len(errors)} errors out of "
+            f"{total_calls} calls ({unique_count} unique calls validated)"
+        )
+
+        self._log_final_statistics(use_github_api)
+        self._finalize_progress(progress, task_id)
+
+        return errors
+
+    async def _run_validation_stages(
+        self,
+        repos_to_validate: set[str],
+        refs_to_validate: list[tuple[str, str]],
+        cached_results: dict[tuple[str, str], Any],
+        progress: Progress | None,
+        task_id: TaskID | None,
+        use_github_api: bool,
+    ) -> _StageResults:
+        """Run the repository, reference and subpath validation stages.
+
+        Each stage narrows the work for the next: only references whose
+        repository resolved are looked up, and only subdirectory actions
+        whose reference resolved have their path checked.
+
+        Args:
+            repos_to_validate: Repositories not satisfied from cache
+            refs_to_validate: ``(repo, ref)`` pairs not satisfied from cache
+            cached_results: Previously cached entries, merged back in
+            progress: Optional progress bar
+            task_id: Optional task ID for progress updates
+            use_github_api: Whether to use the GitHub API or Git operations
+
+        Returns:
+            The combined results of all three stages.
+        """
         repo_results = await self._validate_repositories_stage(
             repos_to_validate, use_github_api
         )
@@ -290,7 +402,7 @@ class ActionCallValidator:
         valid_repo_refs_to_validate = self._select_valid_repo_refs(
             refs_to_validate, repo_results
         )
-        ref_results = await self._validate_references_stage(
+        ref_results, ref_findings = await self._validate_references_stage(
             valid_repo_refs_to_validate, use_github_api
         )
 
@@ -305,6 +417,7 @@ class ActionCallValidator:
         )
 
         self._merge_cached_ref_results(ref_results, cached_results)
+        merge_cached_findings(ref_findings, cached_results)
         self._advance_progress(
             progress,
             task_id,
@@ -312,43 +425,13 @@ class ActionCallValidator:
             "Processing validation results...",
         )
 
-        cache_entries_to_store = self._build_cache_entries(
-            refs_to_validate,
-            inconclusive_subpaths,
-            repo_results,
-            ref_results,
-            subpath_results,
-            use_github_api,
+        return _StageResults(
+            repo_results=repo_results,
+            ref_results=ref_results,
+            ref_findings=ref_findings,
+            subpath_results=subpath_results,
+            inconclusive_subpaths=inconclusive_subpaths,
         )
-        if cache_entries_to_store:
-            self._cache.put_batch(cache_entries_to_store)
-
-        all_repo_results, all_ref_results, all_subpath_results = (
-            self._merge_all_results(
-                repo_results, ref_results, subpath_results, cached_results
-            )
-        )
-
-        validation_results = self._combine_validation_results(
-            unique_calls,
-            all_repo_results,
-            all_ref_results,
-            all_subpath_results,
-        )
-
-        errors = self._build_validation_errors(
-            validation_results, call_locations, unique_calls
-        )
-
-        self.logger.debug(
-            f"Validation complete: {len(errors)} errors out of "
-            f"{total_calls} calls ({unique_count} unique calls validated)"
-        )
-
-        self._log_final_statistics(use_github_api)
-        self._finalize_progress(progress, task_id)
-
-        return errors
 
     def _log_validation_plan(
         self, total_calls: int, unique_count: int, use_github_api: bool
@@ -518,11 +601,31 @@ class ActionCallValidator:
         ref_results: dict[tuple[str, str], bool],
         subpath_results: dict[tuple[str, str], bool],
         use_github_api: bool,
+        ref_findings: dict[tuple[str, str], ReferenceFinding] | None = None,
     ) -> list[
         tuple[str, str, ValidationResult, str, ValidationMethod, str | None]
     ]:
-        """Build the cache entries to persist for freshly validated refs."""
+        """Build the cache entries to persist for freshly validated refs.
+
+        Args:
+            refs_to_validate: The ``(repo, ref)`` pairs validated this run.
+            inconclusive_subpaths: Pairs whose subpath check was
+                inconclusive and so must not be cached.
+            repo_results: Repository verdicts.
+            ref_results: Reference verdicts.
+            subpath_results: Subpath verdicts.
+            use_github_api: Whether the API backend produced the results.
+            ref_findings: Specific reference failures. A definite verdict
+                such as ``ANNOTATED_TAG_SHA`` is cached with its rendered
+                remediation message; an infrastructure failure (network,
+                timeout) is skipped so the next run retries it instead of
+                inheriting a false ``INVALID_REFERENCE``.
+
+        Returns:
+            List of cache-entry tuples to hand to ``ValidationCache``.
+        """
         api_call_type = "graphql" if use_github_api else "git"
+        findings = ref_findings or {}
         cache_entries: list[
             tuple[str, str, ValidationResult, str, ValidationMethod, str | None]
         ] = []
@@ -533,29 +636,28 @@ class ActionCallValidator:
             if (repo, ref) in inconclusive_subpaths:
                 continue
 
+            finding = findings.get((repo, ref))
+            # Never persist a verdict the check could not actually reach.
+            if (
+                finding is not None
+                and result_category(finding.result) is Category.INFRASTRUCTURE
+            ):
+                continue
+
             repo_valid = repo_results.get(repo, False)
             ref_valid = ref_results.get((repo, ref), False)
             # Subpath is considered valid unless we explicitly determined it is
             # bogus. Entries without a subpath never populate subpath_results.
             subpath_valid = subpath_results.get((repo, ref), True)
 
-            if repo_valid and ref_valid and subpath_valid:
-                result = ValidationResult.VALID
-                error_message = None
-            elif not repo_valid:
-                result = ValidationResult.INVALID_REPOSITORY
-                error_message = f"Repository {repo} not found or not accessible"
-            elif not ref_valid:
-                result = ValidationResult.INVALID_REFERENCE
-                error_message = (
-                    f"Reference {ref} not found in repository {repo}"
-                )
-            else:
-                result = ValidationResult.INVALID_PATH
-                error_message = (
-                    f"Subdirectory path '{action_subpath(repo)}' not found in "
-                    f"{base_repository(repo)} at {ref}"
-                )
+            result, error_message = cache_verdict(
+                repo,
+                ref,
+                finding,
+                repo_valid=repo_valid,
+                ref_valid=ref_valid,
+                subpath_valid=subpath_valid,
+            )
 
             cache_entries.append(
                 (
@@ -601,47 +703,6 @@ class ActionCallValidator:
                 cached_entry.result != ValidationResult.INVALID_PATH
             )
         return all_repo_results, all_ref_results, all_subpath_results
-
-    def _build_validation_errors(
-        self,
-        validation_results: dict[str, ValidationResult],
-        call_locations: dict[str, list[tuple[Path, ActionCall]]],
-        unique_calls: dict[str, ActionCall],
-    ) -> list[ValidationError]:
-        """Turn per-call validation results into ``ValidationError`` records."""
-        errors: list[ValidationError] = []
-        for call_key, result in validation_results.items():
-            if result != ValidationResult.VALID:
-                for file_path, action_call in call_locations[call_key]:
-                    errors.append(
-                        ValidationError(
-                            file_path=file_path,
-                            action_call=action_call,
-                            result=result,
-                            error_message=self._get_error_message(result),
-                        )
-                    )
-
-        if self.config.require_pinned_sha:
-            for call_key, action_call in unique_calls.items():
-                if (
-                    validation_results.get(call_key) == ValidationResult.VALID
-                    and action_call.reference_type != ReferenceType.COMMIT_SHA
-                ):
-                    for file_path, actual_action_call in call_locations[
-                        call_key
-                    ]:
-                        errors.append(
-                            ValidationError(
-                                file_path=file_path,
-                                action_call=actual_action_call,
-                                result=ValidationResult.NOT_PINNED_TO_SHA,
-                                error_message=self._get_error_message(
-                                    ValidationResult.NOT_PINNED_TO_SHA
-                                ),
-                            )
-                        )
-        return errors
 
     def _log_final_statistics(self, use_github_api: bool) -> None:
         """Emit end-of-run API/Git statistics at debug level."""
@@ -752,11 +813,27 @@ class ActionCallValidator:
         self,
         valid_repo_refs_to_validate: list[tuple[str, str]],
         use_github_api: bool,
-    ) -> dict[tuple[str, str], bool]:
-        """Validate a batch of references for already-valid repositories."""
+    ) -> tuple[
+        dict[tuple[str, str], bool],
+        dict[tuple[str, str], ReferenceFinding],
+    ]:
+        """Validate a batch of references for already-valid repositories.
+
+        Args:
+            valid_repo_refs_to_validate: ``(repo_key, ref)`` pairs whose
+                repository already validated.
+            use_github_api: Whether to use the API or the Git backend.
+
+        Returns:
+            Tuple of (results, findings): results is the pass/fail verdict
+            per pair, and findings carries the specific reason for each
+            failure (plus any remediation context) so a caller can report
+            something better than a generic invalid reference.
+        """
         ref_results: dict[tuple[str, str], bool] = {}
+        ref_findings: dict[tuple[str, str], ReferenceFinding] = {}
         if not valid_repo_refs_to_validate:
-            return ref_results
+            return ref_results, ref_findings
         try:
             if use_github_api:
                 assert self._github_client is not None
@@ -764,6 +841,12 @@ class ActionCallValidator:
                     await self._github_client.validate_references_batch(
                         valid_repo_refs_to_validate
                     )
+                )
+                # The API backend reports a bare boolean; a recorded peel
+                # is what distinguishes a tag-object SHA from a reference
+                # that simply does not exist.
+                ref_findings = peel_findings(
+                    ref_results, client_peels(self._github_client)
                 )
                 self._merge_api_stats(self._github_client.get_api_stats())
             else:
@@ -777,10 +860,18 @@ class ActionCallValidator:
                     repo_ref: result == ValidationResult.VALID
                     for repo_ref, result in git_ref_results.items()
                 }
+                peels = client_peels(self._git_client)
+                ref_findings = {
+                    repo_ref: ReferenceFinding(
+                        result=result, peel=peels.get(repo_ref)
+                    )
+                    for repo_ref, result in git_ref_results.items()
+                    if result != ValidationResult.VALID
+                }
             self._log_stage_stats("Reference", use_github_api)
         except Exception as e:
             self._abort_validation("reference", use_github_api, e)
-        return ref_results
+        return ref_results, ref_findings
 
     async def _validate_subpaths_stage(
         self,
@@ -926,12 +1017,30 @@ class ActionCallValidator:
 
         return asyncio.run(_run_validation())
 
+    def _ref_key(self, action_call: ActionCall) -> tuple[str, str]:
+        """Return the ``(repo_key, reference)`` a call is validated under.
+
+        Args:
+            action_call: The call whose reference key is wanted.
+
+        Returns:
+            The key used throughout the validation stages for this call.
+        """
+        repo_for_validation = self._extract_repository_for_validation(
+            action_call
+        )
+        return (
+            f"{action_call.organization}/{repo_for_validation}",
+            action_call.reference,
+        )
+
     def _combine_validation_results(
         self,
         unique_calls: dict[str, ActionCall],
         repo_results: dict[str, bool],
         ref_results: dict[tuple[str, str], bool],
         subpath_results: dict[tuple[str, str], bool] | None = None,
+        ref_findings: dict[tuple[str, str], ReferenceFinding] | None = None,
     ) -> dict[str, ValidationResult]:
         """
         Combine repository, reference and subpath validation results.
@@ -943,18 +1052,21 @@ class ActionCallValidator:
             subpath_results: Subdirectory-action subpath validation results,
                 keyed by ``(repo_key, ref)``. Entries are present only for
                 subdirectory actions; a missing entry is treated as valid.
+            ref_findings: Specific reference failures keyed by
+                ``(repo_key, ref)``. Consulted when a reference failed, so
+                a tag-object SHA is reported as ``ANNOTATED_TAG_SHA``
+                rather than as a generic ``INVALID_REFERENCE``.
 
         Returns:
             Dictionary mapping call keys to validation results
         """
         subpath_results = subpath_results or {}
+        findings = ref_findings or {}
         validation_results = {}
 
         for call_key, action_call in unique_calls.items():
-            repo_for_validation = self._extract_repository_for_validation(
-                action_call
-            )
-            repo_key = f"{action_call.organization}/{repo_for_validation}"
+            ref_key = self._ref_key(action_call)
+            repo_key = ref_key[0]
 
             if not repo_results.get(repo_key, False):
                 validation_results[call_key] = (
@@ -962,10 +1074,9 @@ class ActionCallValidator:
                 )
                 continue
 
-            ref_key = (repo_key, action_call.reference)
             if not ref_results.get(ref_key, False):
-                validation_results[call_key] = (
-                    ValidationResult.INVALID_REFERENCE
+                validation_results[call_key] = specific_ref_result(
+                    findings.get(ref_key)
                 )
                 continue
 
@@ -996,38 +1107,25 @@ class ActionCallValidator:
         self.api_stats.rate_limit_delays = client_stats.rate_limit_delays
         self.api_stats.failed_calls = client_stats.failed_calls
 
-    def _get_error_message(self, result: ValidationResult) -> str:
-        """
-        Get human-readable error message for validation result.
+    def _get_error_message(
+        self,
+        result: ValidationResult,
+        finding: ReferenceFinding | None = None,
+    ) -> str:
+        """Get human-readable error message for validation result.
+
+        Thin delegation to
+        :func:`gha_workflow_linter.validator_findings.get_error_message`,
+        kept as a method because callers already reach for it here.
 
         Args:
-            result: ValidationResult enum value
+            result: ValidationResult enum value.
+            finding: Optional context for a reference-level failure.
 
         Returns:
-            Error message string
+            Error message string.
         """
-        messages = {
-            ValidationResult.INVALID_REPOSITORY: "Repository not found",
-            ValidationResult.INVALID_REFERENCE: "Invalid branch, tag, or commit SHA",
-            ValidationResult.INVALID_PATH: "Subdirectory action path not found at reference",
-            ValidationResult.INVALID_SYNTAX: "Invalid action call syntax",
-            ValidationResult.NETWORK_ERROR: "Network error during validation",
-            ValidationResult.TIMEOUT: "Timeout during validation",
-            ValidationResult.NOT_PINNED_TO_SHA: "Action not pinned to commit SHA",
-            ValidationResult.TEST_REFERENCE: "Test action reference",
-            ValidationResult.ANNOTATED_TAG_SHA: (
-                "Reference is an annotated tag object SHA, not a commit; "
-                "GitHub Actions cannot check this out"
-            ),
-            ValidationResult.SHA_COMMENT_MISMATCH: (
-                "Pinned SHA does not match the version named in its comment"
-            ),
-            ValidationResult.OUTDATED_ACTION: (
-                "A newer release of this action is available"
-            ),
-        }
-
-        return messages.get(result, "Unknown validation error")
+        return get_error_message(result, finding)
 
     def get_validation_summary(
         self,
@@ -1060,8 +1158,6 @@ class ActionCallValidator:
             "test_references": 0,
             "not_pinned_to_sha": 0,
             "annotated_tag_shas": 0,
-            "sha_comment_mismatches": 0,
-            "outdated_actions": 0,
             # API call statistics
             "api_calls_total": self.api_stats.total_calls,
             "api_calls_graphql": self.api_stats.graphql_calls,
@@ -1093,10 +1189,6 @@ class ActionCallValidator:
                 summary["not_pinned_to_sha"] += 1
             elif error.result == ValidationResult.ANNOTATED_TAG_SHA:
                 summary["annotated_tag_shas"] += 1
-            elif error.result == ValidationResult.SHA_COMMENT_MISMATCH:
-                summary["sha_comment_mismatches"] += 1
-            elif error.result == ValidationResult.OUTDATED_ACTION:
-                summary["outdated_actions"] += 1
 
         return summary
 

--- a/src/gha_workflow_linter/validator_findings.py
+++ b/src/gha_workflow_linter/validator_findings.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Reference-level findings and the remediation messages they produce.
+
+Both validation backends report a bare boolean per reference. That is all
+the pass/fail decision needs, but it discards *why* a reference failed, so
+a SHA that names an annotated tag object is indistinguishable from a
+reference that simply does not exist — even though the two need very
+different advice. :class:`ReferenceFinding` carries the specific verdict
+plus the context needed to say what to use instead.
+
+This module holds the whole of that concern: constructing findings from
+backend results and recorded tag peels, narrowing a failure to its most
+specific known :class:`~gha_workflow_linter.models.ValidationResult`, and
+rendering the human-readable message for a result. It is kept separate
+from :mod:`gha_workflow_linter.validator` because none of it needs the
+validator's state — no clients, no cache, no configuration — and because
+messaging changes far more often than the orchestration around it.
+
+Nothing here imports :mod:`gha_workflow_linter.validator`; the dependency
+runs one way only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+from .models import (
+    ActionCall,
+    ReferenceType,
+    ValidationError,
+    ValidationResult,
+)
+from .paths import action_subpath, base_repository
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from .git_refs import AnnotatedTagPeel
+
+__all__ = [
+    "SPECIFIC_REF_RESULTS",
+    "ReferenceFinding",
+    "build_validation_errors",
+    "cache_verdict",
+    "client_peels",
+    "get_error_message",
+    "merge_cached_findings",
+    "peel_findings",
+    "specific_ref_result",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class ReferenceFinding:
+    """Why a reference failed validation, with remediation context.
+
+    Both validation backends report a bare boolean per reference, which is
+    all the pass/fail decision needs but throws away *why* a reference
+    failed. This record carries the specific verdict alongside it so an
+    annotated tag-object SHA is not reported as a generic invalid
+    reference, together with the context needed to say what to use instead.
+
+    Attributes:
+        result: The specific validation result. Never
+            ``ValidationResult.VALID``; findings exist only for failures.
+        peel: For ``ANNOTATED_TAG_SHA``, the tag and commit behind the
+            pinned tag object. None when unavailable (for example when the
+            finding was restored from cache).
+        message: A pre-rendered error message, used when a cached finding
+            is replayed and the peel itself was not persisted.
+    """
+
+    result: ValidationResult
+    peel: AnnotatedTagPeel | None = None
+    message: str | None = None
+
+
+#: Reference-level verdicts that are more specific than the generic
+#: ``INVALID_REFERENCE`` and are definite enough to persist in the cache.
+#: ``INVALID_REFERENCE`` itself is omitted because it is the fallback the
+#: absence of a finding already implies.
+SPECIFIC_REF_RESULTS: frozenset[ValidationResult] = frozenset(
+    {ValidationResult.ANNOTATED_TAG_SHA}
+)
+
+#: Static, context-free message per validation result. A result absent
+#: from this mapping falls back to a generic string.
+_RESULT_MESSAGES: dict[ValidationResult, str] = {
+    ValidationResult.INVALID_REPOSITORY: "Repository not found",
+    ValidationResult.INVALID_REFERENCE: "Invalid branch, tag, or commit SHA",
+    ValidationResult.INVALID_PATH: "Subdirectory action path not found at reference",
+    ValidationResult.INVALID_SYNTAX: "Invalid action call syntax",
+    ValidationResult.NETWORK_ERROR: "Network error during validation",
+    ValidationResult.TIMEOUT: "Timeout during validation",
+    ValidationResult.NOT_PINNED_TO_SHA: "Action not pinned to commit SHA",
+    ValidationResult.TEST_REFERENCE: "Test action reference",
+    ValidationResult.ANNOTATED_TAG_SHA: (
+        "Reference is an annotated tag object SHA, not a commit; "
+        "GitHub Actions cannot check this out"
+    ),
+}
+
+
+def client_peels(
+    client: object,
+) -> Mapping[tuple[str, str], AnnotatedTagPeel]:
+    """Read the annotated tag peels a validation backend recorded.
+
+    Both backends expose ``annotated_tag_peels``, but it is an optional
+    enrichment rather than part of the validation contract: a client
+    that does not surface a real mapping simply yields no remediation
+    context, and reporting falls back to the generic verdict.
+
+    Args:
+        client: The validation backend to read peels from.
+
+    Returns:
+        The backend's peel mapping, or an empty mapping.
+    """
+    peels = getattr(client, "annotated_tag_peels", None)
+    return peels if isinstance(peels, Mapping) else {}
+
+
+def peel_findings(
+    ref_results: dict[tuple[str, str], bool],
+    peels: Mapping[tuple[str, str], AnnotatedTagPeel],
+) -> dict[tuple[str, str], ReferenceFinding]:
+    """Build ``ANNOTATED_TAG_SHA`` findings from recorded peels.
+
+    Args:
+        ref_results: Pass/fail verdict per ``(repo_key, ref)``.
+        peels: Peels the backend recorded for tag-object SHAs.
+
+    Returns:
+        A finding for every failing reference that names a tag object.
+    """
+    return {
+        repo_ref: ReferenceFinding(
+            result=ValidationResult.ANNOTATED_TAG_SHA, peel=peel
+        )
+        for repo_ref, peel in peels.items()
+        if not ref_results.get(repo_ref, False)
+    }
+
+
+def specific_ref_result(
+    finding: ReferenceFinding | None,
+) -> ValidationResult:
+    """Narrow a reference failure to its most specific known result.
+
+    Args:
+        finding: The recorded failure, if any.
+
+    Returns:
+        The specific result when one was recorded, otherwise the
+        generic ``INVALID_REFERENCE``. Infrastructure failures also
+        fall back to the generic result, preserving how a transient
+        error has always been surfaced.
+    """
+    if finding is not None and finding.result in SPECIFIC_REF_RESULTS:
+        return finding.result
+    return ValidationResult.INVALID_REFERENCE
+
+
+def get_error_message(
+    result: ValidationResult,
+    finding: ReferenceFinding | None = None,
+) -> str:
+    """Get human-readable error message for validation result.
+
+    Args:
+        result: ValidationResult enum value.
+        finding: Optional context for a reference-level failure. When
+            it carries a peel (or a message replayed from cache) the
+            ``ANNOTATED_TAG_SHA`` message names the tag and the commit
+            to use instead; otherwise the static message is returned.
+
+    Returns:
+        Error message string.
+    """
+    if result == ValidationResult.ANNOTATED_TAG_SHA and finding is not None:
+        if finding.peel is not None:
+            return (
+                f"Reference is the SHA of the annotated tag object for "
+                f"{finding.peel.tag}, not a commit. GitHub Actions "
+                f"cannot check out a tag object. Use the peeled commit "
+                f"instead: {finding.peel.commit_sha}"
+            )
+        if finding.message:
+            return finding.message
+
+    return _RESULT_MESSAGES.get(result, "Unknown validation error")
+
+
+def merge_cached_findings(
+    ref_findings: dict[tuple[str, str], ReferenceFinding],
+    cached_results: dict[tuple[str, str], Any],
+) -> None:
+    """Fold cached reference-level failures into the fresh findings.
+
+    A verdict such as ``ANNOTATED_TAG_SHA`` is definite and therefore
+    cached, so a cache hit must reproduce the same specific result and
+    message rather than degrading to a generic invalid reference. The
+    peel itself is not persisted; the rendered message is.
+
+    Args:
+        ref_findings: Findings from this run, updated in place. Fresh
+            entries win, since a cached ref is never re-validated.
+        cached_results: Cached entries keyed by ``(repo, ref)``.
+
+    Returns:
+        None. ``ref_findings`` is mutated in place.
+    """
+    for key, cached_entry in cached_results.items():
+        result = cached_entry.result
+        if key in ref_findings or result not in SPECIFIC_REF_RESULTS:
+            continue
+        ref_findings[key] = ReferenceFinding(
+            result=result, message=cached_entry.error_message
+        )
+
+
+def cache_verdict(
+    repo: str,
+    ref: str,
+    finding: ReferenceFinding | None,
+    repo_valid: bool,
+    ref_valid: bool,
+    subpath_valid: bool,
+) -> tuple[ValidationResult, str | None]:
+    """Derive the result and message to persist for one validated ref.
+
+    The stages report repository, reference and subpath validity
+    independently; this collapses them into the single verdict a cache
+    entry carries, naming the repository, reference or subpath that
+    actually failed so a cache replay reads as well as a live run.
+
+    Args:
+        repo: Repository key, including any action subpath.
+        ref: The branch, tag or SHA that was validated.
+        finding: Specific reference failure, if one was recorded.
+        repo_valid: Whether the repository validated.
+        ref_valid: Whether the reference validated.
+        subpath_valid: Whether the action subpath validated. Refs without
+            a subpath are always valid here.
+
+    Returns:
+        Tuple of the verdict and its error message, the message being
+        None when the verdict is ``ValidationResult.VALID``.
+    """
+    if repo_valid and ref_valid and subpath_valid:
+        return ValidationResult.VALID, None
+    if not repo_valid:
+        return (
+            ValidationResult.INVALID_REPOSITORY,
+            f"Repository {repo} not found or not accessible",
+        )
+    if not ref_valid:
+        result = specific_ref_result(finding)
+        return result, (
+            get_error_message(result, finding)
+            if result != ValidationResult.INVALID_REFERENCE
+            else f"Reference {ref} not found in repository {repo}"
+        )
+    return (
+        ValidationResult.INVALID_PATH,
+        f"Subdirectory path '{action_subpath(repo)}' not found in "
+        f"{base_repository(repo)} at {ref}",
+    )
+
+
+def build_validation_errors(
+    validation_results: dict[str, ValidationResult],
+    call_locations: dict[str, list[tuple[Path, ActionCall]]],
+    unique_calls: dict[str, ActionCall],
+    ref_key: Callable[[ActionCall], tuple[str, str]],
+    require_pinned_sha: bool,
+    ref_findings: dict[tuple[str, str], ReferenceFinding] | None = None,
+) -> list[ValidationError]:
+    """Turn per-call validation results into ``ValidationError`` records.
+
+    Args:
+        validation_results: Per-call verdicts keyed by call key.
+        call_locations: Where each call key appears in the workflows.
+        unique_calls: The deduplicated calls, keyed by call key.
+        ref_key: Maps a call to the ``(repo_key, ref)`` the reference
+            stages keyed their results by. Supplied by the caller because
+            deriving it depends on how a call names its repository.
+        require_pinned_sha: Whether a valid call that is not pinned to a
+            commit SHA should additionally be reported as an error.
+        ref_findings: Specific reference failures keyed by
+            ``(repo_key, ref)``, used to render a remediation message
+            (for example the peeled commit behind a tag object).
+
+    Returns:
+        List of validation errors, one per occurrence of a failing call.
+    """
+    findings = ref_findings or {}
+    errors: list[ValidationError] = []
+    for call_key, result in validation_results.items():
+        if result != ValidationResult.VALID:
+            for file_path, action_call in call_locations[call_key]:
+                finding = findings.get(ref_key(action_call))
+                errors.append(
+                    ValidationError(
+                        file_path=file_path,
+                        action_call=action_call,
+                        result=result,
+                        error_message=get_error_message(result, finding),
+                    )
+                )
+
+    if require_pinned_sha:
+        for call_key, action_call in unique_calls.items():
+            if (
+                validation_results.get(call_key) == ValidationResult.VALID
+                and action_call.reference_type != ReferenceType.COMMIT_SHA
+            ):
+                for file_path, actual_action_call in call_locations[call_key]:
+                    errors.append(
+                        ValidationError(
+                            file_path=file_path,
+                            action_call=actual_action_call,
+                            result=ValidationResult.NOT_PINNED_TO_SHA,
+                            error_message=get_error_message(
+                                ValidationResult.NOT_PINNED_TO_SHA
+                            ),
+                        )
+                    )
+    return errors

--- a/src/gha_workflow_linter/validator_findings.py
+++ b/src/gha_workflow_linter/validator_findings.py
@@ -30,9 +30,11 @@ from typing import TYPE_CHECKING, Any
 
 from .models import (
     ActionCall,
+    Category,
     ReferenceType,
     ValidationError,
     ValidationResult,
+    result_category,
 )
 from .paths import action_subpath, base_repository
 
@@ -153,16 +155,27 @@ def specific_ref_result(
 ) -> ValidationResult:
     """Narrow a reference failure to its most specific known result.
 
+    Infrastructure failures (a network error or timeout affecting one
+    repository, rather than aborting the whole run) are surfaced as
+    themselves. Collapsing them to ``INVALID_REFERENCE`` would tell the
+    reader their reference is wrong when the check merely could not run,
+    and would leave the summary's ``network_errors`` and ``timeouts``
+    counters permanently at zero. Caching already refuses these results
+    via ``result_category(...) is Category.INFRASTRUCTURE``, so a
+    transient failure is retried rather than persisted as a verdict.
+
     Args:
         finding: The recorded failure, if any.
 
     Returns:
-        The specific result when one was recorded, otherwise the
-        generic ``INVALID_REFERENCE``. Infrastructure failures also
-        fall back to the generic result, preserving how a transient
-        error has always been surfaced.
+        The specific result when one was recorded, otherwise the generic
+        ``INVALID_REFERENCE``.
     """
-    if finding is not None and finding.result in SPECIFIC_REF_RESULTS:
+    if finding is None:
+        return ValidationResult.INVALID_REFERENCE
+    if finding.result in SPECIFIC_REF_RESULTS:
+        return finding.result
+    if result_category(finding.result) is Category.INFRASTRUCTURE:
         return finding.result
     return ValidationResult.INVALID_REFERENCE
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,8 @@ def mock_git_commands(monkeypatch: pytest.MonkeyPatch) -> None:
         if not isinstance(cmd, list):
             cmd = []
 
-        if not isinstance(cmd, list) or len(cmd) < 2 or cmd[0] != "git":
+        # cmd is a list by now, so no further isinstance check is needed.
+        if len(cmd) < 2 or cmd[0] != "git":
             # Pass through non-git commands
             return subprocess.CompletedProcess(
                 args=cmd, returncode=1, stdout=b"", stderr=b"Not a git command"

--- a/tests/test_annotated_tag_reporting.py
+++ b/tests/test_annotated_tag_reporting.py
@@ -40,7 +40,10 @@ from gha_workflow_linter.models import (
     ValidationResult,
 )
 from gha_workflow_linter.validator import ActionCallValidator
-from gha_workflow_linter.validator_findings import ReferenceFinding
+from gha_workflow_linter.validator_findings import (
+    ReferenceFinding,
+    specific_ref_result,
+)
 
 # Real output from ``git ls-remote`` against
 # git@github.com:lfreleng-actions/.github.git. v0.12.2 is an annotated tag,
@@ -450,3 +453,43 @@ async def test_cached_annotated_tag_sha_survives_a_cache_hit(
     assert len(errors) == 1
     assert errors[0].result is ValidationResult.ANNOTATED_TAG_SHA
     assert errors[0].error_message == fresh[0].error_message
+
+
+class TestInfrastructureResultsSurvive:
+    """Transient failures must not masquerade as invalid references.
+
+    ``specific_ref_result`` previously collapsed every non-specific
+    finding to ``INVALID_REFERENCE``, so a per-repository network error
+    or timeout told the reader their reference was wrong when the check
+    had simply not run, and left the summary's ``network_errors`` and
+    ``timeouts`` counters unreachable.
+    """
+
+    @pytest.mark.parametrize(
+        "result",
+        [ValidationResult.NETWORK_ERROR, ValidationResult.TIMEOUT],
+    )
+    def test_infrastructure_results_pass_through(
+        self, result: ValidationResult
+    ) -> None:
+        finding = ReferenceFinding(result=result)
+
+        assert specific_ref_result(finding) is result
+
+    def test_annotated_tag_still_specific(self) -> None:
+        finding = ReferenceFinding(result=ValidationResult.ANNOTATED_TAG_SHA)
+
+        assert (
+            specific_ref_result(finding) is ValidationResult.ANNOTATED_TAG_SHA
+        )
+
+    def test_missing_finding_is_generic(self) -> None:
+        assert specific_ref_result(None) is ValidationResult.INVALID_REFERENCE
+
+    def test_unrelated_result_stays_generic(self) -> None:
+        """A repository-level verdict must not leak into ref reporting."""
+        finding = ReferenceFinding(result=ValidationResult.INVALID_REPOSITORY)
+
+        assert (
+            specific_ref_result(finding) is ValidationResult.INVALID_REFERENCE
+        )

--- a/tests/test_annotated_tag_reporting.py
+++ b/tests/test_annotated_tag_reporting.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests that an annotated tag-object pin is *reported* as such.
+
+``ValidationResult.ANNOTATED_TAG_SHA`` was already produced by the Git
+backend, but the validator flattened every reference verdict to a boolean
+before combining results, so the user saw the generic "Invalid branch, tag,
+or commit SHA". These tests pin the reporting path end to end: the specific
+verdict survives, it carries the peeled commit to use instead, and both
+validation backends agree on the verdict and the message.
+
+Mocking happens at the client boundary — ``git ls-remote`` output for the
+Git backend, GraphQL responses for the API backend — so the real client
+code, including the peel capture, is exercised.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from gha_workflow_linter.git_refs import AnnotatedTagPeel
+from gha_workflow_linter.git_validator import GitValidationClient
+from gha_workflow_linter.github_api import GitHubGraphQLClient
+from gha_workflow_linter.models import (
+    ActionCall,
+    ActionCallType,
+    CacheConfig,
+    Config,
+    GitConfig,
+    ReferenceType,
+    ValidationError,
+    ValidationMethod,
+    ValidationResult,
+)
+from gha_workflow_linter.validator import ActionCallValidator
+from gha_workflow_linter.validator_findings import ReferenceFinding
+
+# Real output from ``git ls-remote`` against
+# git@github.com:lfreleng-actions/.github.git. v0.12.2 is an annotated tag,
+# so it is advertised twice: the tag object, then the commit it peels to.
+TAG_NAME = "v0.12.2"
+TAG_OBJECT_SHA = "8f363565e79650362c3359ee23b6d6fd295866ee"
+PEELED_COMMIT_SHA = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+UNKNOWN_SHA = "1234567890abcdef1234567890abcdef12345678"
+BRANCH_COMMIT_SHA = "0000111122223333444455556666777788889999"
+
+LS_REMOTE_OUTPUT = (
+    f"{BRANCH_COMMIT_SHA}\trefs/heads/main\n"
+    f"{TAG_OBJECT_SHA}\trefs/tags/{TAG_NAME}\n"
+    f"{PEELED_COMMIT_SHA}\trefs/tags/{TAG_NAME}^{{}}\n"
+)
+
+ORGANIZATION = "lfreleng-actions"
+REPOSITORY = "test-action"
+REPO_KEY = f"{ORGANIZATION}/{REPOSITORY}"
+
+# What ``object(oid: ...)`` resolves to for each fixture SHA. GitHub returns
+# null for a SHA the repository does not contain.
+GRAPHQL_OBJECTS: dict[str, dict[str, Any]] = {
+    TAG_OBJECT_SHA: {
+        "__typename": "Tag",
+        "name": TAG_NAME,
+        "target": {"oid": PEELED_COMMIT_SHA},
+    },
+    PEELED_COMMIT_SHA: {
+        "__typename": "Commit",
+        "oid": PEELED_COMMIT_SHA,
+    },
+    BRANCH_COMMIT_SHA: {
+        "__typename": "Commit",
+        "oid": BRANCH_COMMIT_SHA,
+    },
+}
+
+_OBJECT_ALIAS_RE = re.compile(r"(\w+): object\(oid: \"([0-9a-fA-F]+)\"\)")
+_REPO_ALIAS_RE = re.compile(r"(repo_\d+): repository\(")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeCompleted:
+    """Minimal stand-in for ``subprocess.CompletedProcess``."""
+
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = ""
+
+
+def _patch_ls_remote(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub ``subprocess.run`` with the fixture ls-remote output.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+    """
+
+    def fake_run(_cmd: list[str], **_kwargs: object) -> FakeCompleted:
+        return FakeCompleted(LS_REMOTE_OUTPUT)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+async def _fake_graphql_query(query: str) -> dict[str, Any]:
+    """Answer a GraphQL query from the fixture data.
+
+    Args:
+        query: The generated GraphQL document.
+
+    Returns:
+        A response body shaped like GitHub's, covering both the repository
+        existence query and the commit-SHA object query.
+    """
+    if "object(oid:" in query:
+        objects = {
+            alias: GRAPHQL_OBJECTS.get(sha)
+            for alias, sha in _OBJECT_ALIAS_RE.findall(query)
+        }
+        return {"data": {"repository": objects}}
+
+    return {
+        "data": {
+            alias: {"id": alias, "name": REPOSITORY}
+            for alias in _REPO_ALIAS_RE.findall(query)
+        }
+    }
+
+
+def _action_call(reference: str) -> ActionCall:
+    """Build an action call pinned to the given reference.
+
+    Args:
+        reference: The SHA the workflow line pins.
+
+    Returns:
+        An ``ActionCall`` as the scanner would produce for that line.
+    """
+    return ActionCall(
+        raw_line=f"uses: {REPO_KEY}@{reference} # {TAG_NAME}",
+        line_number=42,
+        organization=ORGANIZATION,
+        repository=REPOSITORY,
+        reference=reference,
+        reference_type=ReferenceType.COMMIT_SHA,
+        call_type=ActionCallType.ACTION,
+        comment=f"# {TAG_NAME}",
+    )
+
+
+def _peel() -> AnnotatedTagPeel:
+    """Build the peel behind the fixture tag object.
+
+    Returns:
+        The ``AnnotatedTagPeel`` for ``v0.12.2``.
+    """
+    return AnnotatedTagPeel(tag=TAG_NAME, commit_sha=PEELED_COMMIT_SHA)
+
+
+def _validator(cache_dir: Path | None = None) -> ActionCallValidator:
+    """Build a validator with caching disabled unless a directory is given.
+
+    Args:
+        cache_dir: Directory for an enabled cache, or None to disable it.
+
+    Returns:
+        A validator with no backend client attached yet.
+    """
+    cache = (
+        CacheConfig(enabled=True, cache_dir=cache_dir)
+        if cache_dir is not None
+        else CacheConfig(enabled=False)
+    )
+    return ActionCallValidator(Config(require_pinned_sha=False, cache=cache))
+
+
+async def _validate_with_git(
+    monkeypatch: pytest.MonkeyPatch,
+    reference: str,
+    cache_dir: Path | None = None,
+    validator: ActionCallValidator | None = None,
+) -> list[ValidationError]:
+    """Run a full validation of one pinned reference via the Git backend.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        reference: The SHA the workflow pins.
+        cache_dir: Optional cache directory (enables caching).
+        validator: Optional pre-built validator to reuse.
+
+    Returns:
+        The validation errors produced for the single action call.
+    """
+    _patch_ls_remote(monkeypatch)
+    validator = validator or _validator(cache_dir)
+    validator._validation_method = ValidationMethod.GIT
+    validator._git_client = GitValidationClient(GitConfig())
+
+    return await validator._perform_validation(
+        {Path("wf.yaml"): {42: _action_call(reference)}},
+        use_github_api=False,
+    )
+
+
+async def _validate_with_api(
+    monkeypatch: pytest.MonkeyPatch,
+    reference: str,
+    cache_dir: Path | None = None,
+    validator: ActionCallValidator | None = None,
+) -> list[ValidationError]:
+    """Run a full validation of one pinned reference via the API backend.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        reference: The SHA the workflow pins.
+        cache_dir: Optional cache directory (enables caching).
+        validator: Optional pre-built validator to reuse.
+
+    Returns:
+        The validation errors produced for the single action call.
+    """
+    validator = validator or _validator(cache_dir)
+    validator._validation_method = ValidationMethod.GITHUB_API
+    client = GitHubGraphQLClient(validator.config.github_api)
+    monkeypatch.setattr(client, "_execute_graphql_query", _fake_graphql_query)
+    validator._github_client = client
+
+    return await validator._perform_validation(
+        {Path("wf.yaml"): {42: _action_call(reference)}},
+        use_github_api=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The core regression: the specific verdict reaches the user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_git_backend_reports_annotated_tag_sha_not_invalid_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pinned tag-object SHA is ANNOTATED_TAG_SHA, not INVALID_REFERENCE.
+
+    The validator used to flatten the reference verdict to a boolean, so
+    this precise, actionable result was replaced by the generic one.
+    """
+    errors = await _validate_with_git(monkeypatch, TAG_OBJECT_SHA)
+
+    assert len(errors) == 1
+    assert errors[0].result is ValidationResult.ANNOTATED_TAG_SHA
+
+
+@pytest.mark.asyncio
+async def test_git_backend_message_names_tag_and_peeled_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The message carries the remediation, not just the diagnosis."""
+    errors = await _validate_with_git(monkeypatch, TAG_OBJECT_SHA)
+
+    message = errors[0].error_message or ""
+    assert PEELED_COMMIT_SHA in message
+    assert TAG_NAME in message
+    # The tag-object SHA is what the user already has; it is the commit
+    # that is missing from the report.
+    assert "annotated tag object" in message
+
+
+@pytest.mark.asyncio
+async def test_git_backend_peeled_commit_validates_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real commit SHA still passes; the split only rejects tag objects."""
+    errors = await _validate_with_git(monkeypatch, PEELED_COMMIT_SHA)
+
+    assert errors == []
+
+
+@pytest.mark.asyncio
+async def test_git_backend_unknown_sha_stays_invalid_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SHA the remote never advertises keeps the generic verdict."""
+    errors = await _validate_with_git(monkeypatch, UNKNOWN_SHA)
+
+    assert len(errors) == 1
+    assert errors[0].result is ValidationResult.INVALID_REFERENCE
+    assert errors[0].error_message == "Invalid branch, tag, or commit SHA"
+
+
+# ---------------------------------------------------------------------------
+# Backend parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_backend_reports_annotated_tag_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The API backend recognises and peels a tag object too."""
+    errors = await _validate_with_api(monkeypatch, TAG_OBJECT_SHA)
+
+    assert len(errors) == 1
+    assert errors[0].result is ValidationResult.ANNOTATED_TAG_SHA
+    message = errors[0].error_message or ""
+    assert PEELED_COMMIT_SHA in message
+    assert TAG_NAME in message
+
+
+@pytest.mark.asyncio
+async def test_backends_agree_on_annotated_tag_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both backends return the same verdict and the same message.
+
+    Which backend runs depends only on whether a token happens to be
+    available, so a disagreement here is a defect by construction.
+    """
+    git_errors = await _validate_with_git(monkeypatch, TAG_OBJECT_SHA)
+    api_errors = await _validate_with_api(monkeypatch, TAG_OBJECT_SHA)
+
+    assert git_errors[0].result is api_errors[0].result
+    assert git_errors[0].error_message == api_errors[0].error_message
+
+
+@pytest.mark.asyncio
+async def test_backends_agree_on_valid_and_unknown_shas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parity is not limited to the tag-object case."""
+    assert await _validate_with_git(monkeypatch, PEELED_COMMIT_SHA) == []
+    assert await _validate_with_api(monkeypatch, PEELED_COMMIT_SHA) == []
+
+    git_errors = await _validate_with_git(monkeypatch, UNKNOWN_SHA)
+    api_errors = await _validate_with_api(monkeypatch, UNKNOWN_SHA)
+
+    assert git_errors[0].result is api_errors[0].result
+    assert git_errors[0].error_message == api_errors[0].error_message
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotated_tag_sha_is_cached(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The verdict is definite, so it belongs in the cache.
+
+    Unlike a network failure, nothing about it is transient: the same tag
+    object will still not be a commit on the next run.
+    """
+    validator = _validator(tmp_path)
+    put_batch = Mock()
+    monkeypatch.setattr(validator._cache, "put_batch", put_batch)
+
+    await _validate_with_git(monkeypatch, TAG_OBJECT_SHA, validator=validator)
+
+    put_batch.assert_called_once()
+    entries = put_batch.call_args[0][0]
+    assert len(entries) == 1
+    repo, ref, result, _api_call_type, _method, message = entries[0]
+    assert (repo, ref) == (REPO_KEY, TAG_OBJECT_SHA)
+    assert result is ValidationResult.ANNOTATED_TAG_SHA
+    assert PEELED_COMMIT_SHA in (message or "")
+
+
+def test_transient_reference_failure_is_not_cached() -> None:
+    """An infrastructure failure must not persist as a verdict.
+
+    Caching a network error as INVALID_REFERENCE would turn a blip into a
+    sticky false failure; the next run must re-check it instead.
+    """
+    validator = _validator()
+    flaky_sha = BRANCH_COMMIT_SHA
+
+    entries = validator._build_cache_entries(
+        refs_to_validate=[
+            (REPO_KEY, TAG_OBJECT_SHA),
+            (REPO_KEY, flaky_sha),
+        ],
+        inconclusive_subpaths=set(),
+        repo_results={REPO_KEY: True},
+        ref_results={
+            (REPO_KEY, TAG_OBJECT_SHA): False,
+            (REPO_KEY, flaky_sha): False,
+        },
+        subpath_results={},
+        use_github_api=False,
+        ref_findings={
+            (REPO_KEY, TAG_OBJECT_SHA): ReferenceFinding(
+                result=ValidationResult.ANNOTATED_TAG_SHA,
+                peel=_peel(),
+            ),
+            (REPO_KEY, flaky_sha): ReferenceFinding(
+                result=ValidationResult.NETWORK_ERROR
+            ),
+        },
+    )
+
+    cached_refs = {ref: result for _repo, ref, result, *_rest in entries}
+    assert cached_refs == {TAG_OBJECT_SHA: ValidationResult.ANNOTATED_TAG_SHA}
+
+
+@pytest.mark.asyncio
+async def test_cached_annotated_tag_sha_survives_a_cache_hit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A replayed cache entry keeps the specific verdict and message.
+
+    The peel is not persisted, so the rendered message is what the cache
+    carries; the result must not degrade to INVALID_REFERENCE.
+    """
+    fresh = await _validate_with_git(
+        monkeypatch, TAG_OBJECT_SHA, cache_dir=tmp_path
+    )
+
+    validator = _validator(tmp_path)
+    validator._cache.put(
+        REPO_KEY,
+        TAG_OBJECT_SHA,
+        ValidationResult.ANNOTATED_TAG_SHA,
+        "git",
+        ValidationMethod.GIT,
+        fresh[0].error_message,
+    )
+
+    def _explode(_cmd: list[str], **_kwargs: object) -> FakeCompleted:
+        raise AssertionError("cache hit must not reach the network")
+
+    monkeypatch.setattr(subprocess, "run", _explode)
+    validator._validation_method = ValidationMethod.GIT
+    validator._git_client = GitValidationClient(GitConfig())
+
+    errors = await validator._perform_validation(
+        {Path("wf.yaml"): {42: _action_call(TAG_OBJECT_SHA)}},
+        use_github_api=False,
+    )
+
+    assert len(errors) == 1
+    assert errors[0].result is ValidationResult.ANNOTATED_TAG_SHA
+    assert errors[0].error_message == fresh[0].error_message

--- a/tests/test_annotated_tag_sha.py
+++ b/tests/test_annotated_tag_sha.py
@@ -1,0 +1,438 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Tests for annotated tag handling in the token-less Git validation path.
+
+``git ls-remote --tags`` advertises two lines for an annotated tag: the SHA
+of the tag object, and the SHA of the commit it peels to. Conflating the two
+makes the Git backend report a tag-object SHA as VALID even though GitHub
+Actions cannot check out a tag object.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from gha_workflow_linter.exceptions import GitError
+from gha_workflow_linter.git_refs import (
+    AnnotatedTagPeel,
+    get_all_remote_refs,
+    get_annotated_tag_peels,
+    get_remote_ref_shas,
+    get_remote_tag_object_shas,
+    get_remote_tag_shas,
+)
+from gha_workflow_linter.git_validator import _validate_commit_shas_git
+from gha_workflow_linter.models import GitConfig, ValidationResult
+
+URL = "https://github.com/lfreleng-actions/.github.git"
+
+# Real output from ``git ls-remote --tags`` against
+# git@github.com:lfreleng-actions/.github.git. Both tags are annotated:
+# each has an unpeeled tag-object line and a ``^{}`` commit line.
+V0_12_2_TAG_OBJECT = "8f363565e79650362c3359ee23b6d6fd295866ee"
+V0_12_2_COMMIT = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+V0_1_1_TAG_OBJECT = "a5c2d7a4620ab83fcaeabac868d07ee27335053e"
+V0_1_1_COMMIT = "18d9c4446bea555d0783e850f6d295f844fe8f67"
+
+ANNOTATED_TAGS_OUTPUT = (
+    f"{V0_12_2_TAG_OBJECT}\trefs/tags/v0.12.2\n"
+    f"{V0_12_2_COMMIT}\trefs/tags/v0.12.2^{{}}\n"
+    f"{V0_1_1_TAG_OBJECT}\trefs/tags/v0.1.1\n"
+    f"{V0_1_1_COMMIT}\trefs/tags/v0.1.1^{{}}\n"
+)
+
+# A lightweight tag has a single line and no ``^{}`` peel.
+LIGHTWEIGHT_COMMIT = "3b7bd5b9e1cd3e0d4ed4a6b3d0e1f2a3b4c5d6e7"
+LIGHTWEIGHT_TAGS_OUTPUT = f"{LIGHTWEIGHT_COMMIT}\trefs/tags/v1.0.0\n"
+
+MIXED_TAGS_OUTPUT = ANNOTATED_TAGS_OUTPUT + LIGHTWEIGHT_TAGS_OUTPUT
+
+BRANCH_COMMIT = "0000111122223333444455556666777788889999"
+HEADS_AND_TAGS_OUTPUT = (
+    f"{BRANCH_COMMIT}\trefs/heads/main\n" + MIXED_TAGS_OUTPUT
+)
+
+
+class FakeCompleted:
+    """Minimal stand-in for ``subprocess.CompletedProcess``."""
+
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = ""
+
+
+def _patch_ls_remote(
+    monkeypatch: pytest.MonkeyPatch, stdout: str
+) -> list[list[str]]:
+    """Stub ``subprocess.run`` with fixed ls-remote output.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        stdout: Canned standard output for every invocation
+
+    Returns:
+        List that accumulates each command the code under test ran
+    """
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> FakeCompleted:
+        commands.append(cmd)
+        return FakeCompleted(stdout)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return commands
+
+
+# --------------------------------------------------------------------------
+# _get_remote_tag_shas
+# --------------------------------------------------------------------------
+
+
+def test_get_remote_tag_shas_prefers_peeled_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An annotated tag resolves to its commit, not to its tag object.
+
+    Core requirement: ``uses: org/repo@<tag-object-sha>`` is unusable, so the
+    tag -> SHA map must expose the peeled ``^{}`` commit.
+    """
+    commands = _patch_ls_remote(monkeypatch, ANNOTATED_TAGS_OUTPUT)
+
+    tag_shas = get_remote_tag_shas(URL, GitConfig())
+
+    assert tag_shas == {
+        "v0.12.2": V0_12_2_COMMIT,
+        "v0.1.1": V0_1_1_COMMIT,
+    }
+    assert V0_12_2_TAG_OBJECT not in tag_shas.values()
+    assert commands == [["git", "ls-remote", "--tags", URL]]
+
+
+def test_get_remote_tag_shas_lightweight_tag_uses_single_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lightweight tag has no peel line and keeps its only SHA."""
+    _patch_ls_remote(monkeypatch, LIGHTWEIGHT_TAGS_OUTPUT)
+
+    tag_shas = get_remote_tag_shas(URL, GitConfig())
+
+    assert tag_shas == {"v1.0.0": LIGHTWEIGHT_COMMIT}
+
+
+def test_get_remote_tag_shas_mixed_annotated_and_lightweight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Annotated and lightweight tags coexist in one ls-remote output."""
+    _patch_ls_remote(monkeypatch, MIXED_TAGS_OUTPUT)
+
+    tag_shas = get_remote_tag_shas(URL, GitConfig())
+
+    assert tag_shas == {
+        "v0.12.2": V0_12_2_COMMIT,
+        "v0.1.1": V0_1_1_COMMIT,
+        "v1.0.0": LIGHTWEIGHT_COMMIT,
+    }
+
+
+def test_get_remote_tag_shas_ignores_non_tag_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Branch refs never leak into the tag map."""
+    _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+
+    tag_shas = get_remote_tag_shas(URL, GitConfig())
+
+    assert "main" not in tag_shas
+    assert BRANCH_COMMIT not in tag_shas.values()
+
+
+# --------------------------------------------------------------------------
+# _get_remote_tag_object_shas / _get_annotated_tag_peels
+# --------------------------------------------------------------------------
+
+
+def test_get_remote_tag_object_shas_annotated_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only annotated tags contribute a tag-object SHA."""
+    _patch_ls_remote(monkeypatch, MIXED_TAGS_OUTPUT)
+
+    tag_objects = get_remote_tag_object_shas(URL, GitConfig())
+
+    assert tag_objects == {
+        V0_12_2_TAG_OBJECT: "v0.12.2",
+        V0_1_1_TAG_OBJECT: "v0.1.1",
+    }
+    assert LIGHTWEIGHT_COMMIT not in tag_objects
+
+
+def test_get_annotated_tag_peels_carries_tag_and_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The peel record supplies everything a remediation message needs."""
+    _patch_ls_remote(monkeypatch, ANNOTATED_TAGS_OUTPUT)
+
+    peels = get_annotated_tag_peels(URL, GitConfig())
+
+    assert peels[V0_12_2_TAG_OBJECT] == AnnotatedTagPeel(
+        tag="v0.12.2", commit_sha=V0_12_2_COMMIT
+    )
+    assert peels[V0_1_1_TAG_OBJECT].commit_sha == V0_1_1_COMMIT
+
+
+def test_annotated_tag_peel_is_frozen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The peel record is immutable, so callers cannot corrupt the map."""
+    _patch_ls_remote(monkeypatch, ANNOTATED_TAGS_OUTPUT)
+
+    peel = get_annotated_tag_peels(URL, GitConfig())[V0_12_2_TAG_OBJECT]
+
+    with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError
+        peel.commit_sha = "deadbeef"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------
+# _get_remote_ref_shas
+# --------------------------------------------------------------------------
+
+
+def test_get_remote_ref_shas_splits_commits_from_tag_objects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Commit SHAs and tag-object SHAs are disjoint and correctly assigned."""
+    commands = _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+
+    remote_refs = get_remote_ref_shas(URL, GitConfig())
+
+    assert remote_refs.commit_shas == frozenset(
+        {
+            BRANCH_COMMIT,
+            V0_12_2_COMMIT,
+            V0_1_1_COMMIT,
+            LIGHTWEIGHT_COMMIT,
+        }
+    )
+    assert set(remote_refs.tag_objects) == {
+        V0_12_2_TAG_OBJECT,
+        V0_1_1_TAG_OBJECT,
+    }
+    assert not remote_refs.commit_shas & set(remote_refs.tag_objects)
+    assert commands == [["git", "ls-remote", "--heads", "--tags", URL]]
+
+
+def test_get_all_remote_refs_still_returns_every_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy helper keeps its contract: every advertised SHA.
+
+    Existing callers rely on the union, so the split is additive rather than
+    a change to this function's meaning.
+    """
+    _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+
+    assert get_all_remote_refs(URL, GitConfig()) == {
+        BRANCH_COMMIT,
+        V0_12_2_TAG_OBJECT,
+        V0_12_2_COMMIT,
+        V0_1_1_TAG_OBJECT,
+        V0_1_1_COMMIT,
+        LIGHTWEIGHT_COMMIT,
+    }
+
+
+# --------------------------------------------------------------------------
+# _validate_commit_shas_git — the regression under test
+# --------------------------------------------------------------------------
+
+
+def test_tag_object_sha_is_annotated_tag_sha_not_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tag-object SHA is ANNOTATED_TAG_SHA, never VALID.
+
+    Regression test for the confirmed defect: ``ls-remote`` advertises the
+    tag object, so a plain set-membership test passed it, while GitHub
+    Actions cannot check it out and the API backend rejects it.
+    """
+    _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+
+    results = _validate_commit_shas_git(URL, [V0_12_2_TAG_OBJECT], GitConfig())
+
+    assert results[V0_12_2_TAG_OBJECT] == ValidationResult.ANNOTATED_TAG_SHA
+    assert results[V0_12_2_TAG_OBJECT] != ValidationResult.VALID
+    assert results[V0_12_2_TAG_OBJECT] != ValidationResult.INVALID_REFERENCE
+
+
+def test_peeled_commit_sha_is_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The commit an annotated tag peels to remains VALID."""
+    _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+
+    results = _validate_commit_shas_git(URL, [V0_12_2_COMMIT], GitConfig())
+
+    assert results[V0_12_2_COMMIT] == ValidationResult.VALID
+
+
+def test_branch_head_and_lightweight_tag_shas_are_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ordinary commit SHAs are unaffected by the tag-object split."""
+    _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+
+    results = _validate_commit_shas_git(
+        URL, [BRANCH_COMMIT, LIGHTWEIGHT_COMMIT], GitConfig()
+    )
+
+    assert results == {
+        BRANCH_COMMIT: ValidationResult.VALID,
+        LIGHTWEIGHT_COMMIT: ValidationResult.VALID,
+    }
+
+
+def test_unknown_sha_is_invalid_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SHA the remote never advertises stays INVALID_REFERENCE."""
+    _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+    unknown = "1234567890abcdef1234567890abcdef12345678"
+
+    results = _validate_commit_shas_git(URL, [unknown], GitConfig())
+
+    assert results[unknown] == ValidationResult.INVALID_REFERENCE
+
+
+def test_mixed_shas_classified_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each SHA in a batch gets its own verdict."""
+    _patch_ls_remote(monkeypatch, HEADS_AND_TAGS_OUTPUT)
+    unknown = "1234567890abcdef1234567890abcdef12345678"
+
+    results = _validate_commit_shas_git(
+        URL,
+        [V0_12_2_TAG_OBJECT, V0_1_1_COMMIT, unknown],
+        GitConfig(),
+    )
+
+    assert results == {
+        V0_12_2_TAG_OBJECT: ValidationResult.ANNOTATED_TAG_SHA,
+        V0_1_1_COMMIT: ValidationResult.VALID,
+        unknown: ValidationResult.INVALID_REFERENCE,
+    }
+
+
+# --------------------------------------------------------------------------
+# Degraded inputs
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "",
+        "\n\n",
+        "not-tab-separated output\n",
+        "sha\trefs/tags/a\textra-column\n",
+        "\trefs/tags/v1.0.0\n",
+        f"{V0_12_2_COMMIT}\t\n",
+        f"{V0_12_2_COMMIT}\trefs/tags/^{{}}\n",
+    ],
+)
+def test_malformed_ls_remote_output_degrades_safely(
+    monkeypatch: pytest.MonkeyPatch, stdout: str
+) -> None:
+    """Unparsable lines are skipped rather than raising or half-parsed."""
+    _patch_ls_remote(monkeypatch, stdout)
+
+    assert get_remote_tag_shas(URL, GitConfig()) == {}
+    assert get_remote_tag_object_shas(URL, GitConfig()) == {}
+    assert get_remote_ref_shas(URL, GitConfig()).tag_objects == {}
+
+
+def test_peel_line_matching_unpeeled_sha_is_not_annotated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Identical unpeeled and peeled SHAs mean no tag object exists."""
+    stdout = (
+        f"{LIGHTWEIGHT_COMMIT}\trefs/tags/v1.0.0\n"
+        f"{LIGHTWEIGHT_COMMIT}\trefs/tags/v1.0.0^{{}}\n"
+    )
+    _patch_ls_remote(monkeypatch, stdout)
+
+    assert get_remote_tag_object_shas(URL, GitConfig()) == {}
+    results = _validate_commit_shas_git(URL, [LIGHTWEIGHT_COMMIT], GitConfig())
+    assert results[LIGHTWEIGHT_COMMIT] == ValidationResult.VALID
+
+
+def test_ls_remote_failure_raises_git_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero exit surfaces as GitError, matching existing behaviour."""
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> FakeCompleted:
+        raise subprocess.CalledProcessError(
+            returncode=128, cmd=cmd, stderr="fatal: repository not found"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(GitError):
+        get_remote_tag_shas(URL, GitConfig())
+    with pytest.raises(GitError):
+        get_remote_ref_shas(URL, GitConfig())
+
+
+def test_ls_remote_timeout_raises_git_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout surfaces as GitError, matching existing behaviour."""
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> FakeCompleted:
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(GitError):
+        get_remote_tag_object_shas(URL, GitConfig())
+    with pytest.raises(GitError):
+        get_remote_ref_shas(URL, GitConfig())
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        subprocess.CalledProcessError(
+            returncode=128, cmd=["git"], stderr="boom"
+        ),
+        subprocess.TimeoutExpired(cmd=["git"], timeout=1),
+    ],
+)
+def test_validate_commit_shas_git_falls_back_to_invalid(
+    monkeypatch: pytest.MonkeyPatch, failure: Exception
+) -> None:
+    """Subprocess failure marks every SHA invalid, as it did before.
+
+    The tag-object split must not change how an unreachable remote is
+    handled: the caller retries with the SSH URL, and an unresolved SHA
+    ends up INVALID_REFERENCE rather than a misleading ANNOTATED_TAG_SHA.
+    """
+
+    def fake_run(_cmd: list[str], **_kwargs: object) -> FakeCompleted:
+        raise failure
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    results = _validate_commit_shas_git(
+        URL, [V0_12_2_TAG_OBJECT, V0_12_2_COMMIT], GitConfig()
+    )
+
+    assert results == {
+        V0_12_2_TAG_OBJECT: ValidationResult.INVALID_REFERENCE,
+        V0_12_2_COMMIT: ValidationResult.INVALID_REFERENCE,
+    }

--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable
     from pathlib import Path
 
     from rich.progress import Progress, TaskID
@@ -37,6 +37,7 @@ from gha_workflow_linter.models import (
     ValidationMethod,
     ValidationResult,
 )
+from gha_workflow_linter.validator import ActionCallValidator
 
 
 def parse_json_output(stdout: str) -> dict[str, Any]:
@@ -83,6 +84,72 @@ def build_all_action_calls_from_errors(
             error.action_call
         )
     return all_calls
+
+
+def stub_validator_class(
+    validate: Callable[
+        [dict[Path, dict[int, ActionCall]]], list[ValidationError]
+    ],
+) -> type[ActionCallValidator]:
+    """Build a validator class whose validation step is replaced.
+
+    ``cli.py`` does ``from .validator import ActionCallValidator`` at
+    import time, so patching ``gha_workflow_linter.validator``'s attribute
+    has no effect on the CLI: the name has to be replaced where it is
+    looked up, ``gha_workflow_linter.cli.ActionCallValidator``.
+
+    Subclassing the real validator, rather than substituting a bare mock,
+    keeps every other method genuine. That matters for
+    ``get_validation_summary``, which the CLI calls on the same instance
+    to produce the error counts these tests assert on; a mock would return
+    a mock and the assertions would be meaningless.
+
+    Args:
+        validate: Callable invoked with the scanner's action calls, keyed
+            by file path then by line number, returning the validation
+            errors the CLI should see.
+
+    Returns:
+        A drop-in replacement for ``ActionCallValidator`` that performs no
+        network access.
+    """
+
+    class StubValidator(ActionCallValidator):
+        """Validator reporting pre-computed errors, without network use."""
+
+        def validate_action_calls(
+            self,
+            action_calls: dict[Path, dict[int, ActionCall]],
+            progress: Progress | None = None,
+            task_id: TaskID | None = None,
+        ) -> list[ValidationError]:
+            """Return the errors supplied by the enclosing factory."""
+            return validate(action_calls)
+
+    return StubValidator
+
+
+def iter_calls(
+    action_calls: dict[Path, dict[int, ActionCall]],
+) -> list[tuple[Path, ActionCall]]:
+    """Flatten scanner results into ``(file_path, action_call)`` pairs.
+
+    ``validate_action_calls`` receives a mapping of file path to a mapping
+    of line number to action call. Stubs want the individual calls, paired
+    with the file they came from so the resulting ``ValidationError``
+    points at the right file.
+
+    Args:
+        action_calls: Scanner results as passed to the validator.
+
+    Returns:
+        One ``(file_path, action_call)`` pair per action call.
+    """
+    return [
+        (file_path, call)
+        for file_path, calls in action_calls.items()
+        for call in calls.values()
+    ]
 
 
 class TestAutoFixBehaviorWithPinnedSHA:
@@ -541,114 +608,109 @@ jobs:
 
         runner = CliRunner()
 
-        # Mock git operations for CLI test
-        with patch(
-            "gha_workflow_linter.validator.ActionCallValidator"
-        ) as mock_validator_class:
-            mock_validator = AsyncMock()
-            mock_validator_class.return_value = mock_validator
-
-            # Configure mock to return validation errors for all non-SHA references
-            def mock_validate_calls(
-                calls: Iterable[ActionCall],
-                _progress: Progress | None = None,
-                _task: TaskID | None = None,
-            ) -> list[ValidationError]:
-                errors = []
-                for call in calls:
-                    if call.reference in [
-                        "invalid-branch",
-                        "master",
-                        "v4",
-                        "v3.8.1",
-                        "v2",
-                    ]:
-                        errors.append(
-                            ValidationError(
-                                file_path=workflow_file,
-                                action_call=call,
-                                result=ValidationResult.INVALID_REFERENCE
-                                if call.reference == "invalid-branch"
-                                else ValidationResult.NOT_PINNED_TO_SHA,
-                                error_message="Invalid action call"
-                                if call.reference == "invalid-branch"
-                                else "Action not pinned to SHA",
-                            )
+        # Configure the validator to report errors for all non-SHA
+        # references, so the run exercises auto-fix rather than the
+        # network.
+        def mock_validate_calls(
+            action_calls: dict[Path, dict[int, ActionCall]],
+        ) -> list[ValidationError]:
+            errors: list[ValidationError] = []
+            for file_path, call in iter_calls(action_calls):
+                if call.reference in [
+                    "invalid-branch",
+                    "master",
+                    "v4",
+                    "v3.8.1",
+                    "v2",
+                ]:
+                    errors.append(
+                        ValidationError(
+                            file_path=file_path,
+                            action_call=call,
+                            result=ValidationResult.INVALID_REFERENCE
+                            if call.reference == "invalid-branch"
+                            else ValidationResult.NOT_PINNED_TO_SHA,
+                            error_message="Invalid action call"
+                            if call.reference == "invalid-branch"
+                            else "Action not pinned to SHA",
                         )
-                return errors
+                    )
+            return errors
 
-            mock_validator.validate_action_calls = mock_validate_calls
-
-            # Mock auto-fixer
-            with patch(
+        # Mock git operations and the auto-fixer for this CLI test
+        with (
+            patch(
+                "gha_workflow_linter.cli.ActionCallValidator",
+                stub_validator_class(mock_validate_calls),
+            ),
+            patch(
                 "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class:
-                mock_auto_fixer = AsyncMock()
-                mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                    mock_auto_fixer
-                )
+            ) as mock_auto_fixer_class,
+        ):
+            mock_auto_fixer = AsyncMock()
+            mock_auto_fixer_class.return_value.__aenter__.return_value = (
+                mock_auto_fixer
+            )
 
-                # Mock that it fixes all 5 issues
-                mock_auto_fixer.fix_validation_errors.return_value = (
-                    {
-                        workflow_file: [
-                            {
-                                "line_number": "9",
-                                "old_line": "uses: actions/checkout@invalid-branch",
-                                "new_line": "uses: actions/checkout@abc123",
-                            },
-                            {
-                                "line_number": "12",
-                                "old_line": "uses: actions/checkout@master",
-                                "new_line": "uses: actions/checkout@def456",
-                            },
-                            {
-                                "line_number": "15",
-                                "old_line": "uses: actions/setup-python@v4",
-                                "new_line": "uses: actions/setup-python@ghi789",
-                            },
-                            {
-                                "line_number": "18",
-                                "old_line": "uses: actions/setup-node@v3.8.1",
-                                "new_line": "uses: actions/setup-node@jkl012",
-                            },
-                            {
-                                "line_number": "21",
-                                "old_line": "uses: actions/upload-artifact@v2",
-                                "new_line": "uses: actions/upload-artifact@mno345",
-                            },
-                        ]
-                    },
-                    {"actions_moved": 0, "calls_updated": 0},
-                    {},
-                )
+            # Mock that it fixes all 5 issues
+            mock_auto_fixer.fix_validation_errors.return_value = (
+                {
+                    workflow_file: [
+                        {
+                            "line_number": "9",
+                            "old_line": "uses: actions/checkout@invalid-branch",
+                            "new_line": "uses: actions/checkout@abc123",
+                        },
+                        {
+                            "line_number": "12",
+                            "old_line": "uses: actions/checkout@master",
+                            "new_line": "uses: actions/checkout@def456",
+                        },
+                        {
+                            "line_number": "15",
+                            "old_line": "uses: actions/setup-python@v4",
+                            "new_line": "uses: actions/setup-python@ghi789",
+                        },
+                        {
+                            "line_number": "18",
+                            "old_line": "uses: actions/setup-node@v3.8.1",
+                            "new_line": "uses: actions/setup-node@jkl012",
+                        },
+                        {
+                            "line_number": "21",
+                            "old_line": "uses: actions/upload-artifact@v2",
+                            "new_line": "uses: actions/upload-artifact@mno345",
+                        },
+                    ]
+                },
+                {"actions_moved": 0, "calls_updated": 0},
+                {},
+            )
 
-                # Run CLI with require-pinned-sha (default is True)
-                result = runner.invoke(
-                    app,
-                    [
-                        "lint",
-                        str(temp_dir),
-                        "--auto-fix",
-                        "--auto-latest",
-                        "--validation-method",
-                        "git",
-                        "--format",
-                        "json",
-                    ],
-                )
+            # Run CLI with require-pinned-sha (default is True)
+            result = runner.invoke(
+                app,
+                [
+                    "lint",
+                    str(temp_dir),
+                    "--auto-fix",
+                    "--auto-latest",
+                    "--validation-method",
+                    "git",
+                    "--format",
+                    "json",
+                ],
+            )
 
-                # Should exit with code 1 (files were modified)
-                assert result.exit_code == 1
+            # Should exit with code 1 (files were modified)
+            assert result.exit_code == 1
 
-                # Parse JSON output for structured validation
-                output_data = parse_json_output(result.stdout)
-                assert output_data["validation_summary"]["total_errors"] == 5
+            # Parse JSON output for structured validation
+            output_data = parse_json_output(result.stdout)
+            assert output_data["validation_summary"]["total_errors"] == 5
 
-                # Verify the file was actually modified
-                assert (
-                    workflow_file.read_text() != workflow_with_mixed_references
-                )
+            # Verify the file was actually modified
+            assert workflow_file.read_text() != workflow_with_mixed_references
 
     def test_cli_auto_fix_with_pinned_sha_not_required(
         self,
@@ -673,105 +735,94 @@ validation_method: git
 
         runner = CliRunner()
 
-        with patch(
-            "gha_workflow_linter.validator.ActionCallValidator"
-        ) as mock_validator_class:
-            mock_validator = AsyncMock()
-            mock_validator_class.return_value = mock_validator
+        # When require_pinned_sha=False, only invalid references are errors
+        def mock_validate_calls(
+            action_calls: dict[Path, dict[int, ActionCall]],
+        ) -> list[ValidationError]:
+            return [
+                ValidationError(
+                    file_path=file_path,
+                    action_call=call,
+                    result=ValidationResult.INVALID_REFERENCE,
+                    error_message="Invalid action call",
+                )
+                for file_path, call in iter_calls(action_calls)
+                if call.reference == "invalid-branch"
+            ]
 
-            # When require_pinned_sha=False, only invalid references are errors
-            def mock_validate_calls(
-                calls: Iterable[ActionCall],
-                _progress: Progress | None = None,
-                _task: TaskID | None = None,
-            ) -> list[ValidationError]:
-                errors = []
-                for call in calls:
-                    if (
-                        call.reference == "invalid-branch"
-                    ):  # Only invalid refs are errors
-                        errors.append(
-                            ValidationError(
-                                file_path=workflow_file,
-                                action_call=call,
-                                result=ValidationResult.INVALID_REFERENCE,
-                                error_message="Invalid action call",
-                            )
-                        )
-                return errors
-
-            mock_validator.validate_action_calls = mock_validate_calls
-
-            with patch(
+        with (
+            patch(
+                "gha_workflow_linter.cli.ActionCallValidator",
+                stub_validator_class(mock_validate_calls),
+            ),
+            patch(
                 "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class:
-                mock_auto_fixer = AsyncMock()
-                mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                    mock_auto_fixer
+            ) as mock_auto_fixer_class,
+        ):
+            mock_auto_fixer = AsyncMock()
+            mock_auto_fixer_class.return_value.__aenter__.return_value = (
+                mock_auto_fixer
+            )
+
+            # Mock that it fixes all 5 issues (1 invalid ref + 4 version updates due to auto_latest)
+            mock_auto_fixer.fix_validation_errors.return_value = (
+                {
+                    workflow_file: [
+                        {
+                            "line_number": "9",
+                            "old_line": "uses: actions/checkout@invalid-branch",
+                            "new_line": "uses: actions/checkout@abc123",
+                        },
+                        {
+                            "line_number": "12",
+                            "old_line": "uses: actions/checkout@master",
+                            "new_line": "uses: actions/checkout@def456",
+                        },
+                        {
+                            "line_number": "15",
+                            "old_line": "uses: actions/setup-python@v4",
+                            "new_line": "uses: actions/setup-python@ghi789",
+                        },
+                        {
+                            "line_number": "18",
+                            "old_line": "uses: actions/setup-node@v3.8.1",
+                            "new_line": "uses: actions/setup-node@jkl012",
+                        },
+                        {
+                            "line_number": "21",
+                            "old_line": "uses: actions/upload-artifact@v2",
+                            "new_line": "uses: actions/upload-artifact@mno345",
+                        },
+                    ]
+                },
+                {"actions_moved": 0, "calls_updated": 0},
+                {},
+            )
+
+            result = runner.invoke(
+                app,
+                [
+                    "lint",
+                    str(temp_dir),
+                    "--config",
+                    str(config_file),
+                    "--format",
+                    "json",
+                ],
+            )
+
+            # Should complete successfully
+            if result.exit_code in (0, 1):
+                # Parse JSON output for structured validation
+                output_data = parse_json_output(result.stdout)
+                # Only 1 validation error (require_pinned_sha=False, so tags/branches are valid)
+                # But auto_latest=True updates all actions to latest versions
+                assert output_data["validation_summary"]["total_errors"] >= 1
+
+                # Verify the file was modified
+                assert (
+                    workflow_file.read_text() != workflow_with_mixed_references
                 )
-
-                # Mock that it fixes all 5 issues (1 invalid ref + 4 version updates due to auto_latest)
-                mock_auto_fixer.fix_validation_errors.return_value = (
-                    {
-                        workflow_file: [
-                            {
-                                "line_number": "9",
-                                "old_line": "uses: actions/checkout@invalid-branch",
-                                "new_line": "uses: actions/checkout@abc123",
-                            },
-                            {
-                                "line_number": "12",
-                                "old_line": "uses: actions/checkout@master",
-                                "new_line": "uses: actions/checkout@def456",
-                            },
-                            {
-                                "line_number": "15",
-                                "old_line": "uses: actions/setup-python@v4",
-                                "new_line": "uses: actions/setup-python@ghi789",
-                            },
-                            {
-                                "line_number": "18",
-                                "old_line": "uses: actions/setup-node@v3.8.1",
-                                "new_line": "uses: actions/setup-node@jkl012",
-                            },
-                            {
-                                "line_number": "21",
-                                "old_line": "uses: actions/upload-artifact@v2",
-                                "new_line": "uses: actions/upload-artifact@mno345",
-                            },
-                        ]
-                    },
-                    {"actions_moved": 0, "calls_updated": 0},
-                    {},
-                )
-
-                result = runner.invoke(
-                    app,
-                    [
-                        "lint",
-                        str(temp_dir),
-                        "--config",
-                        str(config_file),
-                        "--format",
-                        "json",
-                    ],
-                )
-
-                # Should complete successfully
-                if result.exit_code in (0, 1):
-                    # Parse JSON output for structured validation
-                    output_data = parse_json_output(result.stdout)
-                    # Only 1 validation error (require_pinned_sha=False, so tags/branches are valid)
-                    # But auto_latest=True updates all actions to latest versions
-                    assert (
-                        output_data["validation_summary"]["total_errors"] >= 1
-                    )
-
-                    # Verify the file was modified
-                    assert (
-                        workflow_file.read_text()
-                        != workflow_with_mixed_references
-                    )
 
     def test_error_count_summary_with_pinned_sha_required(
         self,
@@ -785,89 +836,81 @@ validation_method: git
 
         runner = CliRunner()
 
-        with patch(
-            "gha_workflow_linter.validator.ActionCallValidator"
-        ) as mock_validator_class:
-            mock_validator = AsyncMock()
-            mock_validator_class.return_value = mock_validator
-
-            # All non-SHA references should be errors when require_pinned_sha=True
-            def mock_validate_calls(
-                calls: Iterable[ActionCall],
-                _progress: Progress | None = None,
-                _task: TaskID | None = None,
-            ) -> list[ValidationError]:
-                errors = []
-                for call in calls:
-                    if call.reference in [
-                        "invalid-branch",
-                        "master",
-                        "v4",
-                        "v3.8.1",
-                        "v2",
-                    ]:
-                        if call.reference == "invalid-branch":
-                            errors.append(
-                                ValidationError(
-                                    file_path=workflow_file,
-                                    action_call=call,
-                                    result=ValidationResult.INVALID_REFERENCE,
-                                    error_message="Invalid action call",
-                                )
+        # All non-SHA references should be errors when require_pinned_sha=True
+        def mock_validate_calls(
+            action_calls: dict[Path, dict[int, ActionCall]],
+        ) -> list[ValidationError]:
+            errors: list[ValidationError] = []
+            for file_path, call in iter_calls(action_calls):
+                if call.reference in [
+                    "invalid-branch",
+                    "master",
+                    "v4",
+                    "v3.8.1",
+                    "v2",
+                ]:
+                    if call.reference == "invalid-branch":
+                        errors.append(
+                            ValidationError(
+                                file_path=file_path,
+                                action_call=call,
+                                result=ValidationResult.INVALID_REFERENCE,
+                                error_message="Invalid action call",
                             )
-                        else:
-                            errors.append(
-                                ValidationError(
-                                    file_path=workflow_file,
-                                    action_call=call,
-                                    result=ValidationResult.NOT_PINNED_TO_SHA,
-                                    error_message="Action not pinned to SHA",
-                                )
+                        )
+                    else:
+                        errors.append(
+                            ValidationError(
+                                file_path=file_path,
+                                action_call=call,
+                                result=ValidationResult.NOT_PINNED_TO_SHA,
+                                error_message="Action not pinned to SHA",
                             )
-                return errors
+                        )
+            return errors
 
-            mock_validator.validate_action_calls = mock_validate_calls
-
-            with patch(
+        with (
+            patch(
+                "gha_workflow_linter.cli.ActionCallValidator",
+                stub_validator_class(mock_validate_calls),
+            ),
+            patch(
                 "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class:
-                mock_auto_fixer = AsyncMock()
-                mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                    mock_auto_fixer
-                )
-                mock_auto_fixer.fix_validation_errors.return_value = (
-                    {},
-                    {"actions_moved": 0, "calls_updated": 0},
-                    {},
-                )
+            ) as mock_auto_fixer_class,
+        ):
+            mock_auto_fixer = AsyncMock()
+            mock_auto_fixer_class.return_value.__aenter__.return_value = (
+                mock_auto_fixer
+            )
+            mock_auto_fixer.fix_validation_errors.return_value = (
+                {},
+                {"actions_moved": 0, "calls_updated": 0},
+                {},
+            )
 
-                result = runner.invoke(
-                    app,
-                    [
-                        "lint",
-                        str(temp_dir),
-                        "--auto-fix",
-                        "--validation-method",
-                        "git",
-                        "--format",
-                        "json",
-                    ],
-                )
+            result = runner.invoke(
+                app,
+                [
+                    "lint",
+                    str(temp_dir),
+                    "--auto-fix",
+                    "--validation-method",
+                    "git",
+                    "--format",
+                    "json",
+                ],
+            )
 
-                if result.exit_code in (0, 1):
-                    # Parse JSON output for structured validation
-                    output_data = parse_json_output(result.stdout)
-                    assert (
-                        output_data["validation_summary"]["total_errors"] == 5
-                    )
-                    assert (
-                        output_data["validation_summary"]["invalid_references"]
-                        == 1
-                    )
-                    assert (
-                        output_data["validation_summary"]["not_pinned_to_sha"]
-                        == 4
-                    )
+            if result.exit_code in (0, 1):
+                # Parse JSON output for structured validation
+                output_data = parse_json_output(result.stdout)
+                assert output_data["validation_summary"]["total_errors"] == 5
+                assert (
+                    output_data["validation_summary"]["invalid_references"] == 1
+                )
+                assert (
+                    output_data["validation_summary"]["not_pinned_to_sha"] == 4
+                )
 
     def test_error_count_summary_with_pinned_sha_not_required(
         self,
@@ -1276,67 +1319,59 @@ jobs:
 
         runner = CliRunner()
 
-        with patch(
-            "gha_workflow_linter.validator.ActionCallValidator"
-        ) as mock_validator_class:
-            mock_validator = AsyncMock()
-            mock_validator_class.return_value = mock_validator
+        # Only action calls should be validated for SHA pinning
+        def mock_validate_calls(
+            action_calls: dict[Path, dict[int, ActionCall]],
+        ) -> list[ValidationError]:
+            return [
+                ValidationError(
+                    file_path=file_path,
+                    action_call=call,
+                    result=ValidationResult.NOT_PINNED_TO_SHA,
+                    error_message="Action not pinned to SHA",
+                )
+                for file_path, call in iter_calls(action_calls)
+                if call.call_type == ActionCallType.ACTION
+                and call.reference in ["v3", "v4"]
+            ]
 
-            # Only action calls should be validated for SHA pinning
-            def mock_validate_calls(
-                calls: Iterable[ActionCall],
-                _progress: Progress | None = None,
-                _task: TaskID | None = None,
-            ) -> list[ValidationError]:
-                errors = []
-                for call in calls:
-                    if (
-                        call.call_type == ActionCallType.ACTION
-                        and call.reference in ["v3", "v4"]
-                    ):
-                        errors.append(
-                            ValidationError(
-                                file_path=workflow_file,
-                                action_call=call,
-                                result=ValidationResult.NOT_PINNED_TO_SHA,
-                                error_message="Action not pinned to SHA",
-                            )
-                        )
-                return errors
-
-            mock_validator.validate_action_calls = mock_validate_calls
-
-            with patch(
+        with (
+            patch(
+                "gha_workflow_linter.cli.ActionCallValidator",
+                stub_validator_class(mock_validate_calls),
+            ),
+            patch(
                 "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class:
-                mock_auto_fixer = AsyncMock()
-                mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                    mock_auto_fixer
-                )
-                mock_auto_fixer.fix_validation_errors.return_value = (
-                    {},
-                    {"actions_moved": 0, "calls_updated": 0},
-                    {},
-                )
+            ) as mock_auto_fixer_class,
+        ):
+            mock_auto_fixer = AsyncMock()
+            mock_auto_fixer_class.return_value.__aenter__.return_value = (
+                mock_auto_fixer
+            )
+            mock_auto_fixer.fix_validation_errors.return_value = (
+                {},
+                {"actions_moved": 0, "calls_updated": 0},
+                {},
+            )
 
-                result = runner.invoke(
-                    app,
-                    [
-                        "lint",
-                        str(temp_dir),
-                        "--auto-fix",
-                        "--validation-method",
-                        "git",
-                    ],
-                )
+            result = runner.invoke(
+                app,
+                [
+                    "lint",
+                    str(temp_dir),
+                    "--auto-fix",
+                    "--validation-method",
+                    "git",
+                ],
+            )
 
-                # Should only flag action calls, not reusable workflows
-                assert (
-                    "Found" in result.stdout
-                    and "2" in result.stdout
-                    and "validation errors" in result.stdout
-                )
-                assert "2 actions not pinned to SHA" in result.stdout
+            # Should only flag action calls, not reusable workflows
+            assert (
+                "Found" in result.stdout
+                and "2" in result.stdout
+                and "validation errors" in result.stdout
+            )
+            assert "2 actions not pinned to SHA" in result.stdout
 
     def test_auto_fix_with_large_workflow_file(self, temp_dir: Path) -> None:
         """Test auto-fix performance with large workflow files."""
@@ -1362,61 +1397,57 @@ jobs:
 
         runner = CliRunner()
 
-        with patch(
-            "gha_workflow_linter.validator.ActionCallValidator"
-        ) as mock_validator_class:
-            mock_validator = AsyncMock()
-            mock_validator_class.return_value = mock_validator
+        # All should be validation errors (not pinned to SHA)
+        def mock_validate_calls(
+            action_calls: dict[Path, dict[int, ActionCall]],
+        ) -> list[ValidationError]:
+            return [
+                ValidationError(
+                    file_path=file_path,
+                    action_call=call,
+                    result=ValidationResult.NOT_PINNED_TO_SHA,
+                    error_message="Action not pinned to SHA",
+                )
+                for file_path, call in iter_calls(action_calls)
+            ]
 
-            # All should be validation errors (not pinned to SHA)
-            def mock_validate_calls(
-                calls: Iterable[ActionCall],
-                _progress: Progress | None = None,
-                _task: TaskID | None = None,
-            ) -> list[ValidationError]:
-                return [
-                    ValidationError(
-                        file_path=workflow_file,
-                        action_call=call,
-                        result=ValidationResult.NOT_PINNED_TO_SHA,
-                        error_message="Action not pinned to SHA",
-                    )
-                    for call in calls
-                ]
-
-            mock_validator.validate_action_calls = mock_validate_calls
-
-            with patch(
+        with (
+            patch(
+                "gha_workflow_linter.cli.ActionCallValidator",
+                stub_validator_class(mock_validate_calls),
+            ),
+            patch(
                 "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class:
-                mock_auto_fixer = AsyncMock()
-                mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                    mock_auto_fixer
-                )
-                mock_auto_fixer.fix_validation_errors.return_value = (
-                    {},
-                    {"actions_moved": 0, "calls_updated": 0},
-                    {},
-                )
+            ) as mock_auto_fixer_class,
+        ):
+            mock_auto_fixer = AsyncMock()
+            mock_auto_fixer_class.return_value.__aenter__.return_value = (
+                mock_auto_fixer
+            )
+            mock_auto_fixer.fix_validation_errors.return_value = (
+                {},
+                {"actions_moved": 0, "calls_updated": 0},
+                {},
+            )
 
-                result = runner.invoke(
-                    app,
-                    [
-                        "lint",
-                        str(temp_dir),
-                        "--auto-fix",
-                        "--validation-method",
-                        "git",
-                    ],
-                )
+            result = runner.invoke(
+                app,
+                [
+                    "lint",
+                    str(temp_dir),
+                    "--auto-fix",
+                    "--validation-method",
+                    "git",
+                ],
+            )
 
-                # Should handle all 50 action calls
-                assert (
-                    "Found" in result.stdout
-                    and "50" in result.stdout
-                    and "validation errors" in result.stdout
-                )
-                assert "50 actions not pinned to SHA" in result.stdout
+            # Should handle all 50 action calls
+            assert (
+                "Found" in result.stdout
+                and "50" in result.stdout
+                and "validation errors" in result.stdout
+            )
+            assert "50 actions not pinned to SHA" in result.stdout
 
     def test_auto_fix_with_syntax_errors(self, temp_dir: Path) -> None:
         """Test auto-fix behavior with workflows that have YAML syntax errors."""
@@ -1581,78 +1612,75 @@ jobs:
 
         runner = CliRunner()
 
-        with patch(
-            "gha_workflow_linter.validator.ActionCallValidator"
-        ) as mock_validator_class:
-            mock_validator = AsyncMock()
-            mock_validator_class.return_value = mock_validator
+        # Return errors for all workflows. The file path comes from the
+        # scanner results, so each error points at the file its call was
+        # found in rather than at whichever directory the loop above
+        # happened to leave behind.
+        def mock_validate_calls(
+            action_calls: dict[Path, dict[int, ActionCall]],
+        ) -> list[ValidationError]:
+            return [
+                ValidationError(
+                    file_path=file_path,
+                    action_call=call,
+                    result=ValidationResult.NOT_PINNED_TO_SHA,
+                    error_message="Action not pinned to SHA",
+                )
+                for file_path, call in iter_calls(action_calls)
+            ]
 
-            # Return errors for all workflows
-            def mock_validate_calls(
-                calls: Iterable[ActionCall],
-                _progress: Progress | None = None,
-                _task: TaskID | None = None,
-            ) -> list[ValidationError]:
-                return [
-                    ValidationError(
-                        file_path=workflow_dir / "test.yaml",
-                        action_call=call,
-                        result=ValidationResult.NOT_PINNED_TO_SHA,
-                        error_message="Action not pinned to SHA",
-                    )
-                    for call in calls
+        with (
+            patch(
+                "gha_workflow_linter.cli.ActionCallValidator",
+                stub_validator_class(mock_validate_calls),
+            ),
+            patch(
+                "gha_workflow_linter.auto_fix.AutoFixer"
+            ) as mock_auto_fixer_class,
+        ):
+            mock_auto_fixer = AsyncMock()
+            mock_auto_fixer_class.return_value.__aenter__.return_value = (
+                mock_auto_fixer
+            )
+
+            # Mock fixes for all files
+            fixed_files = {}
+            for workflow_dir in dirs:
+                workflow_file = workflow_dir / "test.yaml"
+                fixed_files[workflow_file] = [
+                    {
+                        "line_number": "7",
+                        "old_line": "uses: actions/checkout@v3",
+                        "new_line": "uses: actions/checkout@sha123",
+                    }
                 ]
 
-            mock_validator.validate_action_calls = mock_validate_calls
+            mock_auto_fixer.fix_validation_errors.return_value = (
+                fixed_files,
+                {"actions_moved": 0, "calls_updated": 0},
+                {},
+            )
 
-            with patch(
-                "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class:
-                mock_auto_fixer = AsyncMock()
-                mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                    mock_auto_fixer
-                )
+            result = runner.invoke(
+                app,
+                [
+                    "lint",
+                    str(temp_dir),
+                    "--auto-fix",
+                    "--auto-latest",
+                    "--validation-method",
+                    "git",
+                ],
+            )
 
-                # Mock fixes for all files
-                fixed_files = {}
-                for workflow_dir in dirs:
-                    workflow_file = workflow_dir / "test.yaml"
-                    fixed_files[workflow_file] = [
-                        {
-                            "line_number": "7",
-                            "old_line": "uses: actions/checkout@v3",
-                            "new_line": "uses: actions/checkout@sha123",
-                        }
-                    ]
-
-                mock_auto_fixer.fix_validation_errors.return_value = (
-                    fixed_files,
-                    {"actions_moved": 0, "calls_updated": 0},
-                    {},
-                )
-
-                result = runner.invoke(
-                    app,
-                    [
-                        "lint",
-                        str(temp_dir),
-                        "--auto-fix",
-                        "--auto-latest",
-                        "--validation-method",
-                        "git",
-                    ],
-                )
-
-                # Should find and fix all 3 workflow files
-                assert (
-                    "Found" in result.stdout
-                    and "3" in result.stdout
-                    and "validation errors" in result.stdout
-                )
-                assert (
-                    "Updated 3 workflow call(s) in 3 file(s)" in result.stdout
-                )
-                assert result.exit_code == 1
+            # Should find and fix all 3 workflow files
+            assert (
+                "Found" in result.stdout
+                and "3" in result.stdout
+                and "validation errors" in result.stdout
+            )
+            assert "Updated 3 workflow call(s) in 3 file(s)" in result.stdout
+            assert result.exit_code == 1
 
 
 class TestYAMLStructurePreservation:

--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -15,7 +15,10 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
+
+    from rich.progress import Progress, TaskID
 
 import pytest
 from typer.testing import CliRunner
@@ -546,7 +549,11 @@ jobs:
             mock_validator_class.return_value = mock_validator
 
             # Configure mock to return validation errors for all non-SHA references
-            def mock_validate_calls(calls, _progress=None, _task=None):
+            def mock_validate_calls(
+                calls: Iterable[ActionCall],
+                _progress: Progress | None = None,
+                _task: TaskID | None = None,
+            ) -> list[ValidationError]:
                 errors = []
                 for call in calls:
                     if call.reference in [
@@ -673,7 +680,11 @@ validation_method: git
             mock_validator_class.return_value = mock_validator
 
             # When require_pinned_sha=False, only invalid references are errors
-            def mock_validate_calls(calls, _progress=None, _task=None):
+            def mock_validate_calls(
+                calls: Iterable[ActionCall],
+                _progress: Progress | None = None,
+                _task: TaskID | None = None,
+            ) -> list[ValidationError]:
                 errors = []
                 for call in calls:
                     if (
@@ -781,7 +792,11 @@ validation_method: git
             mock_validator_class.return_value = mock_validator
 
             # All non-SHA references should be errors when require_pinned_sha=True
-            def mock_validate_calls(calls, _progress=None, _task=None):
+            def mock_validate_calls(
+                calls: Iterable[ActionCall],
+                _progress: Progress | None = None,
+                _task: TaskID | None = None,
+            ) -> list[ValidationError]:
                 errors = []
                 for call in calls:
                     if call.reference in [
@@ -1268,7 +1283,11 @@ jobs:
             mock_validator_class.return_value = mock_validator
 
             # Only action calls should be validated for SHA pinning
-            def mock_validate_calls(calls, _progress=None, _task=None):
+            def mock_validate_calls(
+                calls: Iterable[ActionCall],
+                _progress: Progress | None = None,
+                _task: TaskID | None = None,
+            ) -> list[ValidationError]:
                 errors = []
                 for call in calls:
                     if (
@@ -1350,7 +1369,11 @@ jobs:
             mock_validator_class.return_value = mock_validator
 
             # All should be validation errors (not pinned to SHA)
-            def mock_validate_calls(calls, _progress=None, _task=None):
+            def mock_validate_calls(
+                calls: Iterable[ActionCall],
+                _progress: Progress | None = None,
+                _task: TaskID | None = None,
+            ) -> list[ValidationError]:
                 return [
                     ValidationError(
                         file_path=workflow_file,
@@ -1565,7 +1588,11 @@ jobs:
             mock_validator_class.return_value = mock_validator
 
             # Return errors for all workflows
-            def mock_validate_calls(calls, _progress=None, _task=None):
+            def mock_validate_calls(
+                calls: Iterable[ActionCall],
+                _progress: Progress | None = None,
+                _task: TaskID | None = None,
+            ) -> list[ValidationError]:
                 return [
                     ValidationError(
                         file_path=workflow_dir / "test.yaml",

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -153,7 +153,7 @@ class TestSetupLogging:
             mock_root_logger = Mock()
             mock_root_logger.handlers = []
 
-            def mock_logger_factory(name=None):
+            def mock_logger_factory(name: str | None = None) -> Mock:
                 if name is None or name == "":
                     return mock_root_logger
                 return Mock()
@@ -172,7 +172,7 @@ class TestSetupLogging:
             mock_root_logger = Mock()
             mock_root_logger.handlers = []
 
-            def mock_logger_factory(name=None):
+            def mock_logger_factory(name: str | None = None) -> Mock:
                 if name is None or name == "":
                     return mock_root_logger
                 return Mock()
@@ -191,7 +191,7 @@ class TestSetupLogging:
             mock_root_logger = Mock()
             mock_root_logger.handlers = []
 
-            def mock_logger_factory(name=None):
+            def mock_logger_factory(name: str | None = None) -> Mock:
                 if name is None or name == "":
                     return mock_root_logger
                 return Mock()
@@ -211,7 +211,7 @@ class TestSetupLogging:
             mock_root_logger.handlers = []
             mock_httpx_logger = Mock()
 
-            def get_logger_side_effect(name=None):
+            def get_logger_side_effect(name: str | None = None) -> Mock:
                 if name is None or name == "":  # Root logger
                     return mock_root_logger
                 return mock_httpx_logger
@@ -547,7 +547,7 @@ class TestRunLinter:
         assert result == 0
 
     @patch("gha_workflow_linter.cli.WorkflowScanner")
-    def test_run_linter_scanner_error(self, mock_scanner_class) -> None:
+    def test_run_linter_scanner_error(self, mock_scanner_class: Mock) -> None:
         """Test linter when scanner throws error."""
         mock_scanner = Mock()
         mock_scanner_class.return_value = mock_scanner
@@ -561,7 +561,7 @@ class TestRunLinter:
     @patch("gha_workflow_linter.cli.WorkflowScanner")
     @patch("gha_workflow_linter.cli.Progress")
     def test_run_linter_no_workflows(
-        self, mock_progress, mock_scanner_class
+        self, mock_progress: Mock, mock_scanner_class: Mock
     ) -> None:
         """Test linter when no workflows are found."""
         mock_scanner = Mock()
@@ -581,7 +581,10 @@ class TestRunLinter:
     @patch("gha_workflow_linter.cli.ActionCallValidator")
     @patch("gha_workflow_linter.cli.Progress")
     def test_run_linter_validation_aborted_network_error(
-        self, mock_progress, mock_validator_class, mock_scanner_class
+        self,
+        mock_progress: Mock,
+        mock_validator_class: Mock,
+        mock_scanner_class: Mock,
     ) -> None:
         """Test linter when validation is aborted due to network error."""
         # Mock scanner
@@ -912,7 +915,7 @@ class TestCLIIntegration:
 
     @patch("gha_workflow_linter.cli.ConfigManager")
     def test_lint_command_verbose_quiet_conflict(
-        self, mock_config_manager
+        self, mock_config_manager: Mock
     ) -> None:
         """Test lint command with conflicting verbose and quiet flags."""
         mock_config_manager.return_value.load_config.return_value = Config()
@@ -956,7 +959,7 @@ class TestCLIIntegration:
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.ValidationCache")
     def test_cache_command_info(
-        self, mock_cache_class, mock_config_manager
+        self, mock_cache_class: Mock, mock_config_manager: Mock
     ) -> None:
         """Test cache info command."""
         mock_config_manager.return_value.load_config.return_value = Config()
@@ -987,7 +990,7 @@ class TestCLIIntegration:
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.ValidationCache")
     def test_cache_command_cleanup(
-        self, mock_cache_class, mock_config_manager
+        self, mock_cache_class: Mock, mock_config_manager: Mock
     ) -> None:
         """Test cache cleanup command."""
         mock_config_manager.return_value.load_config.return_value = Config()
@@ -1004,7 +1007,7 @@ class TestCLIIntegration:
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.ValidationCache")
     def test_cache_command_purge(
-        self, mock_cache_class, mock_config_manager
+        self, mock_cache_class: Mock, mock_config_manager: Mock
     ) -> None:
         """Test cache purge command."""
         mock_config_manager.return_value.load_config.return_value = Config()
@@ -1021,7 +1024,7 @@ class TestCLIIntegration:
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.ValidationCache")
     def test_cache_command_default(
-        self, mock_cache_class, mock_config_manager
+        self, mock_cache_class: Mock, mock_config_manager: Mock
     ) -> None:
         """Test cache command with no specific options (default behavior)."""
         mock_config_manager.return_value.load_config.return_value = Config()
@@ -1040,7 +1043,9 @@ class TestCLIIntegration:
         mock_cache.get_cache_info.assert_called_once()
 
     @patch("gha_workflow_linter.cli.ConfigManager")
-    def test_lint_command_config_file_error(self, mock_config_manager) -> None:
+    def test_lint_command_config_file_error(
+        self, mock_config_manager: Mock
+    ) -> None:
         """Test lint command with config file that causes an error."""
         mock_config_manager.return_value.load_config.side_effect = Exception(
             "Invalid config"

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for linter-suppression directive parsing and rendering."""
+
+from __future__ import annotations
+
+import pytest
+
+from gha_workflow_linter.directives import (
+    Directive,
+    ParsedComment,
+    Suppression,
+    SuppressionSource,
+    find_suppression,
+    parse_preceding_directive,
+    parse_trailing_comment,
+    render_comment,
+)
+
+ALLOW = Directive.ALLOW_LIST_PIN_OK
+
+
+class TestParseTrailingComment:
+    """Parsing of the trailing comment on a pinned line."""
+
+    def test_version_only_comment(self) -> None:
+        """The common case: a bare version token, no directives."""
+        parsed = parse_trailing_comment("# v0.5.1")
+        assert parsed == ParsedComment(
+            version="v0.5.1",
+            directives=frozenset(),
+            reason=None,
+            unrecognised=(),
+        )
+
+    def test_inline_directive_after_version(self) -> None:
+        """A directive may follow the version token."""
+        parsed = parse_trailing_comment("# v0.5.1 allow-list-pin-ok")
+        assert parsed.version == "v0.5.1"
+        assert parsed.directives == frozenset({ALLOW})
+        assert parsed.reason is None
+        assert parsed.unrecognised == ()
+
+    def test_directive_only_comment_has_no_version(self) -> None:
+        """A comment that is only a directive yields no version."""
+        parsed = parse_trailing_comment("# allow-list-pin-ok")
+        assert parsed.version is None
+        assert parsed.directives == frozenset({ALLOW})
+
+    def test_none_comment(self) -> None:
+        """``None`` parses to a wholly empty result."""
+        parsed = parse_trailing_comment(None)
+        assert parsed == ParsedComment(
+            version=None,
+            directives=frozenset(),
+            reason=None,
+            unrecognised=(),
+        )
+
+    @pytest.mark.parametrize("comment", ["", "   ", "#", "#   ", "##"])
+    def test_empty_comment_variants(self, comment: str) -> None:
+        """Empty (or marker-only) comments carry nothing."""
+        parsed = parse_trailing_comment(comment)
+        assert parsed.version is None
+        assert parsed.directives == frozenset()
+        assert parsed.reason is None
+        assert parsed.unrecognised == ()
+
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "# v0.5.1",
+            "v0.5.1",
+            "#v0.5.1",
+            "## v0.5.1",
+            "   #   v0.5.1   ",
+        ],
+    )
+    def test_leading_markers_and_whitespace_are_optional(
+        self, comment: str
+    ) -> None:
+        """Leading ``#`` characters and whitespace are insignificant."""
+        assert parse_trailing_comment(comment).version == "v0.5.1"
+
+    def test_repeated_directive_collapses(self) -> None:
+        """Directives are a set, so repetition is harmless."""
+        parsed = parse_trailing_comment(
+            "# v1.2.3 allow-list-pin-ok allow-list-pin-ok"
+        )
+        assert parsed.directives == frozenset({ALLOW})
+        assert parsed.unrecognised == ()
+
+
+class TestReasonParsing:
+    """Splitting of the optional ``--`` introduced reason."""
+
+    def test_reason_after_directive(self) -> None:
+        """Text after ``--`` becomes the reason, stripped."""
+        parsed = parse_trailing_comment(
+            "# v0.5.1 allow-list-pin-ok -- blocked on ONAP mirror rollout"
+        )
+        assert parsed.version == "v0.5.1"
+        assert parsed.directives == frozenset({ALLOW})
+        assert parsed.reason == "blocked on ONAP mirror rollout"
+
+    def test_reason_may_contain_a_double_dash(self) -> None:
+        """Only the first ``--`` introduces the reason."""
+        parsed = parse_trailing_comment(
+            "# v0.5.1 allow-list-pin-ok -- blocked -- see issue 42"
+        )
+        assert parsed.reason == "blocked -- see issue 42"
+
+    def test_reason_surrounding_whitespace_is_stripped(self) -> None:
+        """Extra whitespace around the reason is discarded."""
+        parsed = parse_trailing_comment(
+            "# v0.5.1 allow-list-pin-ok  --   why not   "
+        )
+        assert parsed.reason == "why not"
+
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "# v0.5.1 allow-list-pin-ok --fix",
+            "# v0.5.1 allow-list-pin-ok a--b",
+        ],
+    )
+    def test_double_dash_without_whitespace_is_not_a_reason(
+        self, comment: str
+    ) -> None:
+        """``--`` must be whitespace-delimited to introduce a reason."""
+        parsed = parse_trailing_comment(comment)
+        assert parsed.reason is None
+        assert parsed.directives == frozenset({ALLOW})
+        assert len(parsed.unrecognised) == 1
+
+    def test_trailing_double_dash_with_no_text_is_a_token(self) -> None:
+        """A dangling ``--`` introduces nothing and is preserved."""
+        parsed = parse_trailing_comment("# v0.5.1 allow-list-pin-ok --")
+        assert parsed.reason is None
+        assert parsed.unrecognised == ("--",)
+
+    def test_reason_without_directives(self) -> None:
+        """A reason parses even when no directive is present."""
+        parsed = parse_trailing_comment("# v0.5.1 -- just a note")
+        assert parsed.version == "v0.5.1"
+        assert parsed.directives == frozenset()
+        assert parsed.reason == "just a note"
+
+
+class TestUnrecognisedTokens:
+    """Verbatim preservation of tokens the linter does not know."""
+
+    def test_unrecognised_tokens_keep_order(self) -> None:
+        """Unknown tokens are kept verbatim, in their original order."""
+        parsed = parse_trailing_comment("# v0.5.1 zeta allow-list-pin-ok alpha")
+        assert parsed.version == "v0.5.1"
+        assert parsed.directives == frozenset({ALLOW})
+        assert parsed.unrecognised == ("zeta", "alpha")
+
+    def test_unrecognised_tokens_do_not_suppress(self) -> None:
+        """Unknown tokens are ignored for suppression purposes."""
+        suppression = find_suppression(
+            comment="# v0.5.1 allow-list-pin-nope",
+            preceding_line=None,
+        )
+        assert suppression is None
+
+    def test_case_variant_directive_is_unrecognised(self) -> None:
+        """Directive keywords are matched case-sensitively."""
+        parsed = parse_trailing_comment("# v0.5.1 ALLOW-LIST-PIN-OK")
+        assert parsed.directives == frozenset()
+        assert parsed.unrecognised == ("ALLOW-LIST-PIN-OK",)
+
+
+class TestParsePrecedingDirective:
+    """Parsing of a standalone directive comment line."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "# gha-workflow-linter: allow-list-pin-ok",
+            "    # gha-workflow-linter: allow-list-pin-ok",
+            "\t\t# gha-workflow-linter: allow-list-pin-ok",
+            "        #   gha-workflow-linter:   allow-list-pin-ok  ",
+        ],
+    )
+    def test_indentation_is_irrelevant(self, line: str) -> None:
+        """A directive comment may sit at any column."""
+        suppression = parse_preceding_directive(line)
+        assert suppression == Suppression(
+            directives=frozenset({ALLOW}),
+            source=SuppressionSource.PRECEDING_LINE,
+            reason=None,
+        )
+
+    def test_reason_on_preceding_line(self) -> None:
+        """The preceding form accepts a reason too."""
+        suppression = parse_preceding_directive(
+            "  # gha-workflow-linter: allow-list-pin-ok -- upstream fix"
+        )
+        assert suppression is not None
+        assert suppression.reason == "upstream fix"
+        assert suppression.source is SuppressionSource.PRECEDING_LINE
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "  config: '@8f4f0cf'  # v0.5.1",
+            "",
+            "   ",
+            "# just an ordinary comment",
+            "# allow-list-pin-ok",
+            "# gha-workflow-linter:allow-list-pin-ok",
+            "# gha-workflow-linter: unknown-directive",
+            "# gha-workflow-linter: -- only a reason",
+            "# gha-workflow-linter:",
+        ],
+    )
+    def test_non_directive_lines_return_none(self, line: str) -> None:
+        """Lines without a usable marker and directive yield ``None``."""
+        assert parse_preceding_directive(line) is None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "# GHA-WORKFLOW-LINTER: allow-list-pin-ok",
+            "# Gha-Workflow-Linter: allow-list-pin-ok",
+        ],
+    )
+    def test_marker_is_case_sensitive(self, line: str) -> None:
+        """A wrong-case marker is not recognised."""
+        assert parse_preceding_directive(line) is None
+
+    def test_unrecognised_tokens_alongside_directive(self) -> None:
+        """Unknown tokens do not prevent a valid directive."""
+        suppression = parse_preceding_directive(
+            "# gha-workflow-linter: allow-list-pin-ok extra-token"
+        )
+        assert suppression is not None
+        assert suppression.directives == frozenset({ALLOW})
+
+
+class TestFindSuppression:
+    """Resolution of the effective suppression for a pinned line."""
+
+    def test_inline_form_only(self) -> None:
+        """The inline form suppresses on its own."""
+        suppression = find_suppression(
+            comment="# v0.5.1 allow-list-pin-ok",
+            preceding_line="  with:",
+        )
+        assert suppression == Suppression(
+            directives=frozenset({ALLOW}),
+            source=SuppressionSource.INLINE_COMMENT,
+            reason=None,
+        )
+
+    def test_preceding_form_only(self) -> None:
+        """The preceding form suppresses on its own."""
+        suppression = find_suppression(
+            comment="# v0.5.1",
+            preceding_line="    # gha-workflow-linter: allow-list-pin-ok",
+        )
+        assert suppression == Suppression(
+            directives=frozenset({ALLOW}),
+            source=SuppressionSource.PRECEDING_LINE,
+            reason=None,
+        )
+
+    def test_both_forms_prefer_inline_source(self) -> None:
+        """Both forms together union directives and prefer inline."""
+        suppression = find_suppression(
+            comment="# v0.5.1 allow-list-pin-ok",
+            preceding_line="# gha-workflow-linter: allow-list-pin-ok",
+        )
+        assert suppression is not None
+        assert suppression.source is SuppressionSource.INLINE_COMMENT
+        assert suppression.directives == frozenset({ALLOW})
+
+    def test_both_forms_inline_reason_wins(self) -> None:
+        """When both carry a reason, the inline one is reported."""
+        suppression = find_suppression(
+            comment="# v0.5.1 allow-list-pin-ok -- inline reason",
+            preceding_line=(
+                "# gha-workflow-linter: allow-list-pin-ok -- other reason"
+            ),
+        )
+        assert suppression is not None
+        assert suppression.reason == "inline reason"
+
+    def test_both_forms_falls_back_to_preceding_reason(self) -> None:
+        """A reason on the preceding line is used when inline has none."""
+        suppression = find_suppression(
+            comment="# v0.5.1 allow-list-pin-ok",
+            preceding_line=(
+                "# gha-workflow-linter: allow-list-pin-ok -- mirror rollout"
+            ),
+        )
+        assert suppression is not None
+        assert suppression.reason == "mirror rollout"
+
+    def test_version_only_comment_does_not_suppress(self) -> None:
+        """The overwhelmingly common case yields no suppression."""
+        assert find_suppression(comment="# v0.5.1", preceding_line=None) is None
+
+    @pytest.mark.parametrize("comment", [None, "", "# "])
+    def test_absent_comment_does_not_suppress(
+        self, comment: str | None
+    ) -> None:
+        """Missing or empty comments yield no suppression."""
+        assert find_suppression(comment=comment, preceding_line=None) is None
+
+    def test_preceding_line_none_is_accepted(self) -> None:
+        """A ``None`` preceding line is simply ignored."""
+        suppression = find_suppression(
+            comment="# v0.5.1 allow-list-pin-ok",
+            preceding_line=None,
+        )
+        assert suppression is not None
+        assert suppression.source is SuppressionSource.INLINE_COMMENT
+
+    def test_non_comment_preceding_line_does_not_suppress(self) -> None:
+        """Only a directive comment on the previous line counts."""
+        assert (
+            find_suppression(
+                comment="# v0.5.1",
+                preceding_line="        config: '@8f4f0cf'  # v0.5.1",
+            )
+            is None
+        )
+
+
+class TestRenderComment:
+    """Re-rendering of a parsed comment."""
+
+    def test_render_version_only(self) -> None:
+        """A version-only comment renders as the bare token."""
+        parsed = parse_trailing_comment("# v0.5.1")
+        assert render_comment(parsed, version="v0.5.1") == "v0.5.1"
+
+    def test_render_omits_absent_version(self) -> None:
+        """A ``None`` version emits nothing in its place."""
+        parsed = parse_trailing_comment("# allow-list-pin-ok")
+        assert render_comment(parsed, version=None) == "allow-list-pin-ok"
+
+    def test_render_has_no_leading_hash(self) -> None:
+        """Rendering returns the body, not the comment marker."""
+        parsed = parse_trailing_comment("# v0.5.1 allow-list-pin-ok")
+        assert not render_comment(parsed, version="v0.5.1").startswith("#")
+
+    def test_render_ordering(self) -> None:
+        """Parts render as version, directives, unknowns, then reason."""
+        parsed = parse_trailing_comment(
+            "# v0.5.1 zeta allow-list-pin-ok alpha -- why"
+        )
+        assert render_comment(parsed, version="v0.5.1") == (
+            "v0.5.1 allow-list-pin-ok zeta alpha -- why"
+        )
+
+    def test_render_version_bump(self) -> None:
+        """A version bump keeps directives and reason intact."""
+        parsed = parse_trailing_comment("# v0.5.1 allow-list-pin-ok -- why")
+        rendered = render_comment(parsed, version="v0.12.2")
+        assert rendered == "v0.12.2 allow-list-pin-ok -- why"
+
+        reparsed = parse_trailing_comment(rendered)
+        assert reparsed.version == "v0.12.2"
+        assert reparsed.directives == parsed.directives
+        assert reparsed.reason == parsed.reason
+        assert reparsed.unrecognised == parsed.unrecognised
+
+    def test_render_directives_are_ordered_stably(self) -> None:
+        """Directives render alphabetically by keyword."""
+        parsed = ParsedComment(
+            version="v1.0.0",
+            directives=frozenset(Directive),
+            reason=None,
+            unrecognised=(),
+        )
+        expected = " ".join(["v1.0.0", *sorted(d.value for d in Directive)])
+        assert render_comment(parsed, version="v1.0.0") == expected
+
+
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "",
+        "# v0.5.1",
+        "# allow-list-pin-ok",
+        "# v0.5.1 allow-list-pin-ok",
+        "# v0.5.1 allow-list-pin-ok -- blocked on ONAP mirror rollout",
+        "# v0.5.1 allow-list-pin-ok -- blocked -- see issue 42",
+        "# v0.5.1 zeta allow-list-pin-ok alpha",
+        "# v0.5.1 zeta allow-list-pin-ok alpha -- because",
+        "# v0.5.1 --fix",
+        "# v0.5.1 allow-list-pin-ok --",
+        "## v0.5.1 allow-list-pin-ok",
+    ],
+)
+def test_round_trip_preserves_content(comment: str) -> None:
+    """Rendering a parsed comment preserves everything it carried."""
+    parsed = parse_trailing_comment(comment)
+    rendered = render_comment(parsed, version=parsed.version)
+    reparsed = parse_trailing_comment(rendered)
+
+    assert reparsed.version == parsed.version
+    assert reparsed.directives == parsed.directives
+    assert reparsed.reason == parsed.reason
+    assert reparsed.unrecognised == parsed.unrecognised
+
+
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "# v0.5.1",
+        "# v0.5.1 allow-list-pin-ok",
+        "# v0.5.1 allow-list-pin-ok -- reason text",
+        "# v0.5.1 zeta allow-list-pin-ok",
+    ],
+)
+def test_round_trip_across_version_bump(comment: str) -> None:
+    """A version bump is the only difference a re-render introduces."""
+    parsed = parse_trailing_comment(comment)
+    rendered = render_comment(parsed, version="v9.9.9")
+    reparsed = parse_trailing_comment(rendered)
+
+    assert reparsed.version == "v9.9.9"
+    assert reparsed.directives == parsed.directives
+    assert reparsed.reason == parsed.reason
+    assert reparsed.unrecognised == parsed.unrecognised

--- a/tests/test_end_to_end_network_error.py
+++ b/tests/test_end_to_end_network_error.py
@@ -12,6 +12,7 @@ marking valid GitHub Actions as invalid.
 from collections.abc import Generator
 from pathlib import Path
 import tempfile
+from typing import Any, NoReturn
 from unittest.mock import Mock, patch
 
 import httpx
@@ -184,7 +185,7 @@ jobs:
         options = CLIOptions(path=sample_repo_with_workflows)
 
         # Mock the validator to capture what would have been returned
-        def capture_validation_errors(*_args, **_kwargs):
+        def capture_validation_errors(*_args: Any, **_kwargs: Any) -> NoReturn:
             # This should raise ValidationAbortedError, not return ValidationError objects
             raise ValidationAbortedError(
                 "Unable to validate GitHub Actions due to API/network issues",
@@ -209,8 +210,8 @@ jobs:
             # The old behavior would have created ValidationError objects marking actions as invalid
 
     def test_precommit_ci_scenario_reproduction(
-        self, sample_repo_with_workflows
-    ):
+        self, sample_repo_with_workflows: Path
+    ) -> None:
         """
         Exact reproduction of the pre-commit.ci scenario that failed.
 

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for centralised exit codes and exit-code determination.
+
+These tests pin the contract documented in ``docs/ALLOW_LIST_FEATURE.md``
+section 8. In particular they guard the invariant that presentation
+flags never change the process exit status -- a defect that previously
+allowed ``lint``, ``lint --quiet`` and ``lint --format json`` to disagree
+about the same repository state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gha_workflow_linter import exit_codes
+from gha_workflow_linter.cli import (
+    _AutoFixOutcome,
+    _determine_exit_code,
+    _has_outdated_actions,
+    _ValidationOutcome,
+)
+from gha_workflow_linter.models import (
+    ActionCall,
+    ActionCallType,
+    Category,
+    CLIOptions,
+    Config,
+    ReferenceType,
+    Severity,
+    ValidationError,
+    ValidationResult,
+    result_category,
+)
+from gha_workflow_linter.validator import ActionCallValidator
+
+
+class TestExitCodeConstants:
+    """The documented numeric contract must not drift."""
+
+    def test_documented_values(self) -> None:
+        assert exit_codes.SUCCESS == 0
+        assert exit_codes.DEFECTS_FOUND == 1
+        assert exit_codes.CLI_USAGE_ERROR == 2
+        assert exit_codes.ALLOW_LIST_STALE == 3
+        assert exit_codes.ALLOW_LIST_UNRESOLVED == 4
+        assert exit_codes.ACTIONS_OUTDATED == 5
+
+    def test_codes_are_unique(self) -> None:
+        codes = [
+            exit_codes.SUCCESS,
+            exit_codes.DEFECTS_FOUND,
+            exit_codes.CLI_USAGE_ERROR,
+            exit_codes.ALLOW_LIST_STALE,
+            exit_codes.ALLOW_LIST_UNRESOLVED,
+            exit_codes.ACTIONS_OUTDATED,
+        ]
+        assert len(codes) == len(set(codes))
+
+    def test_usage_error_is_reserved_for_click(self) -> None:
+        """Code 2 must never be produced by our own logic."""
+        with pytest.raises(ValueError, match="Unknown exit code"):
+            exit_codes.combine(exit_codes.CLI_USAGE_ERROR)
+
+
+class TestCombine:
+    """Precedence: 4 > 3 > 5 > 1 > 0."""
+
+    def test_empty_is_success(self) -> None:
+        assert exit_codes.combine() == exit_codes.SUCCESS
+
+    def test_single_code_passes_through(self) -> None:
+        assert (
+            exit_codes.combine(exit_codes.DEFECTS_FOUND)
+            == exit_codes.DEFECTS_FOUND
+        )
+
+    @pytest.mark.parametrize(
+        ("codes", "expected"),
+        [
+            # Infrastructure failure outranks everything: an unresolved
+            # check must never look like a clean-or-stale result.
+            (
+                (exit_codes.ALLOW_LIST_UNRESOLVED, exit_codes.ALLOW_LIST_STALE),
+                exit_codes.ALLOW_LIST_UNRESOLVED,
+            ),
+            (
+                (exit_codes.ALLOW_LIST_UNRESOLVED, exit_codes.DEFECTS_FOUND),
+                exit_codes.ALLOW_LIST_UNRESOLVED,
+            ),
+            # A condition the caller specifically asked about must not be
+            # masked by the generic defect code.
+            (
+                (exit_codes.ALLOW_LIST_STALE, exit_codes.DEFECTS_FOUND),
+                exit_codes.ALLOW_LIST_STALE,
+            ),
+            (
+                (exit_codes.ACTIONS_OUTDATED, exit_codes.DEFECTS_FOUND),
+                exit_codes.ACTIONS_OUTDATED,
+            ),
+            (
+                (exit_codes.ALLOW_LIST_STALE, exit_codes.ACTIONS_OUTDATED),
+                exit_codes.ALLOW_LIST_STALE,
+            ),
+            (
+                (exit_codes.SUCCESS, exit_codes.DEFECTS_FOUND),
+                exit_codes.DEFECTS_FOUND,
+            ),
+            ((exit_codes.SUCCESS, exit_codes.SUCCESS), exit_codes.SUCCESS),
+        ],
+    )
+    def test_precedence(self, codes: tuple[int, ...], expected: int) -> None:
+        assert exit_codes.combine(*codes) == expected
+        # Order of arguments must not matter.
+        assert exit_codes.combine(*reversed(codes)) == expected
+
+    def test_rejects_unknown_code(self) -> None:
+        with pytest.raises(ValueError, match="Unknown exit code"):
+            exit_codes.combine(99)
+
+
+class TestDescribe:
+    def test_known_codes_have_descriptions(self) -> None:
+        for code in (0, 1, 2, 3, 4, 5):
+            assert "Unknown" not in exit_codes.describe(code)
+
+    def test_unknown_code(self) -> None:
+        assert exit_codes.describe(42) == "Unknown exit code 42"
+
+
+class TestResultCategory:
+    """Defect vs currency classification (design doc section 8.4)."""
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            ValidationResult.INVALID_REPOSITORY,
+            ValidationResult.INVALID_REFERENCE,
+            ValidationResult.INVALID_PATH,
+            ValidationResult.INVALID_SYNTAX,
+            ValidationResult.ANNOTATED_TAG_SHA,
+            ValidationResult.SHA_COMMENT_MISMATCH,
+        ],
+    )
+    def test_defects(self, result: ValidationResult) -> None:
+        assert result_category(result) is Category.DEFECT
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            ValidationResult.NOT_PINNED_TO_SHA,
+            ValidationResult.OUTDATED_ACTION,
+            ValidationResult.TEST_REFERENCE,
+        ],
+    )
+    def test_currency(self, result: ValidationResult) -> None:
+        assert result_category(result) is Category.CURRENCY
+
+    @pytest.mark.parametrize(
+        "result",
+        [ValidationResult.NETWORK_ERROR, ValidationResult.TIMEOUT],
+    )
+    def test_infrastructure(self, result: ValidationResult) -> None:
+        assert result_category(result) is Category.INFRASTRUCTURE
+
+    def test_valid_is_not_a_finding(self) -> None:
+        assert result_category(ValidationResult.VALID) is None
+
+    def test_every_result_is_classified(self) -> None:
+        """A new ValidationResult must be classified deliberately."""
+        for result in ValidationResult:
+            if result is ValidationResult.VALID:
+                continue
+            assert result_category(result) is not None, (
+                f"{result.value} has no category; add it to "
+                f"_RESULT_CATEGORIES in models.py"
+            )
+
+    def test_annotated_tag_sha_is_a_defect_not_currency(self) -> None:
+        """A tag-object SHA fails at run time; it is not mere staleness."""
+        assert (
+            result_category(ValidationResult.ANNOTATED_TAG_SHA)
+            is Category.DEFECT
+        )
+
+
+class TestSeverity:
+    def test_members(self) -> None:
+        assert Severity.ERROR.value == "error"
+        assert Severity.WARNING.value == "warning"
+        assert Severity.NOTICE.value == "notice"
+
+
+def _action_call(comment: str | None = None) -> ActionCall:
+    return ActionCall(
+        raw_line=f"      - uses: actions/checkout@v4  {comment or ''}",
+        line_number=1,
+        organization="actions",
+        repository="checkout",
+        reference="v4",
+        comment=comment,
+        call_type=ActionCallType.ACTION,
+        reference_type=ReferenceType.TAG,
+    )
+
+
+def _validation_error(
+    result: ValidationResult = ValidationResult.INVALID_REFERENCE,
+    comment: str | None = None,
+) -> ValidationError:
+    return ValidationError(
+        file_path=Path(".github/workflows/build.yaml"),
+        action_call=_action_call(comment),
+        result=result,
+        error_message="boom",
+    )
+
+
+def _options(**kwargs: Any) -> CLIOptions:
+    base: dict[str, Any] = {"path": Path.cwd()}
+    base.update(kwargs)
+    return CLIOptions(**base)
+
+
+def _validation(
+    errors: list[ValidationError] | None = None,
+) -> _ValidationOutcome:
+    """Build a real _ValidationOutcome so the types are exercised."""
+    return _ValidationOutcome(
+        workflow_calls={},
+        validation_errors=errors or [],
+        validator=ActionCallValidator(Config()),
+        total_calls=len(errors or []),
+    )
+
+
+def _autofix(
+    fixed_files: dict[Path, list[dict[str, str]]] | None = None,
+    stale: dict[str, list[dict[str, Any]]] | None = None,
+) -> _AutoFixOutcome:
+    return _AutoFixOutcome(
+        fixed_files or {},
+        {"actions_moved": 0, "calls_updated": 0},
+        stale or {},
+    )
+
+
+class TestDetermineExitCode:
+    def test_clean_run(self) -> None:
+        code = _determine_exit_code(_options(), _validation(), _autofix())
+        assert code == exit_codes.SUCCESS
+
+    def test_validation_errors_fail(self) -> None:
+        code = _determine_exit_code(
+            _options(),
+            _validation([_validation_error()]),
+            _autofix(),
+        )
+        assert code == exit_codes.DEFECTS_FOUND
+
+    def test_no_fail_on_error_suppresses_defects(self) -> None:
+        code = _determine_exit_code(
+            _options(fail_on_error=False),
+            _validation([_validation_error()]),
+            _autofix(),
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_test_references_do_not_fail(self) -> None:
+        code = _determine_exit_code(
+            _options(),
+            _validation([_validation_error(comment="# v4 testing")]),
+            _autofix(),
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_applied_fixes_fail(self) -> None:
+        fixed = {
+            Path("a.yaml"): [
+                {"line_number": "1", "old_line": "x", "new_line": "y"}
+            ]
+        }
+        code = _determine_exit_code(
+            _options(),
+            _validation(),
+            _autofix(fixed_files=fixed),
+        )
+        assert code == exit_codes.DEFECTS_FOUND
+
+    def test_skipped_only_fixes_do_not_fail(self) -> None:
+        fixed = {Path("a.yaml"): [{"line_number": "1", "skipped": "true"}]}
+        code = _determine_exit_code(
+            _options(),
+            _validation(),
+            _autofix(fixed_files=fixed),
+        )
+        assert code == exit_codes.SUCCESS
+
+
+class TestOutdatedActions:
+    """--verify-actions promotes currency findings to failures."""
+
+    STALE = {"build.yaml": [{"line": 3, "action": "actions/checkout"}]}
+
+    def test_outdated_advisory_by_default(self) -> None:
+        code = _determine_exit_code(
+            _options(),
+            _validation(),
+            _autofix(stale=self.STALE),
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_outdated_fails_under_verify_actions(self) -> None:
+        code = _determine_exit_code(
+            _options(verify_actions=True),
+            _validation(),
+            _autofix(stale=self.STALE),
+        )
+        assert code == exit_codes.ACTIONS_OUTDATED
+
+    def test_verify_actions_clean(self) -> None:
+        code = _determine_exit_code(
+            _options(verify_actions=True),
+            _validation(),
+            _autofix(),
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_empty_stale_lists_are_not_outdated(self) -> None:
+        assert not _has_outdated_actions(_autofix(stale={"build.yaml": []}))
+
+    def test_outdated_outranks_defects(self) -> None:
+        """A specifically-requested condition is not masked by code 1."""
+        code = _determine_exit_code(
+            _options(verify_actions=True),
+            _validation([_validation_error()]),
+            _autofix(stale=self.STALE),
+        )
+        assert code == exit_codes.ACTIONS_OUTDATED
+
+
+class TestPresentationDoesNotAffectExitCode:
+    """Regression tests for the run_linter early-return bypass.
+
+    Previously, whenever any outdated action existed, run_linter returned
+    0 without consulting _determine_exit_code -- masking real defects.
+    The guard was additionally gated on ``not options.quiet``, so the
+    exit code depended on verbosity, and ``--format json`` (which forces
+    quiet) took a different branch entirely.
+    """
+
+    STALE = {"build.yaml": [{"line": 3, "action": "actions/checkout"}]}
+
+    def test_defect_not_masked_by_outdated_actions(self) -> None:
+        """The core bug: a real error alongside an outdated action."""
+        code = _determine_exit_code(
+            _options(),
+            _validation([_validation_error()]),
+            _autofix(stale=self.STALE),
+        )
+        assert code == exit_codes.DEFECTS_FOUND
+
+    def test_applied_fixes_not_masked_by_outdated_actions(self) -> None:
+        fixed = {
+            Path("a.yaml"): [
+                {"line_number": "1", "old_line": "x", "new_line": "y"}
+            ]
+        }
+        code = _determine_exit_code(
+            _options(),
+            _validation(),
+            _autofix(fixed_files=fixed, stale=self.STALE),
+        )
+        assert code == exit_codes.DEFECTS_FOUND
+
+    @pytest.mark.parametrize(
+        "presentation",
+        [
+            {},
+            {"quiet": True},
+            {"verbose": True},
+            {"output_format": "json", "quiet": True},
+        ],
+        ids=["default", "quiet", "verbose", "json"],
+    )
+    def test_exit_code_is_independent_of_presentation(
+        self, presentation: dict[str, object]
+    ) -> None:
+        """lint, --quiet and --format json must agree on the code."""
+        code = _determine_exit_code(
+            _options(**presentation),
+            _validation([_validation_error()]),
+            _autofix(stale=self.STALE),
+        )
+        assert code == exit_codes.DEFECTS_FOUND
+
+    @pytest.mark.parametrize(
+        "presentation",
+        [
+            {},
+            {"quiet": True},
+            {"output_format": "json", "quiet": True},
+        ],
+        ids=["default", "quiet", "json"],
+    )
+    def test_clean_run_agrees_across_presentation(
+        self, presentation: dict[str, object]
+    ) -> None:
+        code = _determine_exit_code(
+            _options(**presentation),
+            _validation(),
+            _autofix(stale=self.STALE),
+        )
+        assert code == exit_codes.SUCCESS

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -143,7 +143,6 @@ class TestResultCategory:
             ValidationResult.INVALID_PATH,
             ValidationResult.INVALID_SYNTAX,
             ValidationResult.ANNOTATED_TAG_SHA,
-            ValidationResult.SHA_COMMENT_MISMATCH,
         ],
     )
     def test_defects(self, result: ValidationResult) -> None:
@@ -153,7 +152,6 @@ class TestResultCategory:
         "result",
         [
             ValidationResult.NOT_PINNED_TO_SHA,
-            ValidationResult.OUTDATED_ACTION,
             ValidationResult.TEST_REFERENCE,
         ],
     )

--- a/tests/test_file_edit.py
+++ b/tests/test_file_edit.py
@@ -1,0 +1,513 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for atomic, terminator-preserving line replacement."""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from typing import TYPE_CHECKING, Any, Literal
+
+import pytest
+
+from gha_workflow_linter.file_edit import LineChange, replace_lines
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+UTF8_BOM = b"\xef\xbb\xbf"
+
+
+def write_bytes(path: Path, name: str, content: bytes) -> Path:
+    """Create ``name`` under ``path`` with exactly ``content``."""
+    target = path / name
+    target.write_bytes(content)
+    return target
+
+
+def directory_entries(path: Path) -> list[str]:
+    """Return the sorted names of every entry in ``path``."""
+    return sorted(entry.name for entry in path.iterdir())
+
+
+class TestBasicReplacement:
+    """Straightforward single and multi-line substitutions."""
+
+    def test_replaces_a_single_line(self, tmp_path: Path) -> None:
+        """Only the requested line changes."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\nthree\n")
+
+        changes = replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\nTWO\nthree\n"
+        assert changes == [
+            LineChange(line_number=2, old_line="two", new_line="TWO")
+        ]
+
+    def test_replaces_multiple_lines(self, tmp_path: Path) -> None:
+        """Every requested line changes and the rest are untouched."""
+        target = write_bytes(tmp_path, "wf.yaml", b"a\nb\nc\nd\n")
+
+        changes = replace_lines(target, {1: "A", 3: "C"})
+
+        assert target.read_bytes() == b"A\nb\nC\nd\n"
+        assert [change.line_number for change in changes] == [1, 3]
+
+    def test_replaces_first_and_last_line(self, tmp_path: Path) -> None:
+        """The boundary line numbers are both valid."""
+        target = write_bytes(tmp_path, "wf.yaml", b"first\nmiddle\nlast\n")
+
+        replace_lines(target, {1: "FIRST", 3: "LAST"})
+
+        assert target.read_bytes() == b"FIRST\nmiddle\nLAST\n"
+
+    def test_replaces_the_only_line(self, tmp_path: Path) -> None:
+        """A single-line file is handled like any other."""
+        target = write_bytes(tmp_path, "wf.yaml", b"solo\n")
+
+        replace_lines(target, {1: "SOLO"})
+
+        assert target.read_bytes() == b"SOLO\n"
+
+    def test_preserves_non_ascii_content(self, tmp_path: Path) -> None:
+        """UTF-8 content round-trips through the rewrite."""
+        original = "café\nnaïve\n".encode()
+        target = write_bytes(tmp_path, "wf.yaml", original)
+
+        changes = replace_lines(target, {1: "résumé"})
+
+        assert target.read_bytes() == "résumé\nnaïve\n".encode()
+        assert changes[0].old_line == "café"
+
+    def test_replacement_may_be_empty(self, tmp_path: Path) -> None:
+        """Blanking a line leaves its terminator in place."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+
+        replace_lines(target, {1: ""})
+
+        assert target.read_bytes() == b"\ntwo\n"
+
+    def test_removes_its_temporary_file(self, tmp_path: Path) -> None:
+        """A successful rewrite leaves no debris behind."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+
+        replace_lines(target, {1: "ONE"})
+
+        assert directory_entries(tmp_path) == ["wf.yaml"]
+
+
+class TestLineEndings:
+    """Each line keeps the terminator it started with."""
+
+    def test_lf_file_stays_lf(self, tmp_path: Path) -> None:
+        """A pure LF file is not converted."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\nthree\n")
+
+        replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\nTWO\nthree\n"
+
+    def test_crlf_file_stays_crlf(self, tmp_path: Path) -> None:
+        """A pure CRLF file is not silently normalised to LF."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\r\ntwo\r\nthree\r\n")
+
+        changes = replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\r\nTWO\r\nthree\r\n"
+        assert changes[0].old_line == "two"
+
+    def test_cr_only_file_stays_cr_only(self, tmp_path: Path) -> None:
+        """Classic Mac line endings survive too."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\rtwo\rthree\r")
+
+        replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\rTWO\rthree\r"
+
+    def test_mixed_endings_are_preserved_per_line(self, tmp_path: Path) -> None:
+        """Every line keeps its own terminator, not the file's first."""
+        target = write_bytes(tmp_path, "wf.yaml", b"crlf\r\nlf\ncr\rnone")
+
+        changes = replace_lines(
+            target, {1: "CRLF", 2: "LF", 3: "CR", 4: "NONE"}
+        )
+
+        assert target.read_bytes() == b"CRLF\r\nLF\nCR\rNONE"
+        assert [change.old_line for change in changes] == [
+            "crlf",
+            "lf",
+            "cr",
+            "none",
+        ]
+
+    def test_untouched_lines_keep_their_endings(self, tmp_path: Path) -> None:
+        """Lines outside the replacement set are byte-identical."""
+        target = write_bytes(tmp_path, "wf.yaml", b"keep\r\nchange\nkeep\r")
+
+        replace_lines(target, {2: "CHANGED"})
+
+        assert target.read_bytes() == b"keep\r\nCHANGED\nkeep\r"
+
+
+class TestTrailingNewline:
+    """The file's trailing-newline state is never altered."""
+
+    def test_missing_final_newline_is_not_added(self, tmp_path: Path) -> None:
+        """Replacing the unterminated last line does not terminate it."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo")
+
+        changes = replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\nTWO"
+        assert changes[0].old_line == "two"
+
+    def test_missing_final_newline_survives_earlier_edit(
+        self, tmp_path: Path
+    ) -> None:
+        """Editing an earlier line does not terminate the last one."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo")
+
+        replace_lines(target, {1: "ONE"})
+
+        assert target.read_bytes() == b"ONE\ntwo"
+
+    def test_trailing_newline_is_kept(self, tmp_path: Path) -> None:
+        """A terminated last line stays terminated."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+
+        replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\nTWO\n"
+
+    def test_trailing_crlf_is_kept(self, tmp_path: Path) -> None:
+        """A terminated last CRLF line keeps its full terminator."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\r\ntwo\r\n")
+
+        replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\r\nTWO\r\n"
+
+    def test_single_line_without_newline(self, tmp_path: Path) -> None:
+        """A one-line, unterminated file gains nothing."""
+        target = write_bytes(tmp_path, "wf.yaml", b"solo")
+
+        replace_lines(target, {1: "SOLO"})
+
+        assert target.read_bytes() == b"SOLO"
+
+
+class TestByteOrderMark:
+    """A UTF-8 BOM is preserved and never introduced."""
+
+    def test_bom_is_preserved(self, tmp_path: Path) -> None:
+        """The BOM is written back exactly once, at the start."""
+        target = write_bytes(tmp_path, "wf.yaml", UTF8_BOM + b"one\ntwo\n")
+
+        replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == UTF8_BOM + b"one\nTWO\n"
+
+    def test_bom_is_excluded_from_reported_content(
+        self, tmp_path: Path
+    ) -> None:
+        """The BOM is not leaked into the first line's content."""
+        target = write_bytes(tmp_path, "wf.yaml", UTF8_BOM + b"one\ntwo\n")
+
+        changes = replace_lines(target, {1: "ONE"})
+
+        assert changes[0].old_line == "one"
+        assert target.read_bytes() == UTF8_BOM + b"ONE\ntwo\n"
+
+    def test_bom_is_not_introduced(self, tmp_path: Path) -> None:
+        """A file without a BOM does not acquire one."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+
+        replace_lines(target, {1: "ONE"})
+
+        assert not target.read_bytes().startswith(UTF8_BOM)
+
+
+class TestValidation:
+    """Invalid input is rejected before the file is rewritten."""
+
+    @pytest.mark.parametrize("line_number", [0, -1, -100, 4, 99])
+    def test_out_of_range_line_number_raises(
+        self, tmp_path: Path, line_number: int
+    ) -> None:
+        """Line numbers outside ``1..len(lines)`` are refused."""
+        original = b"one\ntwo\nthree\n"
+        target = write_bytes(tmp_path, "wf.yaml", original)
+
+        with pytest.raises(ValueError, match="out of range"):
+            replace_lines(target, {line_number: "NOPE"})
+
+        assert target.read_bytes() == original
+
+    def test_out_of_range_rejects_the_whole_batch(self, tmp_path: Path) -> None:
+        """One bad line number prevents every replacement."""
+        original = b"one\ntwo\n"
+        target = write_bytes(tmp_path, "wf.yaml", original)
+
+        with pytest.raises(ValueError, match="out of range"):
+            replace_lines(target, {1: "ONE", 5: "FIVE"})
+
+        assert target.read_bytes() == original
+
+    def test_any_line_number_raises_for_empty_file(
+        self, tmp_path: Path
+    ) -> None:
+        """An empty file has no lines to replace."""
+        target = write_bytes(tmp_path, "wf.yaml", b"")
+
+        with pytest.raises(ValueError, match="0 line"):
+            replace_lines(target, {1: "ONE"})
+
+    @pytest.mark.parametrize(
+        "replacement",
+        ["a\nb", "trailing\n", "\ncarriage", "a\r\nb", "a\rb"],
+    )
+    def test_embedded_newline_raises(
+        self, tmp_path: Path, replacement: str
+    ) -> None:
+        """A replacement must be exactly one line."""
+        original = b"one\ntwo\n"
+        target = write_bytes(tmp_path, "wf.yaml", original)
+
+        with pytest.raises(ValueError, match="embedded line terminator"):
+            replace_lines(target, {1: replacement})
+
+        assert target.read_bytes() == original
+
+    def test_embedded_newline_reports_the_line_number(
+        self, tmp_path: Path
+    ) -> None:
+        """The error identifies the offending replacement."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+
+        with pytest.raises(ValueError, match="line 2"):
+            replace_lines(target, {2: "bad\nvalue"})
+
+    def test_missing_file_raises_os_error(self, tmp_path: Path) -> None:
+        """A nonexistent path surfaces the underlying OS error."""
+        with pytest.raises(OSError):
+            replace_lines(tmp_path / "absent.yaml", {1: "ONE"})
+
+
+class TestEmptyReplacements:
+    """An empty mapping is a legal no-op."""
+
+    def test_returns_empty_list(self, tmp_path: Path) -> None:
+        """Nothing to do means nothing reported."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+
+        assert replace_lines(target, {}) == []
+
+    def test_does_not_touch_the_file(self, tmp_path: Path) -> None:
+        """Content and mtime are both left alone."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+        before = target.stat()
+
+        replace_lines(target, {})
+
+        after = target.stat()
+        assert target.read_bytes() == b"one\ntwo\n"
+        assert after.st_mtime_ns == before.st_mtime_ns
+        assert directory_entries(tmp_path) == ["wf.yaml"]
+
+    def test_does_not_require_the_file_to_exist(self, tmp_path: Path) -> None:
+        """The no-op short-circuits before any I/O."""
+        assert replace_lines(tmp_path / "absent.yaml", {}) == []
+
+
+class PartialWriter:
+    """Handle wrapper that fails midway through ``writelines``."""
+
+    def __init__(self, handle: Any) -> None:
+        self._handle = handle
+
+    def __enter__(self) -> PartialWriter:
+        return self
+
+    def __exit__(self, *exc_info: object) -> Literal[False]:
+        self._handle.close()
+        return False
+
+    def writelines(self, lines: list[str]) -> None:
+        """Write the first line only, then fail as a full disk would."""
+        for line in lines[:1]:
+            self._handle.write(line)
+        raise OSError("simulated disk full")
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._handle, name)
+
+
+class TestAtomicity:
+    """Failures leave the original intact and no debris behind."""
+
+    @pytest.fixture
+    def target(self, tmp_path: Path) -> Path:
+        """A small workflow file used by the failure-injection tests."""
+        return write_bytes(tmp_path, "wf.yaml", b"one\ntwo\nthree\n")
+
+    def test_partial_write_leaves_original_unchanged(
+        self,
+        tmp_path: Path,
+        target: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A crash mid-write never truncates the user's file."""
+        real_fdopen = os.fdopen
+        calls = {"count": 0}
+
+        def failing_fdopen(*args: Any, **kwargs: Any) -> Any:
+            calls["count"] += 1
+            handle = real_fdopen(*args, **kwargs)
+            if calls["count"] > 1:
+                return handle
+            return PartialWriter(handle)
+
+        monkeypatch.setattr(os, "fdopen", failing_fdopen)
+
+        with pytest.raises(OSError, match="simulated disk full"):
+            replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\ntwo\nthree\n"
+        assert directory_entries(tmp_path) == ["wf.yaml"]
+
+    def test_failed_rename_leaves_original_unchanged(
+        self,
+        tmp_path: Path,
+        target: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed publish step is cleaned up completely."""
+
+        def failing_replace(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(os, "replace", failing_replace)
+
+        with pytest.raises(OSError, match="simulated rename failure"):
+            replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\ntwo\nthree\n"
+        assert directory_entries(tmp_path) == ["wf.yaml"]
+
+    def test_cleanup_failure_does_not_mask_the_error(
+        self,
+        target: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The original error propagates even if cleanup fails."""
+
+        def failing_replace(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError("simulated rename failure")
+
+        def failing_unlink(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError("simulated unlink failure")
+
+        monkeypatch.setattr(os, "replace", failing_replace)
+        monkeypatch.setattr(os, "unlink", failing_unlink)
+
+        with pytest.raises(OSError, match="simulated rename failure"):
+            replace_lines(target, {2: "TWO"})
+
+        assert target.read_bytes() == b"one\ntwo\nthree\n"
+
+    def test_temporary_file_is_created_beside_the_original(
+        self,
+        tmp_path: Path,
+        target: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``os.replace`` must not cross a filesystem boundary."""
+        observed: list[str] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def recording_mkstemp(*args: Any, **kwargs: Any) -> Any:
+            observed.append(str(kwargs["dir"]))
+            return real_mkstemp(*args, **kwargs)
+
+        monkeypatch.setattr(tempfile, "mkstemp", recording_mkstemp)
+
+        replace_lines(target, {1: "ONE"})
+
+        assert observed == [str(tmp_path)]
+
+
+class TestPermissions:
+    """The original file mode survives the rename."""
+
+    @pytest.mark.parametrize("mode", [0o600, 0o644, 0o664])
+    def test_mode_is_preserved(self, tmp_path: Path, mode: int) -> None:
+        """A rewritten file keeps the permissions it had."""
+        target = write_bytes(tmp_path, "wf.yaml", b"one\ntwo\n")
+        target.chmod(mode)
+
+        replace_lines(target, {1: "ONE"})
+
+        assert stat.S_IMODE(target.stat().st_mode) == mode
+
+    def test_executable_bit_is_preserved(self, tmp_path: Path) -> None:
+        """Even unusual modes are copied onto the replacement."""
+        target = write_bytes(tmp_path, "script.sh", b"#!/bin/sh\nexit 0\n")
+        target.chmod(0o755)
+
+        replace_lines(target, {2: "exit 1"})
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o755
+        assert target.read_bytes() == b"#!/bin/sh\nexit 1\n"
+
+
+class TestReturnedChanges:
+    """The reported changes describe exactly what happened."""
+
+    def test_changes_are_sorted_by_line_number(self, tmp_path: Path) -> None:
+        """Ordering does not depend on the mapping's insertion order."""
+        target = write_bytes(tmp_path, "wf.yaml", b"a\nb\nc\nd\ne\n")
+
+        changes = replace_lines(target, {5: "E", 1: "A", 3: "C"})
+
+        assert [change.line_number for change in changes] == [1, 3, 5]
+
+    def test_changes_describe_old_and_new_content(self, tmp_path: Path) -> None:
+        """Terminators are excluded from both sides of the change."""
+        target = write_bytes(tmp_path, "wf.yaml", b"a\r\nb\r\n")
+
+        changes = replace_lines(target, {1: "A", 2: "B"})
+
+        assert changes == [
+            LineChange(line_number=1, old_line="a", new_line="A"),
+            LineChange(line_number=2, old_line="b", new_line="B"),
+        ]
+
+    def test_unchanged_content_is_still_reported(self, tmp_path: Path) -> None:
+        """A no-op replacement still yields a ``LineChange``."""
+        target = write_bytes(tmp_path, "wf.yaml", b"same\nother\n")
+
+        changes = replace_lines(target, {1: "same"})
+
+        assert changes == [
+            LineChange(line_number=1, old_line="same", new_line="same")
+        ]
+        assert target.read_bytes() == b"same\nother\n"
+
+    def test_change_count_matches_replacement_count(
+        self, tmp_path: Path
+    ) -> None:
+        """One change is reported per requested line."""
+        target = write_bytes(tmp_path, "wf.yaml", b"a\nb\nc\n")
+
+        changes = replace_lines(target, {1: "A", 2: "B", 3: "C"})
+
+        assert len(changes) == 3
+
+    def test_line_change_is_frozen(self) -> None:
+        """``LineChange`` instances are immutable value objects."""
+        change = LineChange(line_number=1, old_line="a", new_line="A")
+
+        with pytest.raises(AttributeError):
+            change.line_number = 2  # type: ignore[misc]

--- a/tests/test_github_api_comprehensive.py
+++ b/tests/test_github_api_comprehensive.py
@@ -151,7 +151,9 @@ class TestGitHubGraphQLClient:
         ]
 
         # Mock method returns results for each repository separately
-        def mock_validate_refs(repo_key, _refs):
+        def mock_validate_refs(
+            repo_key: str, _refs: list[str]
+        ) -> dict[str, bool]:
             if repo_key == "actions/checkout":
                 return {"v4": True}
             elif repo_key == "actions/setup-node":
@@ -733,7 +735,9 @@ class TestGitHubGraphQLClientIntegration:
         ]
 
         # Mock method returns results for each repository separately
-        def mock_validate_refs(repo_key, _refs):
+        def mock_validate_refs(
+            repo_key: str, _refs: list[str]
+        ) -> dict[str, bool]:
             if repo_key == "actions/checkout":
                 return {"v4": True}
             elif repo_key == "actions/setup-node":

--- a/tests/test_network_error_handling.py
+++ b/tests/test_network_error_handling.py
@@ -304,7 +304,9 @@ class TestValidatorErrorHandling:
             # Mock the GitHub client - first call succeeds, second call fails
             with patch.object(validator, "_github_client") as mock_client:
                 # Repository validation succeeds
-                async def mock_repo_validation(*_args, **_kwargs):
+                async def mock_repo_validation(
+                    *_args: Any, **_kwargs: Any
+                ) -> dict[str, bool]:
                     return {"actions/checkout": True}  # Repository exists
 
                 mock_client.validate_repositories_batch = mock_repo_validation

--- a/tests/test_scanner_yaml_tree.py
+++ b/tests/test_scanner_yaml_tree.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the scanner's composed YAML node tree.
+
+``WorkflowScanner.compose_workflow_file`` exposes PyYAML's node tree so
+consumers can map document structure back onto source positions. These
+tests pin the guarantees that API makes -- source marks, the failure
+contract -- and, just as importantly, document two things it does *not*
+guarantee: comments survive, and a bare ``on:`` key stays a string.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gha_workflow_linter.models import Config
+from gha_workflow_linter.scanner import WorkflowScanner
+
+# Line numbers in the assertions below are 0-based indices into this
+# string, matching PyYAML's ``Mark.line``. The comments name each index
+# so the fixture and the assertions cannot drift apart silently.
+WORKFLOW = """\
+---
+name: Test Workflow
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      # Pin the action to a commit SHA
+      - uses: actions/checkout@v5  # v5.0.0
+"""
+LINE_NAME = 1
+LINE_ON = 3
+LINE_PUSH = 4
+LINE_JOBS = 6
+LINE_RUNS_ON = 8
+LINE_USES = 11
+
+
+@pytest.fixture
+def scanner() -> WorkflowScanner:
+    """Return a scanner backed by the default configuration."""
+    return WorkflowScanner(Config())
+
+
+@pytest.fixture
+def workflow_file(tmp_path: Path) -> Path:
+    """Write ``WORKFLOW`` to a workflow file and return its path."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    path = workflows / "test.yaml"
+    path.write_text(WORKFLOW, encoding="utf-8")
+    return path
+
+
+def mapping_pairs(
+    node: yaml.nodes.Node,
+) -> list[tuple[yaml.nodes.ScalarNode, yaml.nodes.Node]]:
+    """
+    Return the ``(key, value)`` node pairs of a composed mapping.
+
+    Args:
+        node: A node expected to be a ``MappingNode``.
+
+    Returns:
+        The mapping's pairs, in document order.
+    """
+    assert isinstance(node, yaml.nodes.MappingNode)
+    pairs: list[tuple[yaml.nodes.ScalarNode, yaml.nodes.Node]] = []
+    for key_node, value_node in node.value:
+        assert isinstance(key_node, yaml.nodes.ScalarNode)
+        assert isinstance(value_node, yaml.nodes.Node)
+        pairs.append((key_node, value_node))
+    return pairs
+
+
+def key_nodes(node: yaml.nodes.Node) -> dict[str, yaml.nodes.ScalarNode]:
+    """
+    Return a composed mapping's key nodes, keyed by their raw text.
+
+    Args:
+        node: A node expected to be a ``MappingNode``.
+
+    Returns:
+        Mapping of raw key text to the key's scalar node.
+    """
+    return {str(key.value): key for key, _ in mapping_pairs(node)}
+
+
+def value_nodes(node: yaml.nodes.Node) -> dict[str, yaml.nodes.Node]:
+    """
+    Return a composed mapping's value nodes, keyed by raw key text.
+
+    Args:
+        node: A node expected to be a ``MappingNode``.
+
+    Returns:
+        Mapping of raw key text to the key's value node.
+    """
+    return {str(key.value): value for key, value in mapping_pairs(node)}
+
+
+class TestComposeWorkflowFile:
+    """Test the composed node tree and its source marks."""
+
+    def test_returns_root_mapping_node(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """A valid workflow composes to a mapping node."""
+        root = scanner.compose_workflow_file(workflow_file)
+
+        assert isinstance(root, yaml.nodes.MappingNode)
+        assert list(key_nodes(root)) == ["name", "on", "jobs"]
+
+    def test_scalar_nodes_carry_source_marks(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Key and value nodes carry 0-based line and column marks."""
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+        keys = key_nodes(root)
+
+        assert keys["name"].start_mark.line == LINE_NAME
+        assert keys["name"].start_mark.column == 0
+        assert keys["on"].start_mark.line == LINE_ON
+        assert keys["jobs"].start_mark.line == LINE_JOBS
+
+    def test_value_nodes_carry_source_marks(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Marks are available for values, not only for keys."""
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+
+        name_value = value_nodes(root)["name"]
+        assert isinstance(name_value, yaml.nodes.ScalarNode)
+        assert name_value.value == "Test Workflow"
+        assert name_value.start_mark.line == LINE_NAME
+        # "name: " is six characters, so the value starts at column 6.
+        assert name_value.start_mark.column == 6
+
+    def test_marks_reach_nested_nodes(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Marks survive into deeply nested mappings."""
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+
+        build = value_nodes(value_nodes(root)["jobs"])["build"]
+        runs_on = key_nodes(build)["runs-on"]
+
+        assert runs_on.start_mark.line == LINE_RUNS_ON
+
+    def test_marks_reach_sequence_items(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Sequence entries carry marks too, not just mapping keys."""
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+
+        build = value_nodes(value_nodes(root)["jobs"])["build"]
+        steps = value_nodes(build)["steps"]
+        assert isinstance(steps, yaml.nodes.SequenceNode)
+        first_step = steps.value[0]
+        assert isinstance(first_step, yaml.nodes.MappingNode)
+
+        assert key_nodes(first_step)["uses"].start_mark.line == LINE_USES
+
+    def test_end_marks_are_present(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Nodes expose an end mark as well as a start mark."""
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+        name_key = key_nodes(root)["name"]
+
+        assert name_key.end_mark.line == LINE_NAME
+        assert name_key.end_mark.column == len("name")
+
+
+class TestComposeWorkflowFileFailureModes:
+    """Test that composition never raises and returns None instead."""
+
+    def test_invalid_yaml_returns_none(
+        self,
+        scanner: WorkflowScanner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Malformed YAML yields None and a warning, not an exception."""
+        path = tmp_path / "broken.yaml"
+        path.write_text("name: Test\non: [push\njobs: {\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            assert scanner.compose_workflow_file(path) is None
+
+        assert "Invalid YAML" in caplog.text
+
+    def test_missing_file_returns_none(
+        self,
+        scanner: WorkflowScanner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-existent path yields None and a warning."""
+        path = tmp_path / "does-not-exist.yaml"
+
+        with caplog.at_level(logging.WARNING):
+            assert scanner.compose_workflow_file(path) is None
+
+        assert "Error reading file" in caplog.text
+
+    def test_unreadable_path_returns_none(
+        self, scanner: WorkflowScanner, tmp_path: Path
+    ) -> None:
+        """A directory in place of a file yields None, not an OSError."""
+        directory = tmp_path / "workflows"
+        directory.mkdir()
+
+        assert scanner.compose_workflow_file(directory) is None
+
+    def test_empty_file_returns_none(
+        self, scanner: WorkflowScanner, tmp_path: Path
+    ) -> None:
+        """An empty document composes to None, same as a failure.
+
+        This is PyYAML's behaviour, not a decision of the scanner: there
+        is no node to return. Callers that need to distinguish "empty"
+        from "unparsable" must inspect the file themselves.
+        """
+        path = tmp_path / "empty.yaml"
+        path.write_text("", encoding="utf-8")
+
+        assert scanner.compose_workflow_file(path) is None
+
+    def test_comment_only_file_returns_none(
+        self, scanner: WorkflowScanner, tmp_path: Path
+    ) -> None:
+        """A file holding only comments is an empty document."""
+        path = tmp_path / "comments.yaml"
+        path.write_text("# just a comment\n", encoding="utf-8")
+
+        assert scanner.compose_workflow_file(path) is None
+
+
+class TestComposeWorkflowFileGotchas:
+    """Document what the node tree deliberately does not carry."""
+
+    def test_bare_on_key_resolves_to_yaml_11_boolean(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """A bare ``on:`` key is a YAML 1.1 boolean, not the string "on".
+
+        ``SafeLoader`` implements YAML 1.1 resolution, where ``on`` is one
+        of the boolean spellings. In the composed tree the key node keeps
+        its raw text -- ``"on"`` -- but carries the *bool* tag, and any
+        consumer that later constructs Python objects (``yaml.safe_load``)
+        sees the key ``True``. A tree walker matching workflow triggers
+        must therefore accept both ``"on"`` and ``True``.
+        """
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+        on_key = key_nodes(root)["on"]
+
+        # In the node tree the key is still the raw text "on" ...
+        assert on_key.value == "on"
+        # ... but the resolver has already tagged it as a boolean.
+        assert on_key.tag == "tag:yaml.org,2002:bool"
+
+        # The trigger mapping underneath is unaffected and still marked.
+        triggers = value_nodes(root)["on"]
+        assert key_nodes(triggers)["push"].start_mark.line == LINE_PUSH
+
+        # Confirm the consequence rather than assuming it: constructing
+        # the same document produces the key True, not "on".
+        loaded = yaml.safe_load(WORKFLOW)
+        assert isinstance(loaded, dict)
+        assert True in loaded
+        assert "on" not in loaded
+        assert list(loaded) == ["name", True, "jobs"]
+
+    def test_other_keys_keep_the_string_tag(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Only YAML 1.1 boolean spellings are retagged."""
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+        keys = key_nodes(root)
+
+        assert keys["name"].tag == "tag:yaml.org,2002:str"
+        assert keys["jobs"].tag == "tag:yaml.org,2002:str"
+
+    def test_comments_are_absent_from_the_node_tree(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Comments are lexical and do not survive composition.
+
+        The fixture carries both a standalone comment and a trailing
+        ``# v5.0.0`` version pin. PyYAML drops both while scanning, so no
+        node anywhere in the tree mentions them. Recovering a version-pin
+        comment requires reading the source line, not the node tree.
+        """
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+
+        assert "# Pin the action to a commit SHA" in WORKFLOW
+        assert "# v5.0.0" in WORKFLOW
+
+        scalars = [
+            str(node.value)
+            for node in walk(root)
+            if isinstance(node, yaml.nodes.ScalarNode)
+        ]
+        assert scalars
+        assert not any("#" in value for value in scalars)
+
+    def test_uses_scalar_excludes_its_trailing_comment(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """The ``uses:`` value stops before its trailing comment."""
+        root = scanner.compose_workflow_file(workflow_file)
+        assert root is not None
+
+        uses_values = [
+            str(node.value)
+            for node in walk(root)
+            if isinstance(node, yaml.nodes.ScalarNode)
+            and str(node.value).startswith("actions/checkout")
+        ]
+
+        assert uses_values == ["actions/checkout@v5"]
+
+
+def walk(node: yaml.nodes.Node) -> list[yaml.nodes.Node]:
+    """
+    Return ``node`` and every node beneath it, depth first.
+
+    Args:
+        node: Root of the subtree to walk.
+
+    Returns:
+        The subtree's nodes, starting with ``node`` itself.
+    """
+    nodes: list[yaml.nodes.Node] = [node]
+    if isinstance(node, yaml.nodes.MappingNode):
+        for key_node, value_node in mapping_pairs(node):
+            nodes.extend(walk(key_node))
+            nodes.extend(walk(value_node))
+    elif isinstance(node, yaml.nodes.SequenceNode):
+        for child in node.value:
+            assert isinstance(child, yaml.nodes.Node)
+            nodes.extend(walk(child))
+    return nodes
+
+
+class TestComposeSharesTheSyntaxGate:
+    """Test that the refactored validity gate still behaves."""
+
+    def test_parse_workflow_file_still_rejects_invalid_yaml(
+        self, scanner: WorkflowScanner, tmp_path: Path
+    ) -> None:
+        """The gate in parse_workflow_file survives the shared parse."""
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        path = workflows / "broken.yaml"
+        path.write_text(
+            "name: Test\non: [push\n  - uses: actions/checkout@v5\n",
+            encoding="utf-8",
+        )
+
+        assert scanner.parse_workflow_file(path) == {}
+        assert scanner.compose_workflow_file(path) is None
+
+    def test_parse_workflow_file_still_accepts_valid_yaml(
+        self, scanner: WorkflowScanner, workflow_file: Path
+    ) -> None:
+        """Valid workflows still yield their action calls."""
+        calls = scanner.parse_workflow_file(workflow_file)
+
+        assert [call.reference for call in calls.values()] == ["v5"]
+
+    def test_is_valid_yaml_agrees_with_compose(
+        self, scanner: WorkflowScanner
+    ) -> None:
+        """An empty document is valid even though it composes to None."""
+        path = Path("empty.yaml")
+
+        assert scanner._is_valid_yaml("", path) is True
+        assert scanner._compose("", path).node is None
+        assert scanner._is_valid_yaml("a: [b\n", path) is False

--- a/tests/test_validator_comprehensive.py
+++ b/tests/test_validator_comprehensive.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -528,7 +529,9 @@ class TestActionCallValidator:
         workflow_calls = {Path("test.yml"): {1: action_call}}
 
         # Mock the async method
-        async def mock_async_validate(*_args, **_kwargs):
+        async def mock_async_validate(
+            *_args: Any, **_kwargs: Any
+        ) -> dict[Any, Any]:
             return {}
 
         with patch.object(


### PR DESCRIPTION
## Summary

Phase 0 of the allow-list pin detection work tracked in #296 (and
lfreleng-actions/.github#146). It ships independently of that feature:
it fixes **three confirmed bugs**, hardens the type-checking gate, and
lays down the shared primitives the later phases need.

The full design for the allow-list feature is added as
`docs/ALLOW_LIST_FEATURE.md`; no allow-list detection code lands here.

> [!WARNING]
> **Breaking change.** Repositories that previously exited `0` while
> carrying real defects now exit `1`. CI that was accidentally green may
> go red on upgrade. See "Bug 2" below.

## Bug 1 — the git backend passed annotated tag object SHAs

`git ls-remote --tags` advertises two lines per annotated tag:

```console
$ git ls-remote --tags git@github.com:lfreleng-actions/.github.git | grep v0.12.2
8f363565e79650362c3359ee23b6d6fd295866ee  refs/tags/v0.12.2      # tag object
bf6642f68d58c1b81bbe993e676d6cc339ac3654  refs/tags/v0.12.2^{}   # commit
```

`_get_all_remote_refs` collected the SHA from **both**, so a reference
pinned to a tag-object SHA was reported `VALID`. GitHub Actions cannot
check out a tag object, so this was a false pass on a reference that
fails at run time. The GitHub API backend rejected the same reference,
meaning the verdict depended on whether a token happened to be available.

This matters here specifically: every `lfreleng-actions` release uses
annotated tags, so copying a SHA from `git rev-parse vX.Y.Z` rather than
`git rev-parse vX.Y.Z^{commit}` silently produces a broken pin.

## Bug 2 — `run_linter` bypassed exit-code determination

Whenever any outdated action existed, `run_linter` returned `0` without
consulting `_determine_exit_code`, discarding unfixed validation errors
*and* the "files were modified" signal. The guard was further gated on
`not options.quiet`, so the exit code depended on verbosity, and
`--format json` (which forces quiet) took a different branch entirely.

Verified against a workflow carrying both a defect and an outdated
action:

| | `lint` | `--quiet` | `--format json` | files modified |
| --- | --- | --- | --- | --- |
| before | **0** ❌ | 1 | 1 | YES |
| after | 1 ✅ | 1 | 1 | YES |

A default-mode pre-commit run therefore rewrote workflow files and
reported success. Reporting and exit-code determination are now fully
separated, with a regression test asserting the three modes agree.

## Bug 3 — findings were detected but never surfaced

Fixing bug 1 was not enough on its own. `_validate_references_stage`
collapsed the backend's `ValidationResult` to a `bool`, so
`_combine_validation_results` still emitted a generic
`INVALID_REFERENCE` — "Invalid branch, tag, or commit SHA", with no
indication of what was wrong or how to fix it.

References now carry a `ReferenceFinding` (specific result plus the
annotated-tag peel) from either backend through to the report:

```text
lfreleng-actions/.github@8f363565...  # v0.12.2
  Reference is the SHA of the annotated tag object for v0.12.2, not
  a commit. GitHub Actions cannot check out a tag object. Use the
  peeled commit instead: bf6642f68d58c1b81bbe993e676d6cc339ac3654
```

Peel context is captured during the batch that already ran `ls-remote`
or the GraphQL query, so there is no extra round trip. Cached findings
replay their stored message, so a cache hit does not degrade back to the
generic result. **Both backends now agree on the verdict and the
message.**

## Type-checking coverage was not comprehensive

The `basedpyright` hook carried `files: ^src/.+\.py$`, so `tests/`,
`scripts/` and `examples/` were never checked. That let real findings
through — dead `isinstance` narrowing in `tests/conftest.py` and 49
unannotated mock parameters.

The hook now carries **no `files:` filter at all**, so a new top-level
Python directory is covered the day it appears rather than when someone
remembers to widen a regex. `[tool.basedpyright] include` is kept in
step for editors and bare invocations. Verified by reverting the
`conftest.py` fix and confirming the hook fails on it.

Widening surfaced 49 `reportMissingParameterType` errors, all fixed with
types derived from the real signatures in `src/` rather than blanket
`Any`.

## Also included

- **`exit_codes.py`** centralises the contract (`0` success, `1`
  defects, `2` reserved for Click, `3`/`4` allow-list, `5` actions) and
  the precedence `4 > 3 > 5 > 1 > 0`. `RUNTIME_ERROR` aliases
  `DEFECTS_FOUND` so call sites state which they mean while behaviour is
  preserved; splitting them is deferred to a future major.
- **`Severity` / `Category`** classify findings as `DEFECT`, `CURRENCY`
  or `INFRASTRUCTURE`, so enforcement can distinguish "wrong now" from
  "could be newer". A test asserts every `ValidationResult` is
  classified, so new members must be triaged deliberately.
- **`--verify-actions`** promotes outdated action calls to errors
  (exit `5`), mirroring the planned `--verify-allow-list`.
- **`file_edit.py`** — atomic, line-ending-preserving line writer, to
  replace the truncating rewrite in `auto_fix` (wired up in phase 3).
- **`directives.py`** — parses the `allow-list-pin-ok` suppression
  directive in both authoring forms.
- **`git_refs.py`**, **`validator_findings.py`** — extractions keeping
  `git_validator.py` and `validator.py` under the aislop size limits.
- **`WorkflowScanner.compose_workflow_file`** exposes the composed YAML
  node tree with line/column marks. `_is_valid_yaml` previously parsed
  and discarded; both now share one parse instead of reading each file
  twice.

## Two things reviewers should look at

**1. A latent test bug is fixed here.** Six tests in `test_auto_fix.py`
patched `validator.ActionCallValidator`, but `cli.py` binds that name at
import time, so the mocks were **never invoked** and the tests silently
exercised the real validator over the network. They now patch
`cli.ActionCallValidator`. One also built every error with a leaked loop
variable, so all three assertions pointed at the same directory. No
assertion was weakened; each was checked against its original intent.

Note the same pattern remains for `patch("...auto_fix.AutoFixer")` in
five of those tests — left alone as out of scope, worth a follow-up.

**2. Running the linter on itself caught a bug the unit tests could
not.** The first draft of the GraphQL change selected `tagName`, which
exists on `Release` but not on `Tag`, so every GraphQL validation
aborted. The tests mock `_execute_graphql_query`, so only a live call
could find it.

**Deliberately deferred:** `SHA_COMMENT_MISMATCH` and `OUTDATED_ACTION`
were drafted and then removed — nothing emits them yet, so they were
dead branches in the message table and summary counters. They return
with the phase that produces them.

**One gate was narrowed:** `write-good` now excludes
`docs/ALLOW_LIST_FEATURE.md` by name (not the whole directory, so future
prose stays covered). It produced ~200 findings on that file, flagging
`"only"`, `"deliberately"` and `"silently"` — words that carry precise
meaning in a specification. Reversible in one line if you disagree.

## Validation

- **703 → 929 tests**, zero regressions; coverage 80%+ (gate 70%)
- `ruff`, `ruff format`, `mypy --strict`, `basedpyright --strict`,
  `markdownlint`, `reuse`, `codespell`, `aislop`, `yamllint`,
  `actionlint` — all pass
- Exercised end to end against live GitHub, both backends, confirming
  identical verdict and message

Closes #296 (phase 0 only; detection and remediation follow).
