### PR TITLE
Feat: detect and fix stale harden-runner allow-list pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ MANIFEST
 
 # Node
 node_modules/*
+
+# aislop scan history (generated per-run, machine-local)
+.aislop/history.jsonl

--- a/README.md
+++ b/README.md
@@ -268,6 +268,104 @@ latest release remains inside the window.
 > release dates, so the linter skips candidates it cannot date while a
 > cooldown applies.
 
+### Allow-List Pin Checking
+
+The `lfreleng-actions` organisation pins its
+[`step-security/harden-runner`](https://github.com/step-security/harden-runner)
+egress allow-list using a custom `uses:`-style coordinate consumed by
+[`harden-runner-block-action`][hrba]:
+
+[hrba]: https://github.com/lfreleng-actions/harden-runner-block-action
+
+<!-- markdownlint-disable MD013 -->
+
+```yaml
+# Internal workflow, shorthand form
+- uses: lfreleng-actions/harden-runner-block-action@6db537b3...  # v0.2.1
+  with:
+    config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+# Reusable-workflow input default, explicit path form
+harden_runner_allowlist:
+  type: string
+  default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@bf6642f6...'  # v0.12.2
+```
+
+<!-- markdownlint-enable MD013 -->
+
+These are values of `config:` and `default:` keys, **not** `uses:`
+references, so Dependabot cannot see or bump them. They drift without
+warning, and a stale pin means a block-mode job lacks newly allow-listed
+endpoints, producing confusing `ECONNREFUSED` failures long after
+someone corrected the allow-list itself.
+
+The linter detects these pins, resolves the host repository's latest
+release (dereferencing the annotated tag to its commit), and reports
+pins that lag behind.
+
+```bash
+# Detect stale pins; reports them but never fails (the default)
+gha-workflow-linter lint
+
+# Fail the run when stale pins remain
+gha-workflow-linter lint --verify-allow-list
+
+# Skip the check entirely
+gha-workflow-linter lint --no-allow-list
+
+# Show pins silenced by a suppression directive
+gha-workflow-linter lint --show-suppressed
+```
+
+This check follows an `lfreleng-actions` convention rather than
+GitHub-native validation, so it stays **advisory by default**: the
+linter reports findings as warnings and leaves the exit code alone.
+Enforcement is opt-in via `--verify-allow-list`. When the linter cannot
+resolve the latest release (no token, no network, rate limited), the
+default mode prints a notice and carries on; under
+`--verify-allow-list` it exits `4` instead of passing.
+
+A pin counts as stale when the target is newer, and not otherwise.
+It leaves a repository already ahead of the cooldown-eligible release
+alone, so a cooldown never recommends a downgrade.
+
+#### Suppressing a deliberate pin
+
+A repository may hold a pin at an older version on purpose. The linter
+accepts either of two forms:
+
+<!-- markdownlint-disable MD013 -->
+
+```yaml
+    # gha-workflow-linter: allow-list-pin-ok -- waiting on ONAP rollout
+    config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
+
+    config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1 allow-list-pin-ok
+```
+
+<!-- markdownlint-enable MD013 -->
+
+The preceding-line form must sit on the line directly above the pin, at
+any indentation. An optional reason may follow ` -- ` and appears in
+reports. Both forms stay inert at run time: the action never sees them.
+
+The linter excludes a suppressed pin from both reporting and
+enforcement, but still lists it under `--format json` with
+`"suppressed": true`, and every run prints a one-line count so
+suppressions stay visible.
+
+Suppression covers **currency** and nothing else. A pin whose version comment
+disagrees with its SHA, or whose spec breaks the grammar, counts as a
+defect regardless of intent and stays reported.
+
+#### Resolving the organisation
+
+The `@<sha>` shorthand resolves its host organisation from the workflow's
+own organisation. The linter infers this from `GITHUB_REPOSITORY_OWNER`,
+then the `upstream` git remote, then `origin`. Contributors working from
+a personal fork should pass `--allow-list-org` explicitly, since `origin`
+would otherwise resolve to a `.github` repository that does not exist.
+
 ### As a Pre-commit Hook
 
 Add to your `.pre-commit-config.yaml`:

--- a/README.md
+++ b/README.md
@@ -315,7 +315,18 @@ gha-workflow-linter lint --no-allow-list
 
 # Show pins silenced by a suppression directive
 gha-workflow-linter lint --show-suppressed
+
+# Rewrite stale pins in place
+gha-workflow-linter lint --update-allow-list
 ```
+
+`--update-allow-list` changes the reference and its version comment and
+nothing else. Quoting style, the spacing before `#`, the comment's
+position (inside or outside the quotes) and any suppression directive
+all survive the edit, so the resulting diff stays reviewable. Writes are
+atomic and preserve the file's existing line endings. As with the action
+fixer, a run that modifies files exits `1` so a pre-commit hook or CI job
+notices that the tree changed.
 
 This check follows an `lfreleng-actions` convention rather than
 GitHub-native validation, so it stays **advisory by default**: the
@@ -349,8 +360,9 @@ The preceding-line form must sit on the line directly above the pin, at
 any indentation. An optional reason may follow ` -- ` and appears in
 reports. Both forms stay inert at run time: the action never sees them.
 
-The linter excludes a suppressed pin from both reporting and
-enforcement, but still lists it under `--format json` with
+The linter excludes a suppressed pin from reporting, enforcement **and
+remediation**: `--update-allow-list` leaves it alone. It still lists it
+under `--format json` with
 `"suppressed": true`, and every run prints a one-line count so
 suppressions stay visible.
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,23 @@ then the `upstream` git remote, then `origin`. Contributors working from
 a personal fork should pass `--allow-list-org` explicitly, since `origin`
 would otherwise resolve to a `.github` repository that does not exist.
 
+### What Gets Scanned
+
+The linter walks the tree below the path you give it, collecting
+`.github/workflows/*.y{a,}ml` at any depth plus `action.y{a,}ml` files.
+
+Scanning **stops at nested repository boundaries**. Git worktrees,
+submodules and vendored clones each place a `.git` entry at their own
+root, and anything beneath one belongs to a different repository, or to
+a second checkout of this one. A repository that keeps worktrees under
+`.worktrees/` would otherwise report every finding once per checked-out
+branch, against files the working tree does not contain.
+
+The scan root itself never counts as a boundary, so pointing the linter
+at a worktree scans that worktree. Pointing it at a directory that
+merely *contains* repositories finds nothing, since each child is a
+boundary.
+
 ### As a Pre-commit Hook
 
 Add to your `.pre-commit-config.yaml`:

--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,28 @@ inputs:
   validation-method:
     description: "Validation method (github-api, git, or auto-detect)"
     required: false
+  allow-list:
+    description: "Detect stale harden-runner allow-list pins"
+    required: false
+    default: "true"
+  verify-allow-list:
+    description: >
+      Treat stale allow-list pins as errors. Exits with status 3 when
+      stale pins remain, or 4 when the latest release cannot be
+      resolved. Without this the findings are advisory only.
+    required: false
+    default: "false"
+  update-allow-list:
+    description: >
+      Rewrite stale allow-list pins in place. Pins carrying an
+      'allow-list-pin-ok' directive are never rewritten.
+    required: false
+    default: "false"
+  allow-list-org:
+    description: >
+      Organisation used to resolve the '@<sha>' allow-list shorthand.
+      Defaults at runtime to github.repository_owner.
+    required: false
 
 outputs:
   errors-found:
@@ -63,6 +85,12 @@ outputs:
   scan-summary:
     description: "JSON summary of scan results"
     value: ${{ steps.gha-workflow-linter.outputs.scan-summary }}
+  allow-list-stale:
+    description: "Number of stale allow-list pins found"
+    value: ${{ steps.gha-workflow-linter.outputs.allow-list-stale }}
+  allow-list-fixed:
+    description: "Number of allow-list pins rewritten"
+    value: ${{ steps.gha-workflow-linter.outputs.allow-list-fixed }}
 
 runs:
   using: "composite"
@@ -111,6 +139,10 @@ runs:
         INPUT_REQUIRE_PINNED_SHA: ${{ inputs.require-pinned-sha }}
         INPUT_SKIP_ACTIONS: ${{ inputs.skip-actions }}
         INPUT_VALIDATION_METHOD: ${{ inputs.validation-method }}
+        INPUT_ALLOW_LIST: ${{ inputs.allow-list }}
+        INPUT_VERIFY_ALLOW_LIST: ${{ inputs.verify-allow-list }}
+        INPUT_UPDATE_ALLOW_LIST: ${{ inputs.update-allow-list }}
+        INPUT_ALLOW_LIST_ORG: ${{ inputs.allow-list-org }}
       run: |
         # Determine command prefix (uvx for PyPI, direct for local)
         if [[ "$USE_UVX" == "true" ]]; then
@@ -165,6 +197,22 @@ runs:
           args+=(--validation-method "$INPUT_VALIDATION_METHOD")
         fi
 
+        if [[ "$INPUT_ALLOW_LIST" == "false" ]]; then
+          args+=(--no-allow-list)
+        fi
+
+        if [[ "$INPUT_VERIFY_ALLOW_LIST" == "true" ]]; then
+          args+=(--verify-allow-list)
+        fi
+
+        if [[ "$INPUT_UPDATE_ALLOW_LIST" == "true" ]]; then
+          args+=(--update-allow-list)
+        fi
+
+        if [[ -n "$INPUT_ALLOW_LIST_ORG" ]]; then
+          args+=(--allow-list-org "$INPUT_ALLOW_LIST_ORG")
+        fi
+
         # Run gha-workflow-linter and capture output
         if [[ "$INPUT_OUTPUT_FORMAT" == "json" ]]; then
           output=$($cmd_prefix lint "${args[@]}" --no-cache)
@@ -207,8 +255,17 @@ runs:
           echo "EOF" >> "$GITHUB_OUTPUT"
         fi
 
+        # Allow-list counters come from the same JSON summary. Absent
+        # keys (the check disabled, or an older tool) default to 0.
+        allow_list_stale=$(echo "${json_output:-$output}" | \
+          jq -r '.allow_list.summary.stale // 0' 2>/dev/null || echo "0")
+        allow_list_fixed=$(echo "${json_output:-$output}" | \
+          jq -r '.allow_list.summary.fixed // 0' 2>/dev/null || echo "0")
+
         echo "errors-found=$errors_found" >> "$GITHUB_OUTPUT"
         echo "total-calls=$total_calls" >> "$GITHUB_OUTPUT"
+        echo "allow-list-stale=$allow_list_stale" >> "$GITHUB_OUTPUT"
+        echo "allow-list-fixed=$allow_list_fixed" >> "$GITHUB_OUTPUT"
 
         # Set step summary
         if [[ "$errors_found" -eq 0 ]]; then

--- a/docs/ALLOW_LIST_FEATURE.md
+++ b/docs/ALLOW_LIST_FEATURE.md
@@ -1523,8 +1523,14 @@ allow-list code exists.
 - `allow_list_fix.py` + diff-assertion tests, including
   directive-preservation and never-fix-suppressed.
 - CLI: `--update-allow-list`.
-- JSON output `allow_list` block (with `"suppressed"`);
+- JSON output `allow_list` block (with `"suppressed"` and `"fixed"`);
   `action.yaml` inputs/outputs.
+
+Remediation rewrites the reference and its version comment by surgical
+substring replacement, so quoting style, the spacing before `#`, the
+comment's position and any suppression directive all survive. Writes go
+through `file_edit.replace_lines`, so they are atomic and preserve line
+endings.
 
 ### Phase 3 — flag migration and consolidation
 

--- a/src/gha_workflow_linter/allow_list_check.py
+++ b/src/gha_workflow_linter/allow_list_check.py
@@ -79,6 +79,7 @@ from .allow_list_resolver import AllowListResolver
 from .allow_list_scanner import AllowListScanner
 from .allow_list_spec import ORG_RE
 from .directives import Directive
+from .exceptions import ConfigurationError
 from .models import (
     SUPPRESSIBLE_ALLOW_LIST_KINDS,
     AllowListFindingKind,
@@ -386,17 +387,29 @@ def resolve_workflow_org(root: Path, *, configured: str = "") -> str:
     Args:
         root: Directory of the repository being scanned. Used only for
             the Git remote probes.
-        configured: Explicit org from configuration. Returned verbatim
-            when non-empty, without validation, because an explicit
-            setting is a statement of intent.
+        configured: Explicit org from configuration or the
+            ``--allow-list-org`` flag.
 
     Returns:
         The org name, or ``""`` when it cannot be determined. An empty
-        result is not an error: the scanner then skips shorthand pins,
-        which is the documented behaviour of design section 6.4.
+        result is not an error: the caller reports it as an unresolved
+        check rather than a clean one.
+
+    Raises:
+        ConfigurationError: If ``configured`` is not a valid GitHub
+            organisation name. An explicit setting is a statement of
+            intent, so a typo is reported rather than quietly replaced
+            by an inferred value that would check the wrong repository.
     """
     explicit = configured.strip()
     if explicit:
+        if not ORG_RE.match(explicit):
+            raise ConfigurationError(
+                f"Invalid allow-list organisation: {explicit!r}. "
+                "GitHub organisation names are 1-39 characters of "
+                "letters, digits and single hyphens, and cannot start "
+                "or end with a hyphen"
+            )
         return explicit
 
     from_env = os.environ.get(ORG_ENV_VAR, "").strip()
@@ -408,7 +421,10 @@ def resolve_workflow_org(root: Path, *, configured: str = "") -> str:
         if not url:
             continue
         owner = _owner_from_remote_url(url)
-        if owner:
+        # An inferred value was never asked for by name, so an
+        # unusable one falls through to the next source rather than
+        # failing the run.
+        if owner and ORG_RE.match(owner):
             return owner
 
     return ""

--- a/src/gha_workflow_linter/allow_list_check.py
+++ b/src/gha_workflow_linter/allow_list_check.py
@@ -226,6 +226,8 @@ class AllowListOutcome:
         checked: ``False`` when the check was disabled or no pin was
             found, so no conclusion may be drawn from an empty
             ``findings``.
+        fixed_lines: ``(file path, line number)`` pairs that remediation
+            rewrote on disk. Empty unless ``--update-allow-list`` ran.
     """
 
     findings: list[AllowListFinding]
@@ -233,6 +235,9 @@ class AllowListOutcome:
     unresolved: dict[str, str]
     suppressed_count: int
     checked: bool
+    fixed_lines: frozenset[tuple[str, int]] = dataclasses.field(
+        default_factory=frozenset
+    )
 
     @property
     def resolved(self) -> bool:
@@ -252,6 +257,48 @@ class AllowListOutcome:
             order.
         """
         return [finding for finding in self.findings if not finding.suppressed]
+
+    @property
+    def outstanding(self) -> list[AllowListFinding]:
+        """Findings that still need attention after any remediation.
+
+        A finding whose line remediation rewrote is no longer a problem,
+        so it must not keep failing an enforcing run. Without this,
+        ``--update-allow-list --verify-allow-list`` would fix everything
+        and then report failure anyway.
+
+        Returns:
+            Unsuppressed findings whose line was not rewritten.
+        """
+        return [
+            finding
+            for finding in self.unsuppressed
+            if (str(finding.pin.file_path), finding.pin.line_number)
+            not in self.fixed_lines
+        ]
+
+    @property
+    def fixed_count(self) -> int:
+        """How many pins remediation rewrote.
+
+        Returns:
+            The number of rewritten lines.
+        """
+        return len(self.fixed_lines)
+
+    def was_fixed(self, finding: AllowListFinding) -> bool:
+        """Report whether remediation rewrote this finding's line.
+
+        Args:
+            finding: The finding to test.
+
+        Returns:
+            True when the line was rewritten on disk.
+        """
+        return (
+            str(finding.pin.file_path),
+            finding.pin.line_number,
+        ) in self.fixed_lines
 
 
 def host_key(pin: AllowListPin) -> str:

--- a/src/gha_workflow_linter/allow_list_check.py
+++ b/src/gha_workflow_linter/allow_list_check.py
@@ -1,0 +1,710 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Classification of detected allow-list pins against their host repos.
+
+:mod:`gha_workflow_linter.allow_list_scanner` finds the pins and
+:mod:`gha_workflow_linter.allow_list_resolver` answers "what is the
+latest release of this host repository?". This module is the join
+between the two: it turns a pin plus a resolved latest release into a
+:class:`AllowListFinding`, or into nothing at all when the pin is
+current.
+
+Three rules decide the kind, and they are exhaustive for this phase
+(design section 7.2):
+
+* The ref is not a 40-character hexadecimal SHA -- a branch, a tag, or
+  the implicit ``HEAD`` -- so the pin floats: ``UNPINNED``.
+* The ref is a SHA the host repository has moved *beyond*: ``STALE``.
+* The ref *is* the latest release's commit, but the version comment
+  names a different version: ``COMMENT_MISMATCH``. A comment that lies
+  misleads every subsequent human reviewer, so it is a finding in its
+  own right rather than a detail of ``STALE``.
+
+Staleness has a **direction**, and the second rule is not simply "the
+SHA differs from the target". A cooldown deliberately selects an older
+release than the newest one in existence -- with a seven-day window,
+``lfreleng-actions/.github`` resolves to v0.7.0 while the whole v0.12.x
+series is still warming -- so a pin already sitting at v0.12.2 is *ahead*
+of the target, not behind it. Reporting that as stale would advise a
+downgrade in the name of freshness. Direction is therefore established
+by placing the pinned commit in the host repository's own commit-to-tag
+map (``LatestRelease.commit_tags``) and comparing versions numerically,
+never by reading the version comment, which is exactly the thing section
+7.2 assumes can lie. A pin that is at or ahead of the target produces no
+finding at all; a commit belonging to no known release keeps its
+``STALE`` classification, because its position cannot be established and
+the target is then the best advice available.
+
+``INVALID_SPEC`` and ``UNRESOLVABLE`` are deliberately **not produced
+here**, because neither can be substantiated with the information this
+phase has:
+
+* ``INVALID_SPEC`` would require the scanner to hand over scalars that
+  failed the grammar. It does not: its module docstring states that an
+  unparsable scalar is skipped wherever it is found, and
+  :class:`~gha_workflow_linter.allow_list_scanner.AllowListPin` has no
+  representation for a spec that did not resolve. Reporting one needs
+  the orchestrator to know which action consumes the input, which is
+  future work.
+* ``UNRESOLVABLE`` would require proving that a SHA is absent from the
+  host repository. Resolving the latest release does not perform that
+  lookup, and inferring absence from "it is not the latest commit"
+  would report every deliberately-lagging pin as broken.
+
+Both kinds are nonetheless handled defensively -- they have severities
+and categories -- so that adding the lookups later is a matter of
+producing the finding, not of teaching the rest of the pipeline what it
+means.
+
+Resolution failure is fail-soft (design section 6.4). When a host
+repository's latest release cannot be resolved, **no findings are
+produced for the pins naming it** and the host is recorded in
+:attr:`AllowListOutcome.unresolved` with the reason. Whether that is
+fatal is the caller's decision: in default mode it is a notice, and
+under ``--verify-allow-list`` it is exit code ``4``. This module never
+decides it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+from .allow_list_resolver import AllowListResolver
+from .allow_list_scanner import AllowListScanner
+from .allow_list_spec import ORG_RE
+from .directives import Directive
+from .models import (
+    SUPPRESSIBLE_ALLOW_LIST_KINDS,
+    AllowListFindingKind,
+    Category,
+    Severity,
+    allow_list_category,
+)
+from .version_utils import _parse_version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+    from .allow_list_scanner import AllowListPin
+    from .cache import ValidationCache
+    from .latest_release import LatestRelease
+    from .models import Config
+
+__all__ = [
+    "ORG_ENV_VAR",
+    "REMOTE_PRECEDENCE",
+    "UNRESOLVED_REASON",
+    "AllowListChecker",
+    "AllowListFinding",
+    "AllowListOutcome",
+    "classify_pins",
+    "host_key",
+    "resolve_workflow_org",
+]
+
+#: Environment variable GitHub Actions sets to the owner of the running
+#: repository. Second in the precedence order of design section 6.3.
+ORG_ENV_VAR = "GITHUB_REPOSITORY_OWNER"
+
+#: Git remotes consulted, in order. ``upstream`` deliberately outranks
+#: ``origin``: contributors work from personal forks, and the pins track
+#: the upstream org's ``.github`` repository. A fork owner would resolve
+#: to a ``.github`` repository that does not exist.
+REMOTE_PRECEDENCE: tuple[str, ...] = ("upstream", "origin")
+
+#: Seconds allowed for the ``git remote get-url`` probe. Reading a local
+#: config file is instantaneous; the bound only guards against a
+#: pathological environment.
+_GIT_TIMEOUT_SECONDS = 10
+
+#: A checkout-able commit SHA: exactly 40 hexadecimal characters.
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+#: Suffix Git remote URLs conventionally carry.
+_GIT_URL_SUFFIX = ".git"
+
+#: Recorded against every host repository whose latest release could not
+#: be resolved. The resolver is fail-soft and reports ``None`` without
+#: distinguishing the cause, so the reason enumerates the possibilities
+#: rather than claiming one of them.
+UNRESOLVED_REASON = (
+    "the latest release could not be resolved (no token, no network, "
+    "no releases, or an active cooldown excluded every candidate)"
+)
+
+#: Severity each kind carries when enforcement was not requested
+#: (design section 7.2). ``INVALID_SPEC`` is an error even by default
+#: because it is a local correctness problem with no network dependency.
+_DEFAULT_SEVERITIES: dict[AllowListFindingKind, Severity] = {
+    AllowListFindingKind.STALE: Severity.WARNING,
+    AllowListFindingKind.COMMENT_MISMATCH: Severity.WARNING,
+    AllowListFindingKind.UNPINNED: Severity.NOTICE,
+    AllowListFindingKind.UNRESOLVABLE: Severity.WARNING,
+    AllowListFindingKind.INVALID_SPEC: Severity.ERROR,
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class AllowListFinding:
+    """One thing wrong with one detected allow-list pin.
+
+    Attributes:
+        pin: The pin the finding concerns, carrying its source anchor.
+        kind: What is wrong with it.
+        severity: How it is reported. Suppressed findings keep their
+            default severity even under enforcement.
+        message: Human-readable description, safe to print verbatim.
+        current_sha: The commit the pin names, or ``None`` when the pin
+            does not name a commit at all (``UNPINNED``).
+        target_sha: The commit the pin should name.
+        target_version: The release tag ``target_sha`` belongs to.
+        suppressed: Whether an ``allow-list-pin-ok`` directive applies.
+            Suppressed findings are still reported -- machine consumers
+            see the full picture -- but never fail a run.
+    """
+
+    pin: AllowListPin
+    kind: AllowListFindingKind
+    severity: Severity
+    message: str
+    current_sha: str | None
+    target_sha: str | None
+    target_version: str | None
+    suppressed: bool
+
+    @property
+    def category(self) -> Category:
+        """The defect/currency category of this finding.
+
+        Returns:
+            The category implied by :attr:`kind`.
+        """
+        return allow_list_category(self.kind)
+
+    @property
+    def host_repo(self) -> str:
+        """The ``owner/repo`` the pin reads its allow-list from.
+
+        Returns:
+            The host repository key.
+        """
+        return host_key(self.pin)
+
+
+@dataclasses.dataclass(frozen=True)
+class AllowListOutcome:
+    """Everything one allow-list check produced.
+
+    Attributes:
+        findings: Every finding, suppressed ones included, in scan
+            order.
+        hosts: Latest release of each distinct host repository, or
+            ``None`` where resolution failed.
+        unresolved: Host repositories that could not be resolved, mapped
+            to the reason. Non-empty means the check was incomplete, and
+            the caller decides whether that is fatal.
+        suppressed_count: How many of ``findings`` are suppressed.
+        checked: ``False`` when the check was disabled or no pin was
+            found, so no conclusion may be drawn from an empty
+            ``findings``.
+    """
+
+    findings: list[AllowListFinding]
+    hosts: dict[str, LatestRelease | None]
+    unresolved: dict[str, str]
+    suppressed_count: int
+    checked: bool
+
+    @property
+    def resolved(self) -> bool:
+        """Whether every host repository consulted was resolved.
+
+        Returns:
+            ``True`` when no host is recorded in :attr:`unresolved`.
+        """
+        return not self.unresolved
+
+    @property
+    def unsuppressed(self) -> list[AllowListFinding]:
+        """The findings that may affect the exit code.
+
+        Returns:
+            Every finding without an applicable suppression, in scan
+            order.
+        """
+        return [finding for finding in self.findings if not finding.suppressed]
+
+
+def host_key(pin: AllowListPin) -> str:
+    """Return the ``owner/repo`` key of a pin's host repository.
+
+    Args:
+        pin: The pin to key.
+
+    Returns:
+        The host repository key, for example
+        ``lfreleng-actions/.github``.
+    """
+    return f"{pin.spec.host_org}/{pin.spec.repo}"
+
+
+def _git_remote_url(root: Path, remote: str) -> str:
+    """Read one Git remote's URL from a working tree.
+
+    Args:
+        root: Directory inside the repository to interrogate.
+        remote: Remote name, for example ``upstream``.
+
+    Returns:
+        The URL, or ``""`` when the directory is not a repository, the
+        remote does not exist, or Git is unavailable. Never raises.
+    """
+    command = ["git", "-C", str(root), "remote", "get-url", remote]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip()
+
+
+def _owner_from_remote_url(url: str) -> str:
+    """Extract the repository owner from a Git remote URL.
+
+    Handles the three forms in everyday use: an HTTPS URL, an SSH URL,
+    and the scp-like ``git@host:owner/repo``. A trailing ``.git`` and
+    trailing slashes are ignored.
+
+    Args:
+        url: The remote URL.
+
+    Returns:
+        The owner, or ``""`` when the URL names no owner or the owner is
+        not a valid GitHub org name (a local-path remote, for example).
+    """
+    text = url.strip().rstrip("/")
+    if text.endswith(_GIT_URL_SUFFIX):
+        text = text[: -len(_GIT_URL_SUFFIX)]
+    if "://" not in text and ":" in text:
+        # scp-like syntax; everything before ':' is user@host.
+        text = text.split(":", 1)[1]
+
+    segments = [segment for segment in text.split("/") if segment]
+    if len(segments) < 2:
+        return ""
+
+    owner = segments[-2]
+    return owner if ORG_RE.match(owner) else ""
+
+
+def resolve_workflow_org(root: Path, *, configured: str = "") -> str:
+    """Determine the org that owns the workflows being scanned.
+
+    The shorthand ``@<sha>`` pin form names no host org and takes it from
+    here, so this answers "whose ``.github`` repository do these pins
+    read?". Precedence follows design section 6.3:
+
+    1. ``configured`` -- the config key, itself fed by the CLI flag.
+    2. The ``GITHUB_REPOSITORY_OWNER`` environment variable.
+    3. The owner of the ``upstream`` Git remote.
+    4. The owner of the ``origin`` Git remote.
+
+    ``upstream`` deliberately outranks ``origin``: contributors work from
+    personal forks whose owner has no ``.github`` repository at all.
+
+    Args:
+        root: Directory of the repository being scanned. Used only for
+            the Git remote probes.
+        configured: Explicit org from configuration. Returned verbatim
+            when non-empty, without validation, because an explicit
+            setting is a statement of intent.
+
+    Returns:
+        The org name, or ``""`` when it cannot be determined. An empty
+        result is not an error: the scanner then skips shorthand pins,
+        which is the documented behaviour of design section 6.4.
+    """
+    explicit = configured.strip()
+    if explicit:
+        return explicit
+
+    from_env = os.environ.get(ORG_ENV_VAR, "").strip()
+    if from_env and ORG_RE.match(from_env):
+        return from_env
+
+    for remote in REMOTE_PRECEDENCE:
+        url = _git_remote_url(root, remote)
+        if not url:
+            continue
+        owner = _owner_from_remote_url(url)
+        if owner:
+            return owner
+
+    return ""
+
+
+def _normalise_version(text: str) -> str:
+    """Reduce a version token to a comparable form.
+
+    A single leading ``v`` is optional by convention, so ``v0.12.2`` and
+    ``0.12.2`` name the same release and must not be reported as a
+    mismatch. Comparison is case-insensitive.
+
+    Args:
+        text: A version token, from a comment or a release tag.
+
+    Returns:
+        The normalised token.
+    """
+    stripped = text.strip()
+    if stripped[:1] in {"v", "V"}:
+        stripped = stripped[1:]
+    return stripped.lower()
+
+
+def _comment_disagrees(comment: str | None, tag: str) -> bool:
+    """Report whether a version comment contradicts a release tag.
+
+    Args:
+        comment: The pin's version comment, or ``None`` when it carries
+            none. A pin with no comment cannot lie.
+        tag: The latest release tag.
+
+    Returns:
+        ``True`` when the comment names a different version.
+    """
+    if comment is None:
+        return False
+    return _normalise_version(comment) != _normalise_version(tag)
+
+
+def _pin_is_at_or_ahead(ref: str, latest: LatestRelease) -> bool:
+    """Report whether a pinned commit sits at or beyond the target.
+
+    A cooldown makes the resolved target a floor rather than a ceiling:
+    it is the newest release old enough to be trusted, which may be
+    several releases behind the newest release that exists. A pin on a
+    release at or beyond that floor is current, and moving it to the
+    target would be a downgrade.
+
+    The pinned commit is placed through the host repository's
+    commit-to-tag map rather than through the pin's version comment,
+    which may name any version its author last typed.
+
+    Args:
+        ref: The commit SHA the pin names.
+        latest: The host repository's resolved target release.
+
+    Returns:
+        ``True`` when the pinned commit belongs to a known release whose
+        version is greater than or equal to the target's. ``False`` when
+        it belongs to no known release, and whenever the target carries
+        no commit map -- a cache-restored record, which the resolver only
+        produces when no cooldown applied and the target really is the
+        newest release.
+    """
+    pinned_tag = latest.tag_for_commit(ref)
+    if pinned_tag is None:
+        return False
+
+    try:
+        return _parse_version(pinned_tag) >= _parse_version(latest.tag)
+    except ValueError:  # pragma: no cover - eligibility rejects such tags
+        return False
+
+
+def _finding_kind(
+    pin: AllowListPin, latest: LatestRelease
+) -> AllowListFindingKind | None:
+    """Classify one pin against its host repository's target release.
+
+    Args:
+        pin: The pin to classify.
+        latest: The host repository's target release.
+
+    Returns:
+        The finding kind, or ``None`` when the pin is current -- either
+        because it names the target commit and its comment agrees, or
+        because it names a release at or ahead of the target.
+    """
+    ref = pin.spec.ref
+    if not _SHA_RE.match(ref):
+        return AllowListFindingKind.UNPINNED
+    if ref.lower() != latest.commit_sha.lower():
+        if _pin_is_at_or_ahead(ref, latest):
+            return None
+        return AllowListFindingKind.STALE
+    if _comment_disagrees(pin.version_comment, latest.tag):
+        return AllowListFindingKind.COMMENT_MISMATCH
+    return None
+
+
+def _is_suppressed(pin: AllowListPin, kind: AllowListFindingKind) -> bool:
+    """Report whether an ``allow-list-pin-ok`` directive covers a kind.
+
+    The directive asserts "this pin is deliberately at this version",
+    which is a statement about currency, not about correctness. It
+    therefore silences only the kinds in
+    :data:`~gha_workflow_linter.models.SUPPRESSIBLE_ALLOW_LIST_KINDS`.
+
+    Args:
+        pin: The pin, carrying any directives found on or above it.
+        kind: The finding kind under consideration.
+
+    Returns:
+        ``True`` when the pin carries the directive *and* the kind is
+        suppressible.
+    """
+    if kind not in SUPPRESSIBLE_ALLOW_LIST_KINDS:
+        return False
+    return Directive.ALLOW_LIST_PIN_OK in pin.directives
+
+
+def _severity(
+    kind: AllowListFindingKind, *, suppressed: bool, verify: bool
+) -> Severity:
+    """Choose the severity of one finding.
+
+    Args:
+        kind: The finding kind.
+        suppressed: Whether a directive applies. A suppressed finding is
+            never promoted: enforcement must not defeat a suppression.
+        verify: Whether enforcement was requested.
+
+    Returns:
+        The severity to report.
+    """
+    if verify and not suppressed:
+        return Severity.ERROR
+    return _DEFAULT_SEVERITIES[kind]
+
+
+def _message(
+    pin: AllowListPin, latest: LatestRelease, kind: AllowListFindingKind
+) -> str:
+    """Compose the human-readable description of one finding.
+
+    Args:
+        pin: The pin the finding concerns.
+        latest: The host repository's latest release.
+        kind: The finding kind.
+
+    Returns:
+        A single-sentence description naming the host repository.
+    """
+    host = host_key(pin)
+    if kind is AllowListFindingKind.UNPINNED:
+        return (
+            f"Allow-list pin references '{pin.spec.ref}' rather than a "
+            f"commit SHA; {host} is at {latest.tag}"
+        )
+    if kind is AllowListFindingKind.COMMENT_MISMATCH:
+        return (
+            f"Version comment says '{pin.version_comment}' but the "
+            f"pinned commit is {latest.tag} of {host}"
+        )
+    return (
+        f"Allow-list pin is stale; {host} is at {latest.tag} "
+        f"({latest.commit_sha})"
+    )
+
+
+def _build_finding(
+    pin: AllowListPin,
+    latest: LatestRelease,
+    kind: AllowListFindingKind,
+    *,
+    verify: bool,
+) -> AllowListFinding:
+    """Assemble a finding from a classified pin.
+
+    Args:
+        pin: The pin the finding concerns.
+        latest: The host repository's latest release.
+        kind: The finding kind.
+        verify: Whether enforcement was requested.
+
+    Returns:
+        The finding.
+    """
+    suppressed = _is_suppressed(pin, kind)
+    ref = pin.spec.ref
+    return AllowListFinding(
+        pin=pin,
+        kind=kind,
+        severity=_severity(kind, suppressed=suppressed, verify=verify),
+        message=_message(pin, latest, kind),
+        current_sha=ref if _SHA_RE.match(ref) else None,
+        target_sha=latest.commit_sha,
+        target_version=latest.tag,
+        suppressed=suppressed,
+    )
+
+
+def classify_pins(
+    pins: Sequence[AllowListPin],
+    hosts: dict[str, LatestRelease | None],
+    *,
+    verify: bool,
+) -> list[AllowListFinding]:
+    """Classify every pin against its host repository's latest release.
+
+    Pins whose host could not be resolved produce no findings at all.
+    Guessing under uncertainty is the one behaviour a linter must not
+    have; the unresolved host is recorded separately instead.
+
+    Args:
+        pins: The detected pins, in scan order.
+        hosts: Latest release of each host repository, or ``None``.
+        verify: Whether enforcement was requested, promoting every
+            unsuppressed finding to an error.
+
+    Returns:
+        The findings, in scan order.
+    """
+    findings: list[AllowListFinding] = []
+    for pin in pins:
+        latest = hosts.get(host_key(pin))
+        if latest is None:
+            continue
+        kind = _finding_kind(pin, latest)
+        if kind is None:
+            continue
+        findings.append(_build_finding(pin, latest, kind, verify=verify))
+    return findings
+
+
+class AllowListChecker:
+    """Scan, resolve and classify allow-list pins in one pass.
+
+    Attributes:
+        config: Linter configuration, supplying the allow-list settings
+            and the resolution backend.
+        cache: Validation cache reused for latest-release storage, so a
+            repeated run within the TTL costs no API calls.
+    """
+
+    def __init__(self, config: Config, cache: ValidationCache) -> None:
+        """Initialise the checker.
+
+        Args:
+            config: Linter configuration.
+            cache: Validation cache passed through to the resolver.
+        """
+        self.config = config
+        self.cache = cache
+        self.logger = logging.getLogger(__name__)
+
+    async def check(
+        self, paths: Iterable[Path], root: Path
+    ) -> AllowListOutcome:
+        """Check every allow-list pin in the given files.
+
+        Each distinct host repository is resolved exactly once, however
+        many pins name it.
+
+        Args:
+            paths: Workflow or action files to scan. Discovery is the
+                caller's concern.
+            root: Repository root, used to infer the workflow org from
+                the Git remotes when configuration and environment do
+                not supply it.
+
+        Returns:
+            The outcome. ``checked`` is ``False`` when the check is
+            disabled or no pin was found, so an empty ``findings`` is
+            never mistaken for a clean result.
+        """
+        settings = self.config.allow_list
+        if not settings.enabled:
+            self.logger.debug("Allow-list check disabled by configuration")
+            return _empty_outcome()
+
+        pins = self._scan(paths, root)
+        if not pins:
+            self.logger.debug("No allow-list pins found")
+            return _empty_outcome()
+
+        # Distinct host repositories only: twenty pins naming the same
+        # '.github' repository must cost exactly one lookup, and the
+        # de-duplication is stated here rather than relied upon inside
+        # the resolver.
+        repo_keys = list(dict.fromkeys(host_key(pin) for pin in pins))
+        hosts = await AllowListResolver(self.config, self.cache).resolve(
+            repo_keys
+        )
+        unresolved = {
+            repo_key: UNRESOLVED_REASON
+            for repo_key, release in hosts.items()
+            if release is None
+        }
+        for repo_key in unresolved:
+            self.logger.warning(
+                f"Allow-list check skipped for {repo_key}: {UNRESOLVED_REASON}"
+            )
+
+        findings = classify_pins(pins, hosts, verify=settings.verify)
+        return AllowListOutcome(
+            findings=findings,
+            hosts=hosts,
+            unresolved=unresolved,
+            suppressed_count=sum(1 for f in findings if f.suppressed),
+            checked=True,
+        )
+
+    def _scan(self, paths: Iterable[Path], root: Path) -> list[AllowListPin]:
+        """Detect every allow-list pin in the given files.
+
+        Args:
+            paths: Files to scan.
+            root: Repository root, for workflow-org inference.
+
+        Returns:
+            The pins found, flattened into scan order.
+        """
+        settings = self.config.allow_list
+        org = resolve_workflow_org(root, configured=settings.org)
+        if not org:
+            self.logger.debug(
+                "Workflow org could not be determined; shorthand "
+                "'@<sha>' pins will be skipped"
+            )
+
+        scanner = AllowListScanner(
+            self.config,
+            org,
+            key_patterns=settings.key_patterns,
+            filename=settings.filename,
+        )
+        return [
+            pin
+            for file_pins in scanner.scan_files(paths).values()
+            for pin in file_pins
+        ]
+
+
+def _empty_outcome() -> AllowListOutcome:
+    """Build the outcome of a check that did not run.
+
+    Returns:
+        An outcome with ``checked`` set to ``False`` and no findings.
+    """
+    return AllowListOutcome(
+        findings=[],
+        hosts={},
+        unresolved={},
+        suppressed_count=0,
+        checked=False,
+    )

--- a/src/gha_workflow_linter/allow_list_check.py
+++ b/src/gha_workflow_linter/allow_list_check.py
@@ -100,6 +100,8 @@ if TYPE_CHECKING:
 __all__ = [
     "ORG_ENV_VAR",
     "REMOTE_PRECEDENCE",
+    "UNKNOWN_ORG_HOST",
+    "UNKNOWN_ORG_REASON",
     "UNRESOLVED_REASON",
     "AllowListChecker",
     "AllowListFinding",
@@ -134,6 +136,16 @@ _GIT_URL_SUFFIX = ".git"
 #: be resolved. The resolver is fail-soft and reports ``None`` without
 #: distinguishing the cause, so the reason enumerates the possibilities
 #: rather than claiming one of them.
+#: Sentinel host key recorded when the workflow organisation itself
+#: could not be determined, so no pin could be resolved. Distinct from
+#: a named host that failed to resolve.
+UNKNOWN_ORG_HOST = "<workflow organisation>"
+
+UNKNOWN_ORG_REASON = (
+    "workflow organisation could not be determined; pass "
+    "--allow-list-org to set it explicitly"
+)
+
 UNRESOLVED_REASON = (
     "the latest release could not be resolved (no token, no network, "
     "no releases, or an active cooldown excluded every candidate)"
@@ -632,10 +644,29 @@ class AllowListChecker:
             self.logger.debug("Allow-list check disabled by configuration")
             return _empty_outcome()
 
-        pins = self._scan(paths, root)
+        org = resolve_workflow_org(root, configured=settings.org)
+        pins = self._scan(paths, root, org)
         if not pins:
-            self.logger.debug("No allow-list pins found")
-            return _empty_outcome()
+            if org:
+                self.logger.debug("No allow-list pins found")
+                return _empty_outcome()
+            # An unknown workflow org makes every candidate in-repo path
+            # unresolvable, so the scanner finds nothing at all. Reporting
+            # that as "clean" would let --verify-allow-list pass without
+            # having checked anything, which is the failure mode the
+            # verify flag exists to prevent.
+            self.logger.warning(
+                "Workflow organisation could not be determined; no "
+                "allow-list pins could be resolved. Pass --allow-list-org "
+                "to set it explicitly"
+            )
+            return AllowListOutcome(
+                findings=[],
+                hosts={},
+                unresolved={UNKNOWN_ORG_HOST: UNKNOWN_ORG_REASON},
+                suppressed_count=0,
+                checked=True,
+            )
 
         # Distinct host repositories only: twenty pins naming the same
         # '.github' repository must cost exactly one lookup, and the
@@ -664,18 +695,20 @@ class AllowListChecker:
             checked=True,
         )
 
-    def _scan(self, paths: Iterable[Path], root: Path) -> list[AllowListPin]:
+    def _scan(
+        self, paths: Iterable[Path], root: Path, org: str
+    ) -> list[AllowListPin]:
         """Detect every allow-list pin in the given files.
 
         Args:
             paths: Files to scan.
             root: Repository root, for workflow-org inference.
+            org: Resolved workflow organisation, possibly empty.
 
         Returns:
             The pins found, flattened into scan order.
         """
         settings = self.config.allow_list
-        org = resolve_workflow_org(root, configured=settings.org)
         if not org:
             self.logger.debug(
                 "Workflow org could not be determined; shorthand "

--- a/src/gha_workflow_linter/allow_list_fix.py
+++ b/src/gha_workflow_linter/allow_list_fix.py
@@ -1,0 +1,585 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""In-place remediation of stale allow-list pins.
+
+:mod:`gha_workflow_linter.allow_list_check` decides *what* is wrong with
+a pin. This module performs the one repair that follows from it: move
+the ref, correct the version comment, and change nothing else.
+
+    config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+    config: '@bf6642f68d58c1b81bbe993e676d6cc339ac3654'  # v0.12.2
+
+The rewrite is a **surgical substring replacement** on the pin's own
+source line, never a reconstruction of it from parsed fields. That
+distinction is the whole design (§10.1), and it is not fussiness:
+:meth:`~gha_workflow_linter.auto_fix.AutoFixer._build_fixed_line`
+rebuilds, and so normalises comment spacing to the ``two_space_comments``
+preference as a side effect of an unrelated repair. These edits become
+review-ready pull requests, where a reformatted neighbouring comment is
+noise a reviewer has to read past. So:
+
+* The quote style survives because the quotes are never touched. SHAs and
+  version tags contain no character needing an escape, so there is no
+  re-quoting to do.
+* The spacing before ``#`` survives because the ``#`` is never touched.
+  Three spaces stay three spaces.
+* Both comment positions -- a YAML comment outside the quotes, and a
+  comment inside the scalar that the consuming action strips itself --
+  are rewritten where they sit, never moved.
+* Suppression directives and any ``-- reason`` tail survive, because the
+  comment body is round-tripped through
+  :func:`~gha_workflow_linter.directives.parse_trailing_comment` and
+  :func:`~gha_workflow_linter.directives.render_comment`. Dropping a
+  suppression while repairing something else would silently re-enable the
+  churn its author suppressed.
+
+House style applies to exactly one thing: a comment that does not exist
+yet. New content has no author intent to preserve, so it is added with
+the project's default two-space separation.
+
+Four conditions stop a rewrite before it starts, each recorded in
+:attr:`FixOutcome.skipped` with its reason: a suppressed finding (checked
+first, and never rewritten), a multi-line scalar, a finding with no
+target commit, and a line whose text no longer matches what the scanner
+recorded.
+
+Writes go through :func:`~gha_workflow_linter.file_edit.replace_lines`,
+one call per file, so a file is rewritten atomically and keeps its line
+endings. Two findings claiming the same line is a bug in the caller's
+pipeline rather than a condition to paper over, so it raises
+:class:`DuplicateFixError` (§10.3).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING
+
+from .allow_list_scanner import CommentPosition, QuoteStyle
+from .allow_list_spec import SpecError, render_spec, split_comment
+from .directives import parse_trailing_comment, render_comment
+from .file_edit import replace_lines
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+    from .allow_list_check import AllowListFinding
+    from .allow_list_scanner import AllowListPin
+
+__all__ = [
+    "COMMENT_SEPARATOR",
+    "REASON_COMMENT_CHANGED",
+    "REASON_COMMENT_NOT_FOUND",
+    "REASON_INVALID_REF",
+    "REASON_MULTILINE",
+    "REASON_NO_TARGET",
+    "REASON_SPEC_NOT_FOUND",
+    "REASON_SUPPRESSED",
+    "AppliedFix",
+    "DuplicateFixError",
+    "FixOutcome",
+    "apply_fixes",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Separation between a value and a comment this module *adds*. Existing
+#: comments keep whatever separation their author chose; only new content
+#: follows the project default of two spaces.
+COMMENT_SEPARATOR = "  "
+
+#: Recorded when a directive covers the finding. Suppression is checked
+#: before every other condition, so a suppressed pin is never rewritten
+#: even when it is also unfixable for some other reason.
+REASON_SUPPRESSED = "an allow-list-pin-ok directive covers this finding"
+
+#: Recorded for a scalar spanning several lines. The scanner reports
+#: those with ``auto_fixable=False`` and they are never rewritten.
+REASON_MULTILINE = "the value is a multi-line scalar"
+
+#: Recorded when the finding names no commit to move to, which leaves
+#: nothing to write.
+REASON_NO_TARGET = "the finding names no target commit"
+
+#: Recorded when the spec text the scanner captured is absent from the
+#: line it captured with it, which means the file changed underneath the
+#: scan or the scalar carries YAML escapes.
+REASON_SPEC_NOT_FOUND = "the spec is not present on its recorded source line"
+
+#: Recorded when the target commit is not a usable git ref. Defensive:
+#: a resolved release always yields a SHA.
+REASON_INVALID_REF = "the target commit is not a valid git ref"
+
+#: Recorded when the pin claims a comment that the line does not carry.
+REASON_COMMENT_NOT_FOUND = "the version comment is not present on its line"
+
+#: Recorded when the comment on the line no longer says what the scanner
+#: recorded, so rewriting it would overwrite something unexamined.
+REASON_COMMENT_CHANGED = "the version comment no longer matches the scan"
+
+#: Quote character of each quoted style. Absent for an unquoted scalar.
+_QUOTE_CHARACTERS: dict[QuoteStyle, str] = {
+    QuoteStyle.SINGLE: "'",
+    QuoteStyle.DOUBLE: '"',
+}
+
+#: Whitespace permitted around a comment marker.
+_BLANK = " \t"
+
+
+class DuplicateFixError(RuntimeError):
+    """Two findings claimed the same line of the same file.
+
+    Attributes:
+        file_path: The file both findings named.
+        line_number: The 1-based line both findings named.
+    """
+
+    def __init__(self, file_path: Path, line_number: int) -> None:
+        """Initialise the error.
+
+        Args:
+            file_path: The file both findings named.
+            line_number: The 1-based line both findings named.
+        """
+        self.file_path = file_path
+        self.line_number = line_number
+        super().__init__(
+            f"Two allow-list fixes claim line {line_number} of "
+            f"{file_path}; one would be silently discarded"
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class AppliedFix:
+    """One finding that was written back to its file.
+
+    Attributes:
+        finding: The finding the rewrite resolved.
+        line_number: 1-based line that was rewritten.
+        old_line: The line as it was on disk, without its terminator.
+        new_line: The line as written, without its terminator.
+    """
+
+    finding: AllowListFinding
+    line_number: int
+    old_line: str
+    new_line: str
+
+
+@dataclasses.dataclass(frozen=True)
+class FixOutcome:
+    """Everything one remediation pass did, and declined to do.
+
+    Attributes:
+        applied: The rewrites performed, in the order the findings were
+            supplied.
+        skipped: Each finding that was not rewritten, paired with the
+            reason, in the order the findings were supplied.
+    """
+
+    applied: list[AppliedFix]
+    skipped: list[tuple[AllowListFinding, str]]
+
+
+@dataclasses.dataclass(frozen=True)
+class _Edit:
+    """One substitution within a single source line.
+
+    Attributes:
+        start: 0-based index of the first character replaced.
+        end: 0-based index just past the last character replaced; equal
+            to ``start`` for a pure insertion.
+        text: Replacement text.
+    """
+
+    start: int
+    end: int
+    text: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _Planned:
+    """A rewrite computed but not yet written.
+
+    Attributes:
+        finding: The finding the rewrite resolves.
+        new_line: Replacement content, without a line terminator.
+    """
+
+    finding: AllowListFinding
+    new_line: str
+
+
+class _Unfixable(Exception):
+    """Internal signal that one finding cannot be rewritten.
+
+    Attributes:
+        reason: Why the finding was declined, for
+            :attr:`FixOutcome.skipped`.
+    """
+
+    def __init__(self, reason: str) -> None:
+        """Initialise the signal.
+
+        Args:
+            reason: Why the finding was declined.
+        """
+        self.reason = reason
+        super().__init__(reason)
+
+
+def apply_fixes(findings: Iterable[AllowListFinding]) -> FixOutcome:
+    """Rewrite every fixable finding in place.
+
+    Findings are grouped by file and each file is rewritten with a single
+    atomic :func:`~gha_workflow_linter.file_edit.replace_lines` call, so
+    a file is either fully updated or untouched. A file all of whose
+    findings were skipped is not opened at all, and its modification time
+    does not change.
+
+    Args:
+        findings: The findings to remediate, in any order. Ones that
+            cannot or must not be rewritten are reported rather than
+            raised.
+
+    Returns:
+        The rewrites performed and the findings declined, each in the
+        order the findings were supplied.
+
+    Raises:
+        DuplicateFixError: Two findings named the same line of the same
+            file, so applying both would silently discard one.
+        ValueError: A file no longer has the line a finding names, which
+            means it changed after it was scanned.
+        OSError: A file could not be read or rewritten. Files handled
+            before it keep their rewrites; the failing file is unchanged.
+    """
+    plans, skipped = _plan_fixes(findings)
+    return FixOutcome(applied=_write_plans(plans), skipped=skipped)
+
+
+def _plan_fixes(
+    findings: Iterable[AllowListFinding],
+) -> tuple[
+    dict[Path, dict[int, _Planned]],
+    list[tuple[AllowListFinding, str]],
+]:
+    """Compute the replacement line for every fixable finding.
+
+    Nothing is written here, so a :class:`DuplicateFixError` leaves every
+    file untouched rather than half of them rewritten.
+
+    Args:
+        findings: The findings to remediate.
+
+    Returns:
+        A ``(plans, skipped)`` tuple. ``plans`` maps each file to its
+        planned rewrites by 1-based line number, both mappings in
+        first-seen order.
+
+    Raises:
+        DuplicateFixError: Two findings named the same line of the same
+            file.
+    """
+    plans: dict[Path, dict[int, _Planned]] = {}
+    skipped: list[tuple[AllowListFinding, str]] = []
+
+    for finding in findings:
+        pin = finding.pin
+        try:
+            new_line = _rewrite_line(finding)
+        except _Unfixable as declined:
+            logger.debug(
+                f"Not fixing {pin.file_path}:{pin.line_number}: "
+                f"{declined.reason}"
+            )
+            skipped.append((finding, declined.reason))
+            continue
+
+        by_line = plans.setdefault(pin.file_path, {})
+        if pin.line_number in by_line:
+            raise DuplicateFixError(pin.file_path, pin.line_number)
+        by_line[pin.line_number] = _Planned(finding=finding, new_line=new_line)
+
+    return plans, skipped
+
+
+def _write_plans(plans: dict[Path, dict[int, _Planned]]) -> list[AppliedFix]:
+    """Write each file's planned rewrites in one atomic call.
+
+    Args:
+        plans: Planned rewrites, keyed by file and 1-based line number.
+
+    Returns:
+        One :class:`AppliedFix` per planned rewrite, in planning order.
+        ``old_line`` is the content that was actually on disk, which is
+        what a caller should render in a diff.
+
+    Raises:
+        ValueError: A file no longer has a line a plan names.
+        OSError: A file could not be read or rewritten.
+    """
+    applied: list[AppliedFix] = []
+    for path, by_line in plans.items():
+        changes = replace_lines(
+            path,
+            {number: plan.new_line for number, plan in by_line.items()},
+        )
+        by_number = {change.line_number: change for change in changes}
+        for number, plan in by_line.items():
+            change = by_number[number]
+            applied.append(
+                AppliedFix(
+                    finding=plan.finding,
+                    line_number=number,
+                    old_line=change.old_line,
+                    new_line=change.new_line,
+                )
+            )
+    return applied
+
+
+def _rewrite_line(finding: AllowListFinding) -> str:
+    """Build the replacement for one finding's source line.
+
+    Args:
+        finding: The finding to remediate.
+
+    Returns:
+        The complete replacement line, without a terminator.
+
+    Raises:
+        _Unfixable: The finding must not, or cannot, be rewritten.
+    """
+    pin = finding.pin
+    if finding.suppressed:
+        raise _Unfixable(REASON_SUPPRESSED)
+    if not pin.auto_fixable:
+        raise _Unfixable(REASON_MULTILINE)
+    if finding.target_sha is None:
+        raise _Unfixable(REASON_NO_TARGET)
+
+    start, end = _locate_spec(pin)
+    edits = [_ref_edit(pin, start, end, finding.target_sha)]
+    comment = _comment_edit(pin, end, finding.target_version)
+    if comment is not None:
+        edits.append(comment)
+    return _apply_edits(pin.raw_line, edits)
+
+
+def _locate_spec(pin: AllowListPin) -> tuple[int, int]:
+    """Find the spec text within the pin's source line.
+
+    The search starts at the scalar's own column, so a spec that also
+    appears earlier on the line -- in a comment, say -- cannot be matched
+    by accident.
+
+    Args:
+        pin: The pin to locate.
+
+    Returns:
+        The half-open ``(start, end)`` span of the spec text.
+
+    Raises:
+        _Unfixable: The spec is not present on the recorded line.
+    """
+    spec_text = pin.raw_value.strip()
+    if not spec_text:
+        raise _Unfixable(REASON_SPEC_NOT_FOUND)
+    start = pin.raw_line.find(spec_text, max(pin.column, 0))
+    if start < 0:
+        raise _Unfixable(REASON_SPEC_NOT_FOUND)
+    return start, start + len(spec_text)
+
+
+def _ref_edit(
+    pin: AllowListPin,
+    start: int,
+    end: int,
+    target_sha: str,
+) -> _Edit:
+    """Build the edit that moves the spec's ref to the target commit.
+
+    :func:`~gha_workflow_linter.allow_list_spec.render_spec` re-emits the
+    repository and subpath parts exactly as the author wrote them, so the
+    rendered spec differs from the original only from the final ``@``
+    onwards. Trimming the shared prefix therefore reduces the edit to the
+    ref itself -- and to appending ``@<sha>`` when the author wrote no
+    ref at all.
+
+    Args:
+        pin: The pin being repaired.
+        start: Index the spec text starts at.
+        end: Index just past the spec text.
+        target_sha: Commit the pin should name.
+
+    Returns:
+        The edit to apply to the line.
+
+    Raises:
+        _Unfixable: ``target_sha`` is not a valid git ref.
+    """
+    try:
+        rendered = render_spec(pin.spec, ref=target_sha)
+    except SpecError as error:
+        logger.debug(f"Cannot render spec with ref '{target_sha}': {error}")
+        raise _Unfixable(REASON_INVALID_REF) from error
+
+    shared = _shared_prefix(pin.raw_line[start:end], rendered)
+    return _Edit(start=start + shared, end=end, text=rendered[shared:])
+
+
+def _shared_prefix(left: str, right: str) -> int:
+    """Return how many leading characters two strings have in common.
+
+    Args:
+        left: First string.
+        right: Second string.
+
+    Returns:
+        The length of the common prefix, zero when there is none.
+    """
+    limit = min(len(left), len(right))
+    index = 0
+    while index < limit and left[index] == right[index]:
+        index += 1
+    return index
+
+
+def _comment_edit(
+    pin: AllowListPin,
+    spec_end: int,
+    target_version: str | None,
+) -> _Edit | None:
+    """Build the edit that corrects (or adds) the version comment.
+
+    A pin with no comment gains one, separated by
+    :data:`COMMENT_SEPARATOR`, at the end of its line -- past any
+    trailing whitespace, which is left exactly where its author put it.
+    An existing comment has only its body replaced, so the ``#``, the
+    spacing on either side of it and, for an in-scalar comment, the
+    closing quote are all untouched.
+
+    Args:
+        pin: The pin being repaired.
+        spec_end: Index just past the spec text on the line.
+        target_version: Release tag to name, or ``None`` when the target
+            has no tag, in which case the comment is left entirely
+            alone rather than stripped of a version it still needs.
+
+    Returns:
+        The edit to apply, or ``None`` when the comment needs no change.
+
+    Raises:
+        _Unfixable: The pin records a comment that its line does not
+            carry, or carries with different content.
+    """
+    if target_version is None:
+        return None
+
+    if pin.comment_position is CommentPosition.NONE:
+        end_of_line = len(pin.raw_line)
+        return _Edit(
+            start=end_of_line,
+            end=end_of_line,
+            text=f"{COMMENT_SEPARATOR}# {target_version}",
+        )
+
+    start, end = _locate_comment_body(pin, spec_end)
+    parsed = parse_trailing_comment(pin.raw_line[start:end])
+    if parsed.version != pin.version_comment:
+        raise _Unfixable(REASON_COMMENT_CHANGED)
+    return _Edit(
+        start=start,
+        end=end,
+        text=render_comment(parsed, version=target_version),
+    )
+
+
+def _locate_comment_body(pin: AllowListPin, spec_end: int) -> tuple[int, int]:
+    """Find the body of the pin's trailing comment on its line.
+
+    The body excludes the ``#``, the whitespace on either side of it and,
+    for an in-scalar comment, the closing quote, so replacing it cannot
+    disturb any of them.
+
+    Args:
+        pin: The pin being repaired.
+        spec_end: Index just past the spec text on the line.
+
+    Returns:
+        The half-open ``(start, end)`` span of the comment body.
+
+    Raises:
+        _Unfixable: The line carries no comment after the spec, or the
+            in-scalar comment's closing quote cannot be found.
+    """
+    line = pin.raw_line
+    tail = line[spec_end:]
+    before, comment = split_comment(tail)
+    marker = tail.find("#", len(before))
+    if not comment or marker < 0:
+        raise _Unfixable(REASON_COMMENT_NOT_FOUND)
+
+    start = spec_end + marker + 1
+    while start < len(line) and line[start] in _BLANK:
+        start += 1
+
+    end = _comment_body_end(pin, start)
+    while end > start and line[end - 1] in _BLANK:
+        end -= 1
+    return start, end
+
+
+def _comment_body_end(pin: AllowListPin, body_start: int) -> int:
+    """Return where the comment body stops, before any trailing text.
+
+    A YAML comment runs to the end of the line. A comment inside the
+    scalar stops at the closing quote, which is the last one on the line:
+    a quote after it would itself be inside the comment, and a quote
+    within the comment body would have to be escaped to survive the YAML
+    parse that produced this pin.
+
+    Args:
+        pin: The pin being repaired.
+        body_start: Index the comment body starts at.
+
+    Returns:
+        Index just past the last character of the body.
+
+    Raises:
+        _Unfixable: The scalar is quoted but its closing quote is not
+            after the comment body, so the line is not the shape the
+            scan recorded.
+    """
+    if pin.comment_position is not CommentPosition.IN_SCALAR:
+        return len(pin.raw_line)
+
+    quote = _QUOTE_CHARACTERS.get(pin.quote_style)
+    closing = -1 if quote is None else pin.raw_line.rfind(quote)
+    if closing < body_start:
+        raise _Unfixable(REASON_COMMENT_NOT_FOUND)
+    return closing
+
+
+def _apply_edits(line: str, edits: Sequence[_Edit]) -> str:
+    """Apply non-overlapping substitutions to one line.
+
+    Edits are applied from the right so that each one's indices still
+    refer to the text they were computed against.
+
+    Args:
+        line: The source line, without its terminator.
+        edits: The substitutions to make. They must not overlap.
+
+    Returns:
+        The rewritten line.
+    """
+    result = line
+    for edit in sorted(edits, key=lambda item: item.start, reverse=True):
+        result = result[: edit.start] + edit.text + result[edit.end :]
+    return result

--- a/src/gha_workflow_linter/allow_list_report.py
+++ b/src/gha_workflow_linter/allow_list_report.py
@@ -1,0 +1,481 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Rendering of allow-list findings, for humans and for machines.
+
+Two renderers sit side by side here because they answer to different
+audiences and must not drift apart:
+
+* :func:`render_text` writes a Rich report styled after the existing
+  stale-actions block, deduplicated so that a workflow carrying fifteen
+  identical pins produces one readable paragraph rather than fifteen.
+* :func:`build_json` returns the ``allow_list`` object of the
+  ``--format json`` document (design section 9.4), including suppressed
+  findings, so a machine consumer sees the whole picture without needing
+  ``--show-suppressed``.
+
+Neither renderer decides anything. Severity, suppression and resolution
+status arrive already settled on the
+:class:`~gha_workflow_linter.allow_list_check.AllowListOutcome`; what
+varies here is only what reaches the terminal.
+
+Deduplication groups findings by ``(kind, current_sha, target_sha)``
+within each file, mirroring ``cli._print_deduplicated_action_refs``. The
+group's source lines are listed together, so nothing is hidden -- the
+repetition is what disappears, not the information.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .console import console
+from .models import AllowListFindingKind
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+    from .allow_list_check import AllowListFinding, AllowListOutcome
+
+__all__ = [
+    "build_json",
+    "render_text",
+]
+
+#: Sections, in the order they are printed. Defect kinds come first: a
+#: comment that lies is wrong now, whereas a stale pin merely could be
+#: newer.
+_SECTION_ORDER: tuple[AllowListFindingKind, ...] = (
+    AllowListFindingKind.COMMENT_MISMATCH,
+    AllowListFindingKind.STALE,
+    AllowListFindingKind.UNPINNED,
+    AllowListFindingKind.UNRESOLVABLE,
+    AllowListFindingKind.INVALID_SPEC,
+)
+
+#: Heading and Rich style for each section.
+_SECTIONS: dict[AllowListFindingKind, tuple[str, str]] = {
+    AllowListFindingKind.COMMENT_MISMATCH: (
+        "Allow-list pins with incorrect version comments ⚠️",
+        "yellow",
+    ),
+    AllowListFindingKind.STALE: ("Stale allow-list pins ⚠️", "yellow"),
+    AllowListFindingKind.UNPINNED: (
+        "Allow-list pins not pinned to a commit SHA ℹ️",
+        "cyan",
+    ),
+    AllowListFindingKind.UNRESOLVABLE: (
+        "Allow-list pins naming an unknown commit ⚠️",
+        "red",
+    ),
+    AllowListFindingKind.INVALID_SPEC: (
+        "Malformed allow-list pins ❌",
+        "red",
+    ),
+}
+
+#: Kinds ``--update-allow-list`` can repair, and therefore the kinds
+#: whose presence justifies advertising it.
+_FIXABLE: frozenset[AllowListFindingKind] = frozenset(
+    {
+        AllowListFindingKind.STALE,
+        AllowListFindingKind.COMMENT_MISMATCH,
+        AllowListFindingKind.UNPINNED,
+    }
+)
+
+#: Characters of a SHA shown before the ellipsis. Enough to identify a
+#: commit at a glance, short enough to keep a pin on one line.
+_SHA_DISPLAY_LENGTH = 8
+
+#: Summary buckets always present, in the order design section 9.4 lists
+#: them. Kinds outside this set gain a bucket only if they occur.
+_SUMMARY_KINDS: tuple[AllowListFindingKind, ...] = (
+    AllowListFindingKind.STALE,
+    AllowListFindingKind.COMMENT_MISMATCH,
+    AllowListFindingKind.UNPINNED,
+)
+
+
+def _relative(file_path: Path, root: Path) -> str:
+    """Render a path relative to the scan root, with POSIX separators.
+
+    Args:
+        file_path: The path to render.
+        root: The base the path should be relative to.
+
+    Returns:
+        The relative path, or the original path when it lies outside
+        ``root``. Separators are always ``/`` so that reports and JSON
+        compare equal across platforms.
+    """
+    try:
+        return file_path.relative_to(root).as_posix()
+    except ValueError:
+        return file_path.as_posix()
+
+
+def _short_sha(sha: str) -> str:
+    """Abbreviate a commit SHA for display.
+
+    Args:
+        sha: The full SHA.
+
+    Returns:
+        The first :data:`_SHA_DISPLAY_LENGTH` characters followed by an
+        ellipsis, or the SHA unchanged when it is already short.
+    """
+    if len(sha) <= _SHA_DISPLAY_LENGTH:
+        return sha
+    return f"{sha[:_SHA_DISPLAY_LENGTH]}…"
+
+
+def _quoted(finding: AllowListFinding, ref: str) -> str:
+    """Render a ref in the quoting style its pin was written with.
+
+    Args:
+        finding: The finding whose pin supplies the quoting style.
+        ref: The ref text to quote, without its leading ``@``.
+
+    Returns:
+        The quoted ``@<ref>`` text.
+    """
+    quote = {"single": "'", "double": '"'}.get(
+        finding.pin.quote_style.value, ""
+    )
+    return f"{quote}@{ref}{quote}"
+
+
+def _current_text(finding: AllowListFinding) -> str:
+    """Render the "as written" half of one finding.
+
+    Args:
+        finding: The finding to render.
+
+    Returns:
+        Text of the form ``config: '@18d9c444…'  # v0.1.1``. The comment
+        is omitted when the pin carries none.
+    """
+    key = finding.pin.key_path[-1] if finding.pin.key_path else "config"
+    ref = finding.pin.spec.ref
+    shown = _short_sha(ref) if finding.current_sha else ref
+    text = f"{key}: {_quoted(finding, shown)}"
+    comment = finding.pin.version_comment
+    if comment:
+        text = f"{text}  # {comment}"
+    return text
+
+
+def _target_text(finding: AllowListFinding) -> str:
+    """Render the "should be" half of one finding.
+
+    Args:
+        finding: The finding to render.
+
+    Returns:
+        Text of the form ``'@bf6642f6…'  # v0.12.2   (org/repo)``.
+    """
+    sha = finding.target_sha or ""
+    text = f"→ {_quoted(finding, _short_sha(sha))}"
+    if finding.target_version:
+        text = f"{text}  # {finding.target_version}"
+    return f"{text}   ({finding.host_repo})"
+
+
+def _line_label(lines: Sequence[int]) -> str:
+    """Render the line-number label of one deduplicated group.
+
+    Args:
+        lines: The distinct source lines the group covers, ascending.
+
+    Returns:
+        ``line 116`` for a single line, ``lines 116, 292, 349``
+        otherwise.
+    """
+    numbers = ", ".join(str(number) for number in lines)
+    return f"line {numbers}" if len(lines) == 1 else f"lines {numbers}"
+
+
+def _group_findings(
+    findings: Iterable[AllowListFinding],
+) -> dict[tuple[str, str | None, str | None], list[AllowListFinding]]:
+    """Group findings by ``(kind, current_sha, target_sha)``.
+
+    Args:
+        findings: Findings from a single file.
+
+    Returns:
+        Mapping of group key to its findings, in first-seen order.
+    """
+    groups: dict[
+        tuple[str, str | None, str | None], list[AllowListFinding]
+    ] = {}
+    for finding in findings:
+        key = (finding.kind.value, finding.current_sha, finding.target_sha)
+        groups.setdefault(key, []).append(finding)
+    return groups
+
+
+def _by_file(
+    findings: Iterable[AllowListFinding], root: Path
+) -> dict[str, list[AllowListFinding]]:
+    """Group findings by their file, keyed by the displayed path.
+
+    Args:
+        findings: The findings to group.
+        root: Base for relative paths.
+
+    Returns:
+        Mapping of relative path to its findings, in first-seen order.
+    """
+    files: dict[str, list[AllowListFinding]] = {}
+    for finding in findings:
+        path = _relative(finding.pin.file_path, root)
+        files.setdefault(path, []).append(finding)
+    return files
+
+
+def _print_group(
+    group: list[AllowListFinding], *, style: str, reasons: bool
+) -> None:
+    """Print one deduplicated group of findings.
+
+    Args:
+        group: Findings sharing a kind, a current SHA and a target SHA.
+        style: Rich style for the "as written" line.
+        reasons: Whether to print the suppression reasons the group
+            carries.
+    """
+    lines = sorted({finding.pin.line_number for finding in group})
+    label = _line_label(lines)
+    pad = " " * len(label)
+    first = group[0]
+
+    console.print(f"    [{style}]{label}[/{style}]   {_current_text(first)}")
+    console.print(f"    {pad}   [green]{_target_text(first)}[/green]")
+
+    if not reasons:
+        return
+    seen: list[str] = []
+    for finding in group:
+        reason = finding.pin.suppression_reason or "no reason given"
+        if reason not in seen:
+            seen.append(reason)
+            console.print(f"    {pad}   [dim]suppressed: {reason}[/dim]")
+
+
+def _print_section(
+    title: str,
+    style: str,
+    findings: list[AllowListFinding],
+    *,
+    root: Path,
+    reasons: bool = False,
+) -> None:
+    """Print one titled section of findings, grouped by file.
+
+    Args:
+        title: Section heading.
+        style: Rich style for the heading and the "as written" lines.
+        findings: The findings in this section.
+        root: Base for relative paths.
+        reasons: Whether to print suppression reasons.
+    """
+    console.print(f"[bold {style}]{title}[/bold {style}]\n")
+    for path, file_findings in _by_file(findings, root).items():
+        console.print(f"  [bold]{path}[/bold]")
+        for group in _group_findings(file_findings).values():
+            _print_group(group, style=style, reasons=reasons)
+        console.print()
+
+
+def _print_unresolved(outcome: AllowListOutcome) -> None:
+    """Print a notice for every host repository that failed to resolve.
+
+    Args:
+        outcome: The check outcome.
+    """
+    for repo_key, reason in outcome.unresolved.items():
+        console.print(
+            f"[yellow]Allow-list check skipped for {repo_key}: "
+            f"{reason}[/yellow]\n"
+        )
+
+
+def _print_suppression_summary(
+    outcome: AllowListOutcome, *, root: Path, show_suppressed: bool
+) -> None:
+    """Print the always-on suppression summary, and optionally detail.
+
+    A suppression that becomes invisible forever is a suppression nobody
+    audits, so the one-line count is emitted whenever any suppression is
+    active, regardless of ``show_suppressed``.
+
+    Args:
+        outcome: The check outcome.
+        root: Base for relative paths.
+        show_suppressed: Whether to list each suppressed pin as a notice
+            with its reason.
+    """
+    suppressed = [finding for finding in outcome.findings if finding.suppressed]
+    if not suppressed:
+        return
+
+    if show_suppressed:
+        _print_section(
+            "Suppressed allow-list pins ℹ️",
+            "dim",
+            suppressed,
+            root=root,
+            reasons=True,
+        )
+
+    files = {finding.pin.file_path for finding in suppressed}
+    noun = "pin" if len(suppressed) == 1 else "pins"
+    file_noun = "file" if len(files) == 1 else "files"
+    summary = (
+        f"{len(suppressed)} allow-list {noun} suppressed "
+        f"({len(files)} {file_noun})"
+    )
+    if not show_suppressed:
+        summary = f"{summary} — use --show-suppressed for detail"
+    console.print(f"[dim]{summary}[/dim]\n")
+
+
+def render_text(
+    outcome: AllowListOutcome,
+    *,
+    root: Path,
+    show_suppressed: bool,
+    update_hint: bool,
+) -> None:
+    """Write the human-readable allow-list report to the shared console.
+
+    Nothing is printed when the check did not run, or when it ran and
+    found nothing: silence is the success signal, matching the rest of
+    the linter's report.
+
+    Args:
+        outcome: The check outcome.
+        root: Repository root, so paths print relative to it.
+        show_suppressed: List suppressed pins as notices with their
+            reasons. Never changes what the caller returns.
+        update_hint: Advertise ``--update-allow-list`` when repairable
+            findings remain. Callers pass ``False`` once remediation has
+            already run.
+    """
+    if not outcome.checked:
+        return
+
+    _print_unresolved(outcome)
+
+    visible = outcome.unsuppressed
+    for kind in _SECTION_ORDER:
+        group = [finding for finding in visible if finding.kind is kind]
+        if not group:
+            continue
+        title, style = _SECTIONS[kind]
+        _print_section(title, style, group, root=root)
+
+    _print_suppression_summary(
+        outcome, root=root, show_suppressed=show_suppressed
+    )
+
+    if update_hint and any(finding.kind in _FIXABLE for finding in visible):
+        console.print(
+            "[cyan]  Run with [bold]--update-allow-list[/bold] to apply "
+            "these changes 💡[/cyan]\n"
+        )
+
+
+def _finding_json(finding: AllowListFinding, *, root: Path) -> dict[str, Any]:
+    """Render one finding as a JSON object.
+
+    Args:
+        finding: The finding to render.
+        root: Base for the relative ``file`` path.
+
+    Returns:
+        The finding object of design section 9.4. ``fixed`` is always
+        ``False`` here: remediation is a separate phase, and the fixer
+        rewrites this field when it runs.
+    """
+    return {
+        "file": _relative(finding.pin.file_path, root),
+        "line": finding.pin.line_number,
+        "kind": finding.kind.value,
+        "severity": finding.severity.value,
+        "current_sha": finding.current_sha,
+        "current_version": finding.pin.version_comment,
+        "target_sha": finding.target_sha,
+        "target_version": finding.target_version,
+        "suppressed": finding.suppressed,
+        "fixed": False,
+    }
+
+
+def _summary_json(outcome: AllowListOutcome) -> dict[str, int]:
+    """Count findings per kind, plus the suppressed and fixed totals.
+
+    The per-kind buckets count **unsuppressed** findings only, so
+    ``stale`` reads as "stale pins that count". Suppressed findings are
+    counted once, together, under ``suppressed``; the two therefore sum
+    to the length of ``findings``.
+
+    Args:
+        outcome: The check outcome.
+
+    Returns:
+        The summary object, with the buckets of design section 9.4
+        always present even when zero.
+    """
+    counts = {kind.value: 0 for kind in _SUMMARY_KINDS}
+    for finding in outcome.findings:
+        if finding.suppressed:
+            continue
+        counts[finding.kind.value] = counts.get(finding.kind.value, 0) + 1
+
+    counts["suppressed"] = outcome.suppressed_count
+    counts["fixed"] = 0
+    return counts
+
+
+def build_json(outcome: AllowListOutcome, *, root: Path) -> dict[str, Any]:
+    """Build the ``allow_list`` object of the JSON report.
+
+    Suppressed findings are always included, carrying
+    ``"suppressed": true``, so a machine consumer sees everything the
+    ``--show-suppressed`` flag would reveal.
+
+    Args:
+        outcome: The check outcome.
+        root: Repository root, so paths appear relative to it.
+
+    Returns:
+        A single-key dictionary, ready to merge into the report
+        document. ``hosts`` holds only the repositories that resolved;
+        the rest appear in ``unresolved`` with their reason, which is
+        what a caller needs to distinguish "clean" from "could not
+        check".
+    """
+    return {
+        "allow_list": {
+            "checked": outcome.checked,
+            "resolved": outcome.resolved,
+            "hosts": {
+                repo_key: {
+                    "latest_version": release.tag,
+                    "latest_sha": release.commit_sha,
+                }
+                for repo_key, release in outcome.hosts.items()
+                if release is not None
+            },
+            "unresolved": dict(outcome.unresolved),
+            "findings": [
+                _finding_json(finding, root=root)
+                for finding in outcome.findings
+            ],
+            "summary": _summary_json(outcome),
+        }
+    }

--- a/src/gha_workflow_linter/allow_list_report.py
+++ b/src/gha_workflow_linter/allow_list_report.py
@@ -389,17 +389,18 @@ def render_text(
         )
 
 
-def _finding_json(finding: AllowListFinding, *, root: Path) -> dict[str, Any]:
+def _finding_json(
+    finding: AllowListFinding, *, root: Path, fixed: bool
+) -> dict[str, Any]:
     """Render one finding as a JSON object.
 
     Args:
         finding: The finding to render.
         root: Base for the relative ``file`` path.
+        fixed: Whether remediation rewrote this finding's line.
 
     Returns:
-        The finding object of design section 9.4. ``fixed`` is always
-        ``False`` here: remediation is a separate phase, and the fixer
-        rewrites this field when it runs.
+        The finding object of design section 9.4.
     """
     return {
         "file": _relative(finding.pin.file_path, root),
@@ -411,7 +412,7 @@ def _finding_json(finding: AllowListFinding, *, root: Path) -> dict[str, Any]:
         "target_sha": finding.target_sha,
         "target_version": finding.target_version,
         "suppressed": finding.suppressed,
-        "fixed": False,
+        "fixed": fixed,
     }
 
 
@@ -437,7 +438,7 @@ def _summary_json(outcome: AllowListOutcome) -> dict[str, int]:
         counts[finding.kind.value] = counts.get(finding.kind.value, 0) + 1
 
     counts["suppressed"] = outcome.suppressed_count
-    counts["fixed"] = 0
+    counts["fixed"] = outcome.fixed_count
     return counts
 
 
@@ -473,7 +474,9 @@ def build_json(outcome: AllowListOutcome, *, root: Path) -> dict[str, Any]:
             },
             "unresolved": dict(outcome.unresolved),
             "findings": [
-                _finding_json(finding, root=root)
+                _finding_json(
+                    finding, root=root, fixed=outcome.was_fixed(finding)
+                )
                 for finding in outcome.findings
             ],
             "summary": _summary_json(outcome),

--- a/src/gha_workflow_linter/allow_list_resolver.py
+++ b/src/gha_workflow_linter/allow_list_resolver.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Latest-release resolution for harden-runner allow-list host repos.
+
+A harden-runner allow-list pin names a commit of a host repository
+(normally ``<org>/.github``) and is stale when that commit is not the one
+behind the host repository's latest release. This module answers the
+second half of that question: given host repositories, what is the latest
+release and which *commit* does its tag peel to?
+
+:class:`AllowListResolver` is deliberately backend-agnostic. It drives the
+GitHub GraphQL client when ``validation_method`` is
+:attr:`~gha_workflow_linter.models.ValidationMethod.GITHUB_API` and
+``git ls-remote`` otherwise, but the ranking, draft/prerelease filtering
+and cooldown enforcement are the shared, pure helpers in
+:mod:`gha_workflow_linter.latest_release`, so both backends give the same
+answer for the same repository.
+
+Two behaviours are worth stating up front, because they are contracts the
+caller depends on rather than incidental implementation details:
+
+* **Resolution is fail-soft.** No token, no network, a rate limit, a
+  missing repository, a repository with no releases, or a cooldown that
+  excludes everything all produce ``None`` for that repository. Deciding
+  whether "could not check" is fatal belongs to the caller, which knows
+  whether enforcement was requested.
+* **Each distinct host repository costs one lookup.** Twenty pins naming
+  ``lfreleng-actions/.github`` resolve it once, and a repeated run within
+  the cache TTL resolves it zero times -- except while a cooldown is
+  active, when the cache is bypassed entirely. See :attr:`cache_usable`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from .git_refs import get_remote_tag_shas
+from .github_api import GitHubGraphQLClient
+from .github_auth import get_github_token_with_fallback
+from .latest_release import (
+    LatestRelease,
+    ReleasePolicy,
+    select_latest_release,
+    tag_candidates,
+)
+from .models import ValidationMethod
+from .paths import base_repository
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from .cache import ValidationCache
+    from .models import Config
+
+
+class AllowListResolver:
+    """Resolve the latest release of each allow-list host repository.
+
+    Attributes:
+        config: The linter configuration, supplying the validation method,
+            prerelease and cooldown policy, and backend settings.
+        cache: Validation cache reused for latest-version storage.
+    """
+
+    def __init__(self, config: Config, cache: ValidationCache) -> None:
+        """
+        Initialise the resolver.
+
+        Args:
+            config: Linter configuration.
+            cache: Validation cache used to avoid repeat lookups across
+                runs. The existing ``get_latest_version`` /
+                ``put_latest_version`` pair is reused unchanged; no new
+                cache store is introduced.
+        """
+        self.config = config
+        self.cache = cache
+        self.logger = logging.getLogger(__name__)
+
+    @property
+    def policy(self) -> ReleasePolicy:
+        """The release policy implied by the configuration.
+
+        Returns:
+            A :class:`~gha_workflow_linter.latest_release.ReleasePolicy`
+            carrying ``allow_prerelease`` and ``cooldown_days``.
+        """
+        return ReleasePolicy(
+            allow_prerelease=self.config.allow_prerelease,
+            cooldown_days=self.config.cooldown_days,
+        )
+
+    @property
+    def cache_usable(self) -> bool:
+        """Whether persisted results may be used and written this run.
+
+        The cache stores ``(tag, sha)`` and nothing else, so a restored
+        :class:`~gha_workflow_linter.latest_release.LatestRelease` has an
+        empty ``commit_tags`` and cannot say whether a pin is behind the
+        target or ahead of it. That is harmless without a cooldown --
+        the target is then the newest release, so nothing can be ahead of
+        it -- but under a cooldown the target is deliberately an *older*
+        release, and losing direction would turn a correct pin into a
+        recommendation to downgrade.
+
+        Bypassing the cache while a cooldown is active also keeps the
+        stored entries honest: only unconstrained "newest release"
+        answers are ever written, so a later run without a cooldown
+        cannot read back a cooldown-shifted target.
+
+        Returns:
+            ``True`` when no cooldown is in force.
+        """
+        return self.config.cooldown_days <= 0
+
+    async def resolve(
+        self, repo_keys: Iterable[str]
+    ) -> dict[str, LatestRelease | None]:
+        """
+        Resolve the latest release of each distinct host repository.
+
+        Repository keys are de-duplicated first, so a host shared by many
+        pins costs exactly one lookup. Cached repositories are answered
+        without touching a backend at all, unless :attr:`cache_usable` is
+        ``False``.
+
+        Args:
+            repo_keys: Host repository keys, ``owner/repo``. Duplicates
+                and empty entries are ignored.
+
+        Returns:
+            Dictionary mapping each distinct repository key to its latest
+            release, or ``None`` where resolution failed or no release
+            qualified. Never raises for a resolution failure.
+        """
+        unique = list(dict.fromkeys(key for key in repo_keys if key))
+        if not unique:
+            return {}
+
+        cache_usable = self.cache_usable
+        results: dict[str, LatestRelease | None] = {}
+        pending: list[str] = []
+        for repo_key in unique:
+            cached = self._cached(repo_key) if cache_usable else None
+            if cached is not None:
+                results[repo_key] = cached
+            else:
+                pending.append(repo_key)
+
+        if not pending:
+            self.logger.debug(
+                f"Latest-release cache hits: {len(results)}, 0 to resolve"
+            )
+            return results
+
+        if not cache_usable:
+            self.logger.debug(
+                "Cooldown active; bypassing the latest-release cache so "
+                "the release each pinned commit belongs to stays known"
+            )
+
+        self.logger.debug(
+            f"Latest-release cache hits: {len(results)}, "
+            f"{len(pending)} to resolve"
+        )
+        results.update(await self._resolve_uncached(pending))
+        if cache_usable:
+            self._store(results, pending)
+
+        return results
+
+    def _cached(self, repo_key: str) -> LatestRelease | None:
+        """
+        Read a repository's latest release from the persistent cache.
+
+        Args:
+            repo_key: Host repository key.
+
+        Returns:
+            The cached release, or ``None`` on a miss, an expired entry,
+            or an unreadable cache. ``published_at`` is always ``None``
+            and ``commit_tags`` always empty: the cache stores only
+            ``(tag, sha)``. Neither is needed once a release has been
+            selected without a cooldown, and :attr:`cache_usable` keeps
+            this path out of the runs where they would be.
+        """
+        try:
+            cached = self.cache.get_latest_version(repo_key)
+        except Exception as e:
+            self.logger.debug(f"Latest-version cache read failed: {e}")
+            return None
+
+        if not cached:
+            return None
+
+        tag, commit_sha = cached
+        if not tag or not commit_sha:
+            return None
+
+        return LatestRelease(tag=tag, commit_sha=commit_sha)
+
+    def _store(
+        self,
+        results: dict[str, LatestRelease | None],
+        repo_keys: list[str],
+    ) -> None:
+        """
+        Persist freshly resolved releases so the next run costs nothing.
+
+        Unresolved repositories are deliberately not cached: a transient
+        outage must not be remembered as "this repository has no release"
+        for the duration of the cache TTL.
+
+        Args:
+            results: The resolution results.
+            repo_keys: Keys that were resolved in this run (as opposed to
+                served from the cache).
+        """
+        try:
+            stored = False
+            for repo_key in repo_keys:
+                release = results.get(repo_key)
+                if release is None:
+                    continue
+                self.cache.put_latest_version(
+                    repo_key, release.tag, release.commit_sha
+                )
+                stored = True
+            if stored:
+                self.cache.save()
+        except Exception as e:
+            self.logger.debug(f"Latest-version cache write failed: {e}")
+
+    async def _resolve_uncached(
+        self, repo_keys: list[str]
+    ) -> dict[str, LatestRelease | None]:
+        """
+        Resolve repositories that the cache could not answer.
+
+        Args:
+            repo_keys: Distinct host repository keys.
+
+        Returns:
+            Dictionary mapping every supplied key to its latest release or
+            ``None``. This is the fail-soft boundary: no failure escapes.
+        """
+        try:
+            if self.config.validation_method == ValidationMethod.GITHUB_API:
+                return await self._resolve_via_api(repo_keys)
+            return await self._resolve_via_git(repo_keys)
+        except Exception as e:
+            self.logger.warning(
+                f"Could not resolve the latest release of "
+                f"{len(repo_keys)} repositories: {e}"
+            )
+            return dict.fromkeys(repo_keys, None)
+
+    def _make_github_client(self) -> GitHubGraphQLClient:
+        """
+        Build the GraphQL client, reusing the shared token discovery.
+
+        Returns:
+            A client configured with the best available token. Tests
+            override this method to supply a double.
+        """
+        api_config = self.config.github_api
+        token = get_github_token_with_fallback(api_config.token, quiet=True)
+        if token and token != api_config.token:
+            api_config = api_config.model_copy(update={"token": token})
+
+        return GitHubGraphQLClient(api_config)
+
+    async def _resolve_via_api(
+        self, repo_keys: list[str]
+    ) -> dict[str, LatestRelease | None]:
+        """
+        Resolve latest releases through the batched GraphQL query.
+
+        Args:
+            repo_keys: Distinct host repository keys.
+
+        Returns:
+            Dictionary mapping every supplied key to its latest release or
+            ``None``.
+        """
+        client = self._make_github_client()
+        async with client:
+            resolved = await client.resolve_latest_releases_batch(
+                repo_keys, self.policy
+            )
+
+        return {repo_key: resolved.get(repo_key) for repo_key in repo_keys}
+
+    async def _resolve_via_git(
+        self, repo_keys: list[str]
+    ) -> dict[str, LatestRelease | None]:
+        """
+        Resolve latest releases through ``git ls-remote``, in parallel.
+
+        Args:
+            repo_keys: Distinct host repository keys.
+
+        Returns:
+            Dictionary mapping every supplied key to its latest release or
+            ``None``.
+        """
+        semaphore = asyncio.Semaphore(max(1, self.config.parallel_workers))
+
+        async def resolve_one(
+            repo_key: str,
+        ) -> tuple[str, LatestRelease | None]:
+            """Resolve one repository off the event loop."""
+            async with semaphore:
+                release = await asyncio.to_thread(
+                    self._resolve_one_via_git, repo_key
+                )
+                return repo_key, release
+
+        results: dict[str, LatestRelease | None] = {}
+        for repo_key, release in await asyncio.gather(
+            *[resolve_one(repo_key) for repo_key in repo_keys]
+        ):
+            results[repo_key] = release
+
+        return results
+
+    def _resolve_one_via_git(self, repo_key: str) -> LatestRelease | None:
+        """
+        Resolve one repository's latest release from its remote tags.
+
+        ``git ls-remote`` advertises tags but no release metadata, so this
+        path can supply no publication dates. Rather than guess at a
+        release's age it declines to answer while a cooldown is active,
+        matching ``auto_fix_versions._get_latest_version_via_git``.
+
+        Args:
+            repo_key: Host repository key.
+
+        Returns:
+            The latest release, or ``None`` when the remote could not be
+            read, no clean version tag exists, or a cooldown is active.
+        """
+        if self.config.cooldown_days > 0:
+            self.logger.debug(
+                "Cooldown active but release dates are unavailable via "
+                "Git for %s; reporting no latest release",
+                repo_key,
+            )
+            return None
+
+        url = f"https://github.com/{base_repository(repo_key)}.git"
+        try:
+            tag_shas = get_remote_tag_shas(url, self.config.git)
+        except Exception as e:
+            self.logger.debug(f"Git tag listing failed for {repo_key}: {e}")
+            return None
+
+        return select_latest_release(tag_candidates(tag_shas), self.policy)
+
+
+__all__ = [
+    "AllowListResolver",
+    "LatestRelease",
+    "ReleasePolicy",
+]

--- a/src/gha_workflow_linter/allow_list_scanner.py
+++ b/src/gha_workflow_linter/allow_list_scanner.py
@@ -1,0 +1,785 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Detection of allow-list pins in workflow and action YAML.
+
+An allow-list pin is a ``uses:``-style coordinate naming a file in a
+host repository, written as the value of an ordinary workflow input.
+Dependabot cannot see those coordinates, so they drift. Finding them is
+the first half of the job; this module is that half, and nothing more --
+it performs no network, cache or filesystem work beyond reading the file
+it was asked to scan.
+
+Detection runs in two stages, as set out in section 5.1 of
+``docs/ALLOW_LIST_FEATURE.md``.
+
+**Stage 1, structural identification.** The composed YAML node tree from
+:meth:`~gha_workflow_linter.scanner.WorkflowScanner.compose_workflow_file`
+is walked, and candidate scalars are collected from three locations:
+
+1. ``jobs.<job>.steps[*].with.config`` -- the shared resolver's input is
+   always named ``config``, so this location is anchored by structure.
+2. ``on.workflow_call.inputs.<name>.default``.
+3. ``jobs.<job>.with.<name>`` -- a reusable-workflow caller.
+
+Locations 2 and 3 carry an arbitrary key name, so a scalar found there
+qualifies only when the recogniser predicate accepts it: it must parse
+under the grammar in :mod:`gha_workflow_linter.allow_list_spec` *and*
+either name the conventional allow-list filename explicitly or sit under
+a key whose name matches :data:`DEFAULT_KEY_PATTERNS`.
+
+**Stage 2, lexical extraction.** Comments are lexical and do not survive
+composition, so each candidate's source line is read back and the
+version comment, quoting style and suppression directives are recovered
+from it. Every pin therefore carries an exact anchor -- 1-based line,
+0-based column -- that a later fixer can rewrite without re-parsing.
+
+There is deliberately **no per-consumer registry** (section 5.4). Every
+allow-list consumer shares one grammar, one resolver and one host
+repository, and staleness never depends on the consumer family, so
+detection keys on syntax alone. A new consumer is covered on the day it
+appears, with no code change here.
+
+The two-position comment problem (section 2) is handled throughout: the
+version comment may be a YAML comment *outside* the quotes, which PyYAML
+discards, or an in-scalar comment *inside* them, which the action's own
+``split_comment`` strips. Both are recognised, the in-scalar form takes
+precedence when both are present, and :attr:`AllowListPin.comment_position`
+records which form was found so a rewrite can preserve it.
+
+Note:
+    A scalar that fails to parse under the grammar is skipped with a
+    debug log wherever it is found, including the anchored ``config``
+    location. Section 5.4 is explicit that the failure mode for an
+    unrelated ``config:`` value must be a skip rather than a false
+    finding, and :class:`AllowListPin` has no representation for a spec
+    that did not resolve. Reporting a genuinely broken coordinate as
+    ``INVALID_SPEC`` (section 7.2) belongs to the orchestrator, which
+    knows which action consumes the input.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import fnmatch
+import logging
+from typing import TYPE_CHECKING
+
+import yaml
+
+from .allow_list_spec import (
+    DEFAULT_FILENAME,
+    SpecError,
+    resolve_spec,
+    split_comment,
+)
+from .directives import find_suppression, parse_trailing_comment
+from .scanner import WorkflowScanner
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+    from pathlib import Path
+
+    from .allow_list_spec import ResolvedSpec
+    from .directives import Directive, Suppression, SuppressionSource
+    from .models import Config
+
+__all__ = [
+    "DEFAULT_KEY_PATTERNS",
+    "AllowListPin",
+    "AllowListScanner",
+    "CommentPosition",
+    "QuoteStyle",
+]
+
+#: Key-name patterns recognised as allow-list coordinates where the key
+#: name is arbitrary (locations 2 and 3). Matched with :mod:`fnmatch`,
+#: case-insensitively. ``allow_list`` and ``allowlist`` are distinct
+#: spellings under glob matching, so both are listed.
+DEFAULT_KEY_PATTERNS: tuple[str, ...] = (
+    "*allow_list*",
+    "*allowlist*",
+    "*allow-list*",
+)
+
+#: Marker introducing a GitHub expression. A value holding one is
+#: resolved at run time and is not a pin.
+_EXPRESSION_MARKER = "${{"
+
+
+class QuoteStyle(str, Enum):
+    """How a scalar is quoted in the source."""
+
+    NONE = "none"
+    SINGLE = "single"
+    DOUBLE = "double"
+
+
+class CommentPosition(str, Enum):
+    """Which of the two comment positions carried the version.
+
+    Attributes:
+        NONE: The pin has no trailing comment in either position.
+        YAML: A YAML comment, with the ``#`` outside the quotes. PyYAML
+            discards it, and the action never sees it. Every pin in the
+            current estate uses this form.
+        IN_SCALAR: A comment inside the quotes, part of the scalar,
+            stripped by the action's own ``split_comment``.
+    """
+
+    NONE = "none"
+    YAML = "yaml"
+    IN_SCALAR = "in_scalar"
+
+
+@dataclass(frozen=True)
+class AllowListPin:
+    """A detected allow-list coordinate in a workflow file.
+
+    Attributes:
+        file_path: File the pin was found in.
+        line_number: 1-based line of the scalar's first character.
+        column: 0-based column of the scalar's first character. For a
+            quoted scalar this is the opening quote, not the first
+            character of the value.
+        key_path: Document path to the scalar, with sequence indices
+            rendered as decimal strings, for example
+            ``("jobs", "build", "steps", "0", "with", "config")``.
+        raw_line: The source line, without its line ending.
+        raw_value: The scalar as written, with any in-scalar comment
+            removed and surrounding whitespace left intact.
+        quote_style: Quoting inferred from the source text at ``column``.
+        version_comment: Version token of the effective trailing comment,
+            or ``None`` when there is no comment or it carries only
+            directives.
+        comment_position: Which position the effective comment came from.
+        directives: Suppression directives in force for this pin. Empty
+            when none apply.
+        suppressed_by: Where the suppression was authored, or ``None``
+            when the pin is not suppressed.
+        suppression_reason: Free text the suppression carried, if any.
+        spec: The coordinate resolved into lookup components.
+        auto_fixable: ``False`` for a scalar spanning several lines,
+            which is recorded and reported but never rewritten.
+    """
+
+    file_path: Path
+    line_number: int
+    column: int
+    key_path: tuple[str, ...]
+    raw_line: str
+    raw_value: str
+    quote_style: QuoteStyle
+    version_comment: str | None
+    comment_position: CommentPosition
+    directives: frozenset[Directive]
+    suppressed_by: SuppressionSource | None
+    suppression_reason: str | None
+    spec: ResolvedSpec
+    auto_fixable: bool
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """A scalar the structural walk offered for recognition.
+
+    Attributes:
+        node: The scalar node, carrying the source marks.
+        key_path: Document path to the scalar.
+        key_name: Name of the mapping key holding the scalar.
+        anchored: True when the location itself identifies the input
+            (``with.config`` on a step), so the recogniser predicate for
+            arbitrary key names does not apply.
+    """
+
+    node: yaml.nodes.ScalarNode
+    key_path: tuple[str, ...]
+    key_name: str
+    anchored: bool
+
+
+@dataclass(frozen=True)
+class _Lexical:
+    """Facts recovered from the source line rather than the node tree.
+
+    Attributes:
+        raw_line: The source line, without its line ending.
+        quote_style: Quoting inferred at the scalar's start column.
+        auto_fixable: False when the scalar spans several lines.
+        comments: The trailing comments found, most authoritative first.
+            Empty when the pin carries no comment at all.
+        position: Which position the first comment came from.
+    """
+
+    raw_line: str
+    quote_style: QuoteStyle
+    auto_fixable: bool
+    comments: tuple[str, ...]
+    position: CommentPosition
+
+
+def _key_text(node: yaml.nodes.ScalarNode) -> str:
+    """Return a key node's raw text.
+
+    Args:
+        node: A scalar key node.
+
+    Returns:
+        The key exactly as written in the source. This is deliberately
+        the raw text rather than a constructed value: under YAML 1.1 a
+        bare ``on:`` key resolves to the boolean ``True``, but the
+        composed node still holds ``"on"``.
+    """
+    return str(node.value)
+
+
+def _mapping_pairs(
+    node: yaml.nodes.Node | None,
+) -> list[tuple[yaml.nodes.ScalarNode, yaml.nodes.Node]]:
+    """Return a node's ``(key, value)`` pairs when it is a mapping.
+
+    Args:
+        node: Any node, or ``None``.
+
+    Returns:
+        The mapping's pairs in document order, restricted to those with
+        a scalar key. An empty list for any other node, so a caller can
+        walk a malformed or unexpected document without guarding every
+        step.
+    """
+    if not isinstance(node, yaml.nodes.MappingNode):
+        return []
+    pairs: list[tuple[yaml.nodes.ScalarNode, yaml.nodes.Node]] = []
+    for key_node, value_node in node.value:
+        if isinstance(key_node, yaml.nodes.ScalarNode):
+            pairs.append((key_node, value_node))
+    return pairs
+
+
+def _child(node: yaml.nodes.Node | None, key: str) -> yaml.nodes.Node | None:
+    """Return the value node of ``key`` within a mapping node.
+
+    Args:
+        node: The mapping to look in, or ``None``.
+        key: Raw key text to match, compared exactly.
+
+    Returns:
+        The value node, or ``None`` when the node is not a mapping or
+        holds no such key.
+    """
+    for key_node, value_node in _mapping_pairs(node):
+        if _key_text(key_node) == key:
+            return value_node
+    return None
+
+
+def _is_trigger_key(node: yaml.nodes.ScalarNode) -> bool:
+    """Report whether a top-level key is the workflow trigger block.
+
+    Under YAML 1.1, which ``SafeLoader`` implements, ``on`` is a boolean
+    spelling: a document constructed with ``yaml.safe_load`` has the key
+    ``True``, not ``"on"``. Walking the *composed* tree sidesteps that,
+    because the key node keeps its raw text and only its tag changes.
+    Matching on the raw text is therefore both correct and immune to the
+    retagging; the tag is deliberately not consulted.
+
+    Args:
+        node: A top-level key node.
+
+    Returns:
+        True when the key is ``on`` in any capitalisation.
+    """
+    return _key_text(node).lower() == "on"
+
+
+def _collect_step_configs(
+    steps_node: yaml.nodes.Node | None, job: str
+) -> Iterator[_Candidate]:
+    """Yield ``with.config`` scalars from a job's steps (location 1).
+
+    Args:
+        steps_node: The job's ``steps`` node, or ``None``.
+        job: Job name, for the key path.
+
+    Yields:
+        One candidate per step carrying a scalar ``with.config``.
+    """
+    if not isinstance(steps_node, yaml.nodes.SequenceNode):
+        return
+    for index, step in enumerate(steps_node.value):
+        config = _child(_child(step, "with"), "config")
+        if isinstance(config, yaml.nodes.ScalarNode):
+            yield _Candidate(
+                node=config,
+                key_path=(
+                    "jobs",
+                    job,
+                    "steps",
+                    str(index),
+                    "with",
+                    "config",
+                ),
+                key_name="config",
+                anchored=True,
+            )
+
+
+def _collect_job_inputs(
+    with_node: yaml.nodes.Node | None, job: str
+) -> Iterator[_Candidate]:
+    """Yield a reusable-workflow caller's inputs (location 3).
+
+    Args:
+        with_node: The job's ``with`` node, or ``None``.
+        job: Job name, for the key path.
+
+    Yields:
+        One candidate per scalar input. Recognition happens later.
+    """
+    for key_node, value_node in _mapping_pairs(with_node):
+        if isinstance(value_node, yaml.nodes.ScalarNode):
+            name = _key_text(key_node)
+            yield _Candidate(
+                node=value_node,
+                key_path=("jobs", job, "with", name),
+                key_name=name,
+                anchored=False,
+            )
+
+
+def _collect_jobs(jobs_node: yaml.nodes.Node | None) -> Iterator[_Candidate]:
+    """Yield every candidate beneath the ``jobs`` block.
+
+    Args:
+        jobs_node: The document's ``jobs`` node, or ``None``.
+
+    Yields:
+        Candidates from locations 1 and 3, job by job.
+    """
+    for key_node, job_node in _mapping_pairs(jobs_node):
+        job = _key_text(key_node)
+        yield from _collect_step_configs(_child(job_node, "steps"), job)
+        yield from _collect_job_inputs(_child(job_node, "with"), job)
+
+
+def _collect_input_defaults(
+    on_node: yaml.nodes.Node | None, on_key: str
+) -> Iterator[_Candidate]:
+    """Yield ``workflow_call`` input defaults (location 2).
+
+    Args:
+        on_node: The trigger block's value node, or ``None``. A trigger
+            block written as a scalar or a sequence yields nothing.
+        on_key: The trigger key exactly as written, for the key path.
+
+    Yields:
+        One candidate per input carrying a scalar default.
+    """
+    inputs = _child(_child(on_node, "workflow_call"), "inputs")
+    for key_node, input_node in _mapping_pairs(inputs):
+        default = _child(input_node, "default")
+        if isinstance(default, yaml.nodes.ScalarNode):
+            name = _key_text(key_node)
+            yield _Candidate(
+                node=default,
+                key_path=(on_key, "workflow_call", "inputs", name, "default"),
+                key_name=name,
+                anchored=False,
+            )
+
+
+def _collect_candidates(root: yaml.nodes.Node) -> list[_Candidate]:
+    """Walk a composed document for all three detection locations.
+
+    Args:
+        root: Root node of the composed tree.
+
+    Returns:
+        Every candidate scalar, in document order.
+    """
+    candidates: list[_Candidate] = []
+    for key_node, value_node in _mapping_pairs(root):
+        if _is_trigger_key(key_node):
+            candidates.extend(
+                _collect_input_defaults(value_node, _key_text(key_node))
+            )
+        elif _key_text(key_node) == "jobs":
+            candidates.extend(_collect_jobs(value_node))
+    return candidates
+
+
+def _quote_style(raw_line: str, column: int) -> QuoteStyle:
+    """Infer a scalar's quoting from the source text.
+
+    Args:
+        raw_line: The source line holding the scalar.
+        column: 0-based column the scalar starts at.
+
+    Returns:
+        The quoting style. A block scalar, whose start mark points at
+        its ``|`` or ``>`` indicator, reports :attr:`QuoteStyle.NONE`.
+    """
+    if column < 0 or column >= len(raw_line):
+        return QuoteStyle.NONE
+    character = raw_line[column]
+    if character == "'":
+        return QuoteStyle.SINGLE
+    if character == '"':
+        return QuoteStyle.DOUBLE
+    return QuoteStyle.NONE
+
+
+def _yaml_comment(raw_line: str, end_column: int) -> str | None:
+    """Recover a YAML comment written after a scalar on its own line.
+
+    The same rule the action applies inside the scalar is applied here:
+    the ``#`` must be preceded by at least one space or tab, so a ``#``
+    abutting the value does not start a comment.
+
+    Args:
+        raw_line: The source line holding the scalar.
+        end_column: 0-based column just past the scalar's last
+            character, which for a quoted scalar is just past its
+            closing quote.
+
+    Returns:
+        The comment text without its marker, or ``None`` when the line
+        carries no comment after the scalar.
+    """
+    _, comment = split_comment(raw_line[end_column:])
+    return comment or None
+
+
+def _preceding_comment_line(lines: Sequence[str], index: int) -> str | None:
+    """Return the immediately preceding line when it is a comment.
+
+    A preceding-line directive binds to exactly one pin, so a blank line
+    or any content between the two breaks the binding.
+
+    Args:
+        lines: The file's lines, without line endings.
+        index: 0-based index of the pinned line.
+
+    Returns:
+        The preceding line, or ``None`` when there is none or it is not
+        a comment.
+    """
+    if index <= 0 or index > len(lines):
+        return None
+    previous = lines[index - 1]
+    return previous if previous.lstrip().startswith("#") else None
+
+
+def _matches_key_pattern(name: str, patterns: Sequence[str]) -> bool:
+    """Report whether a key name matches any configured pattern.
+
+    Args:
+        name: The mapping key holding the scalar.
+        patterns: fnmatch patterns.
+
+    Returns:
+        True when any pattern matches, compared case-insensitively.
+        :func:`fnmatch.fnmatchcase` is used over both lowered operands
+        so the verdict does not vary with the host filesystem.
+    """
+    lowered = name.lower()
+    return any(
+        fnmatch.fnmatchcase(lowered, pattern.lower()) for pattern in patterns
+    )
+
+
+def _names_conventional_filename(spec: ResolvedSpec, filename: str) -> bool:
+    """Report whether the author *wrote* the conventional filename.
+
+    The test is deliberately made against the source subpath rather than
+    against the resolved
+    :attr:`~gha_workflow_linter.allow_list_spec.ResolvedSpec.candidates`.
+    An omitted filename defaults to the conventional one, so every
+    resolved candidate chain ends in it and testing the chain would
+    accept any string that happens to parse. Requiring the author to
+    have named the file keeps the predicate conservative, which is the
+    stated intent of section 5.1.
+
+    Args:
+        spec: The resolved coordinate.
+        filename: The conventional allow-list filename.
+
+    Returns:
+        True when the coordinate carries a subpath whose last segment is
+        ``filename``.
+    """
+    subpath = spec.source.subpath
+    if not spec.source.has_subpath or not subpath:
+        return False
+    return subpath.rsplit("/", 1)[-1] == filename
+
+
+class AllowListScanner:
+    """Find allow-list pins, with exact source anchors, in YAML files.
+
+    Attributes:
+        config: Linter configuration, supplying the file-reading and
+            YAML-composition behaviour shared with the action-call scan.
+        workflow_org: Org owning the workflow being scanned.
+        key_patterns: Key-name patterns for the recogniser predicate.
+        filename: Conventional allow-list filename.
+
+    Note:
+        ``workflow_org`` is not optional in practice. The shorthand
+        ``@<sha>`` form, which every internal workflow uses, has no host
+        org of its own and takes it from here; an empty or invalid org
+        makes those coordinates unparsable, and they are then skipped
+        with a debug log like any other unparsable scalar. Callers
+        determine the org as described in section 6.3 of the design.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        workflow_org: str,
+        *,
+        key_patterns: Sequence[str] | None = None,
+        filename: str = DEFAULT_FILENAME,
+    ) -> None:
+        """Initialise the scanner.
+
+        Args:
+            config: Linter configuration.
+            workflow_org: Org owning the workflow being scanned. It
+                supplies the host org when a coordinate omits it.
+            key_patterns: Key-name patterns recognised in locations 2
+                and 3. Defaults to :data:`DEFAULT_KEY_PATTERNS`.
+            filename: Conventional allow-list filename, the other half
+                of the recogniser predicate.
+        """
+        self.config = config
+        self.workflow_org = workflow_org
+        self.key_patterns = tuple(
+            DEFAULT_KEY_PATTERNS if key_patterns is None else key_patterns
+        )
+        self.filename = filename
+        self.logger = logging.getLogger(__name__)
+        self._scanner = WorkflowScanner(config)
+
+    def scan_file(self, file_path: Path) -> list[AllowListPin]:
+        """Return every allow-list pin in one workflow or action file.
+
+        Args:
+            file_path: Path to the file to scan.
+
+        Returns:
+            The pins found, in document order. Empty when the file
+            cannot be read, is not valid YAML, is empty, or holds no
+            recognised coordinate. Never raises for a bad file.
+        """
+        root = self._scanner.compose_workflow_file(file_path)
+        if root is None:
+            return []
+
+        # Comments are lexical and absent from the composed tree, so the
+        # source is read back for the version comment, the quoting style
+        # and any suppression directive.
+        try:
+            lines = file_path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError) as error:
+            self.logger.warning(f"Error reading file {file_path}: {error}")
+            return []
+
+        pins: list[AllowListPin] = []
+        for candidate in _collect_candidates(root):
+            pin = self._build_pin(candidate, file_path, lines)
+            if pin is not None:
+                pins.append(pin)
+
+        self.logger.debug(f"Found {len(pins)} allow-list pins in {file_path}")
+        return pins
+
+    def scan_files(
+        self, paths: Iterable[Path]
+    ) -> dict[Path, list[AllowListPin]]:
+        """Scan several files, keeping only those that hold pins.
+
+        Args:
+            paths: Files to scan.
+
+        Returns:
+            Mapping of file path to its pins, in scan order. Files
+            without pins are omitted, matching the convention of
+            :meth:`~gha_workflow_linter.scanner.WorkflowScanner.scan_directory`.
+        """
+        results: dict[Path, list[AllowListPin]] = {}
+        for path in paths:
+            pins = self.scan_file(path)
+            if pins:
+                results[path] = pins
+        return results
+
+    def _resolve_candidate(self, candidate: _Candidate) -> ResolvedSpec | None:
+        """Apply the skip rules and the recogniser to one candidate.
+
+        Args:
+            candidate: A scalar offered by the structural walk.
+
+        Returns:
+            The resolved coordinate, or ``None`` when the scalar is not
+            a pin. Every rejection is logged at debug level and none
+            produces a finding (design sections 5.2 and 5.4).
+        """
+        text = str(candidate.node.value)
+        key = ".".join(candidate.key_path)
+
+        if _EXPRESSION_MARKER in text:
+            self.logger.debug(
+                f"Skipping {key}: value is a GitHub expression, not a pin"
+            )
+            return None
+
+        try:
+            spec = resolve_spec(text, workflow_org=self.workflow_org)
+        except SpecError as error:
+            self.logger.debug(f"Skipping {key}: not a config spec ({error})")
+            return None
+
+        if candidate.anchored:
+            return spec
+        if _names_conventional_filename(spec, self.filename):
+            return spec
+        if _matches_key_pattern(candidate.key_name, self.key_patterns):
+            return spec
+
+        self.logger.debug(
+            f"Skipping {key}: parses as a spec but names neither "
+            f"'{self.filename}' nor a recognised key"
+        )
+        return None
+
+    def _lexical_context(
+        self,
+        node: yaml.nodes.ScalarNode,
+        in_scalar_comment: str,
+        lines: Sequence[str],
+    ) -> _Lexical:
+        """Recover the source-level facts around a candidate scalar.
+
+        Args:
+            node: The candidate scalar node.
+            in_scalar_comment: Comment found inside the scalar, ``""``
+                when it has none.
+            lines: The file's lines, without line endings.
+
+        Returns:
+            The quoting, fixability and trailing comments of the pin.
+            The in-scalar comment is listed first when present, because
+            it is the one the action itself sees; a YAML comment on the
+            same line follows it. A multi-line scalar contributes no
+            YAML comment, since its end mark is on another line.
+        """
+        start = node.start_mark
+        raw_line = lines[start.line] if start.line < len(lines) else ""
+        multiline = start.line != node.end_mark.line
+
+        yaml_comment = (
+            None if multiline else _yaml_comment(raw_line, node.end_mark.column)
+        )
+        comments = tuple(
+            comment
+            for comment in (in_scalar_comment or None, yaml_comment)
+            if comment is not None
+        )
+        if in_scalar_comment:
+            position = CommentPosition.IN_SCALAR
+        elif yaml_comment is not None:
+            position = CommentPosition.YAML
+        else:
+            position = CommentPosition.NONE
+
+        return _Lexical(
+            raw_line=raw_line,
+            quote_style=_quote_style(raw_line, start.column),
+            auto_fixable=not multiline,
+            comments=comments,
+            position=position,
+        )
+
+    def _find_suppression(
+        self, lexical: _Lexical, line_index: int, lines: Sequence[str]
+    ) -> Suppression | None:
+        """Resolve the suppression in force for one pin.
+
+        Either comment position may carry the inline directive, so each
+        is offered in turn, most authoritative first. The preceding-line
+        form is checked on every attempt, which is harmless: the first
+        call already returns it when no inline directive exists.
+
+        Args:
+            lexical: The pin's recovered source facts.
+            line_index: 0-based index of the pinned line.
+            lines: The file's lines, without line endings.
+
+        Returns:
+            The effective suppression, or ``None`` when neither form
+            declares a directive.
+        """
+        preceding = _preceding_comment_line(lines, line_index)
+        comments: tuple[str | None, ...] = lexical.comments or (None,)
+        for comment in comments:
+            suppression = find_suppression(
+                comment=comment, preceding_line=preceding
+            )
+            if suppression is not None:
+                return suppression
+        return None
+
+    def _build_pin(
+        self,
+        candidate: _Candidate,
+        file_path: Path,
+        lines: Sequence[str],
+    ) -> AllowListPin | None:
+        """Turn a recognised candidate into a fully anchored pin.
+
+        Args:
+            candidate: A scalar offered by the structural walk.
+            file_path: File the scalar was found in.
+            lines: The file's lines, without line endings.
+
+        Returns:
+            The pin, or ``None`` when the candidate is not one.
+        """
+        spec = self._resolve_candidate(candidate)
+        if spec is None:
+            return None
+
+        node = candidate.node
+        raw_value, in_scalar_comment = split_comment(str(node.value))
+        lexical = self._lexical_context(node, in_scalar_comment, lines)
+        suppression = self._find_suppression(
+            lexical, node.start_mark.line, lines
+        )
+        effective = lexical.comments[0] if lexical.comments else None
+
+        return AllowListPin(
+            file_path=file_path,
+            line_number=node.start_mark.line + 1,
+            column=node.start_mark.column,
+            key_path=candidate.key_path,
+            raw_line=lexical.raw_line,
+            raw_value=raw_value,
+            quote_style=lexical.quote_style,
+            version_comment=parse_trailing_comment(effective).version,
+            comment_position=lexical.position,
+            directives=(
+                suppression.directives
+                if suppression is not None
+                else frozenset()
+            ),
+            suppressed_by=(
+                suppression.source if suppression is not None else None
+            ),
+            suppression_reason=(
+                suppression.reason if suppression is not None else None
+            ),
+            spec=spec,
+            auto_fixable=lexical.auto_fixable,
+        )

--- a/src/gha_workflow_linter/allow_list_spec.py
+++ b/src/gha_workflow_linter/allow_list_spec.py
@@ -1,0 +1,494 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Parsing of the allow-list ``config`` coordinate grammar.
+
+``step-security/harden-runner`` egress allow-lists reach a workflow
+through the ``config`` input of
+``lfreleng-actions/harden-runner-block-action``, written as a
+GitHub-Actions ``uses:``-style coordinate::
+
+    <config> ::= <source> [ "@" <ref> ] [ <ws>+ "#" <comment> ]
+    <source> ::= [ <host-org> [ "/" <repo> ] ] [ "//" <subpath> ]
+
+Dependabot cannot see those coordinates, so the SHAs they pin drift.
+Detecting that drift requires the linter to read the grammar exactly as
+the action reads it: any divergence produces findings against pins that
+are in fact valid.
+
+This module is a **port of the parsing half** of
+``src/resolve_config_source.py``, a file mirrored byte-for-byte between
+two repositories:
+
+* ``lfreleng-actions/harden-runner-block-action``
+* ``lfreleng-actions/python-audit-action``
+
+A CI check in each of those repositories diffs the file against the
+other's copy, so the grammar has exactly one definition. **Any change
+made to it upstream must be reflected here.** Only parsing and
+resolution are ported -- this module is pure, and performs no network,
+filesystem or subprocess work whatsoever. ``tests/test_allow_list_spec``
+carries a port of the upstream conformance tests so that divergence
+shows up as a test failure rather than as a false finding.
+
+The port makes two deliberate, behaviour-preserving changes: results are
+frozen dataclasses rather than ``dict`` objects, and the error type
+derives from :class:`ValueError` rather than :class:`Exception`. Neither
+changes which inputs are accepted or rejected.
+
+:func:`render_spec` has no upstream counterpart. Remediation needs to
+rebuild a coordinate around a new ref while disturbing nothing else the
+author wrote, which is why :class:`ResolvedSpec` retains the raw source
+components in :attr:`ResolvedSpec.source` alongside the resolved ones.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+__all__ = [
+    "DEFAULT_FAMILY",
+    "DEFAULT_FILENAME",
+    "DEFAULT_REPO",
+    "MAX_REF_LENGTH",
+    "ORG_RE",
+    "REF_RE",
+    "REPO_RE",
+    "SEGMENT_RE",
+    "ResolvedSpec",
+    "SpecError",
+    "SpecParts",
+    "parse_spec",
+    "render_spec",
+    "resolve_spec",
+    "split_comment",
+]
+
+#: GitHub org/user names: 1-39 chars, alphanumerics and single hyphens,
+#: no leading/trailing hyphen, no consecutive hyphens.
+ORG_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+
+#: Repository names: alphanumerics plus ``.``, ``_``, ``-``. The
+#: canonical host repo is the special ``.github`` repo, so a leading dot
+#: must be allowed.
+REPO_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+#: A single in-repo path segment. No empty segments, no slashes (the
+#: path is split on ``/`` before validation), no shell metacharacters.
+#: ``..`` matches this pattern and is rejected separately.
+SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+#: Git ref: branch name, tag name, or commit SHA. A conservative subset
+#: of the characters git permits.
+REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+#: Trailing comment separator: a ``#`` preceded by at least one space or
+#: tab, running to end of line. Newlines are excluded deliberately (see
+#: :func:`split_comment`).
+_COMMENT_RE = re.compile(r"[ \t]+#[^\r\n]*$")
+
+#: Longest ref the upstream parser accepts.
+MAX_REF_LENGTH = 255
+
+#: Config family for ``harden-runner-block-action``. The sibling
+#: ``python-audit-action`` passes ``"python-audit"``; the parser itself
+#: holds no per-action constants, so the family is always a caller
+#: concern.
+DEFAULT_FAMILY = "harden-runner"
+
+#: Repository assumed when the coordinate names only an org.
+DEFAULT_REPO = ".github"
+
+#: Filename assumed when the coordinate names no file.
+DEFAULT_FILENAME = "allow_list.txt"
+
+#: The ref standing for "the host repository's default branch".
+HEAD_REF = "HEAD"
+
+
+class SpecError(ValueError):
+    """A config spec that does not satisfy the grammar.
+
+    Upstream raises a bare ``ResolveError(Exception)`` because it fails
+    the action; here the condition is "this string is not a valid
+    coordinate", for which :class:`ValueError` is the natural base.
+    """
+
+
+@dataclass(frozen=True)
+class SpecParts:
+    """The raw components of a config spec, before defaults apply.
+
+    Attributes:
+        repospec: Text before ``//`` (or the whole source when no ``//``
+            is present); ``""`` when the coordinate omits it.
+        subpath: Text after ``//``; ``""`` when absent or empty.
+        has_subpath: Whether a ``//`` separator was present at all. A
+            bare ``//`` is not the same as no ``//`` for round-tripping,
+            though both resolve identically.
+        ref: Text after ``@``; ``""`` when the coordinate omits the ref.
+    """
+
+    repospec: str
+    subpath: str
+    has_subpath: bool
+    ref: str
+
+
+@dataclass(frozen=True)
+class ResolvedSpec:
+    """A config spec resolved into concrete lookup coordinates.
+
+    Attributes:
+        host_org: Org owning the repository that holds the file.
+        repo: Repository within ``host_org``.
+        ref: Git ref to read at; ``"HEAD"`` when the spec omitted one.
+        candidates: Ordered in-repo paths to try. One entry when the
+            author gave an explicit path, otherwise the two-entry
+            search chain.
+        path_explicit: Whether the author gave an explicit in-repo path,
+            disabling the search chain.
+        comment: In-scalar trailing comment, ``""`` when there is none.
+            Informational only; it never affects resolution.
+        source: The raw components the spec was written with, retained
+            so that :func:`render_spec` can rebuild the source form
+            without normalising away the author's choices.
+    """
+
+    host_org: str
+    repo: str
+    ref: str
+    candidates: tuple[str, ...]
+    path_explicit: bool
+    comment: str
+    source: SpecParts
+
+
+def split_comment(value: str) -> tuple[str, str]:
+    """Split a trailing ``' #...'`` comment off a config spec.
+
+    The separator is one or more spaces or tabs before the ``#``, so
+    ``foo#bar`` is a single token rather than a token plus a comment.
+
+    A newline is deliberately *not* accepted as the separator. Were it
+    accepted, ``"lfit@main\\n# hidden"`` would split into a clean spec
+    plus a comment and slip past the newline rejection in
+    :func:`parse_spec`.
+
+    Args:
+        value: The raw scalar value.
+
+    Returns:
+        A ``(spec, comment)`` tuple. ``comment`` has its leading
+        whitespace and ``#`` removed and is stripped; it is ``""`` when
+        the value carries no trailing comment.
+    """
+    match = _COMMENT_RE.search(value)
+    if match is None:
+        return value, ""
+    comment = value[match.start() :].lstrip(" \t")[1:].strip()
+    return value[: match.start()], comment
+
+
+def parse_spec(spec: str) -> SpecParts:
+    """Parse a config spec into its raw components.
+
+    The grammar handled here is::
+
+        <spec>     ::= <source> [ "@" <ref> ]
+        <source>   ::= <repospec> [ "//" <subpath> ]
+        <repospec> ::= [ <host-org> [ "/" <repo> ] ]
+        <subpath>  ::= [ <dir> "/" ]... [ <filename> ]
+
+    Any trailing comment must already have been removed with
+    :func:`split_comment`.
+
+    Args:
+        spec: The comment-free spec text.
+
+    Returns:
+        The raw components, with no defaults applied and no validation
+        of their contents beyond the separator rules.
+
+    Raises:
+        SpecError: The spec contains a newline, more than one ``@``,
+            an empty ref after ``@``, or more than one ``//``.
+    """
+    if "\n" in spec or "\r" in spec:
+        raise SpecError("config must not contain newline characters")
+
+    ref = ""
+    if "@" in spec:
+        source, _, ref = spec.partition("@")
+        if "@" in ref:
+            raise SpecError("config contains more than one '@' separator")
+        if ref == "":
+            raise SpecError("config has an empty ref after '@'")
+    else:
+        source = spec
+
+    subpath = ""
+    has_subpath = False
+    if "//" in source:
+        repospec, _, subpath = source.partition("//")
+        has_subpath = True
+        if "//" in subpath:
+            raise SpecError("config contains more than one '//' separator")
+    else:
+        repospec = source
+
+    return SpecParts(
+        repospec=repospec,
+        subpath=subpath,
+        has_subpath=has_subpath,
+        ref=ref,
+    )
+
+
+def _resolve_repository(
+    repospec: str, *, workflow_org: str, default_repo: str
+) -> tuple[str, str]:
+    """Apply defaults to the repository part and validate it.
+
+    Args:
+        repospec: Raw text before any ``//`` separator.
+        workflow_org: Org of the workflow being linted, used when the
+            coordinate omits the host org.
+        default_repo: Repository assumed when the coordinate names only
+            an org.
+
+    Returns:
+        A ``(host_org, repo)`` tuple.
+
+    Raises:
+        SpecError: The repository part has more than two segments, or
+            either segment fails validation.
+    """
+    trimmed = repospec.strip("/")
+    if trimmed == "":
+        host_org, repo = workflow_org, default_repo
+    else:
+        segments = trimmed.split("/")
+        if len(segments) == 1:
+            host_org, repo = segments[0], default_repo
+        elif len(segments) == 2:
+            host_org, repo = segments[0], segments[1]
+        else:
+            raise SpecError(
+                "config repository part accepts at most '<org>/<repo>'; "
+                "put any in-repo path after '//'"
+            )
+
+    if host_org == "":
+        host_org = workflow_org
+    if not ORG_RE.match(host_org):
+        raise SpecError(f"invalid host org in config: '{host_org}'")
+    if repo == "":
+        repo = default_repo
+    if repo in ("..", ".") or not REPO_RE.match(repo):
+        raise SpecError(f"invalid repository in config: '{repo}'")
+    return host_org, repo
+
+
+def _validate_ref(ref: str) -> str:
+    """Validate a git ref and return it unchanged.
+
+    ``HEAD`` stands for the host repository's default branch and is
+    accepted without further checks.
+
+    Args:
+        ref: The ref to validate.
+
+    Returns:
+        The ref, unchanged.
+
+    Raises:
+        SpecError: The ref is empty, over-long, starts with ``-`` or
+            ``/``, contains ``..`` or ``@{``, or holds a character
+            outside :data:`REF_RE`.
+    """
+    if ref == HEAD_REF:
+        return ref
+    if (
+        ref == ""
+        or ref.startswith("-")
+        or ref.startswith("/")
+        or ".." in ref
+        or "@{" in ref
+        or len(ref) > MAX_REF_LENGTH
+        or not REF_RE.match(ref)
+    ):
+        raise SpecError(f"invalid git ref in config: '{ref}'")
+    return ref
+
+
+def _resolve_candidates(
+    parts: SpecParts,
+    *,
+    workflow_org: str,
+    family: str,
+    default_filename: str,
+) -> tuple[tuple[str, ...], bool]:
+    """Turn the subpath into the ordered list of paths to try.
+
+    Args:
+        parts: The raw parsed components.
+        workflow_org: Org of the workflow being linted; it names the
+            org-specific directory in the search chain.
+        family: Config family, for example ``harden-runner``. The
+            parser is family-agnostic: callers supply it.
+        default_filename: Filename assumed when the spec names none.
+
+    Returns:
+        A ``(candidates, path_explicit)`` tuple. ``candidates`` holds
+        the two-entry search chain unless the author gave an explicit
+        path, in which case it holds that path alone.
+    """
+    org_specific_dir = f".github/{family}/{workflow_org}"
+    family_dir = f".github/{family}"
+
+    if not parts.has_subpath or parts.subpath == "":
+        filename = default_filename
+    elif "/" not in parts.subpath:
+        filename = parts.subpath
+    else:
+        return (parts.subpath,), True
+
+    return (
+        f"{org_specific_dir}/{filename}",
+        f"{family_dir}/{filename}",
+    ), False
+
+
+def _validate_candidates(candidates: tuple[str, ...]) -> None:
+    """Validate every segment of every candidate in-repo path.
+
+    Args:
+        candidates: The resolved candidate paths.
+
+    Raises:
+        SpecError: A path is absolute, holds a backslash or a ``..``
+            segment, has an empty segment, or has a segment outside
+            :data:`SEGMENT_RE`.
+    """
+    for candidate in candidates:
+        segments = candidate.split("/")
+        if (
+            candidate.startswith("/")
+            or "\\" in candidate
+            or ".." in segments
+            or any(segment == "" for segment in segments)
+        ):
+            raise SpecError(f"invalid in-repo path in config: '{candidate}'")
+        for segment in segments:
+            if not SEGMENT_RE.match(segment):
+                raise SpecError(
+                    f"invalid path segment '{segment}' in config path "
+                    f"'{candidate}'"
+                )
+
+
+def resolve_spec(
+    spec: str,
+    *,
+    workflow_org: str,
+    family: str = DEFAULT_FAMILY,
+    default_repo: str = DEFAULT_REPO,
+    default_filename: str = DEFAULT_FILENAME,
+) -> ResolvedSpec:
+    """Resolve a config spec into concrete lookup coordinates.
+
+    Args:
+        spec: The raw scalar value, with or without a trailing comment
+            and with or without surrounding whitespace.
+        workflow_org: Org owning the workflow being linted. It supplies
+            the host org when the spec omits it, and names the
+            org-specific directory of the search chain.
+        family: Config family; ``harden-runner`` for the allow-list
+            action, ``python-audit`` for its sibling.
+        default_repo: Repository assumed when the spec names only an
+            org.
+        default_filename: Filename assumed when the spec names none.
+
+    Returns:
+        The resolved spec.
+
+    Raises:
+        SpecError: The spec is empty or violates the grammar in any of
+            the ways described by the helpers it delegates to.
+    """
+    text, comment = split_comment(spec.strip())
+    if text == "":
+        raise SpecError("config is empty")
+
+    parts = parse_spec(text)
+    host_org, repo = _resolve_repository(
+        parts.repospec,
+        workflow_org=workflow_org,
+        default_repo=default_repo,
+    )
+    ref = _validate_ref(parts.ref or HEAD_REF)
+    candidates, path_explicit = _resolve_candidates(
+        parts,
+        workflow_org=workflow_org,
+        family=family,
+        default_filename=default_filename,
+    )
+    _validate_candidates(candidates)
+
+    if workflow_org != "" and not ORG_RE.match(workflow_org):
+        raise SpecError(f"invalid workflow org: '{workflow_org}'")
+
+    return ResolvedSpec(
+        host_org=host_org,
+        repo=repo,
+        ref=ref,
+        candidates=candidates,
+        path_explicit=path_explicit,
+        comment=comment,
+        source=parts,
+    )
+
+
+def render_spec(spec: ResolvedSpec, *, ref: str) -> str:
+    """Rebuild the source form of a spec around a (possibly new) ref.
+
+    Remediation rewrites the ref and nothing else, so the repository and
+    subpath parts are re-emitted exactly as the author wrote them --
+    including a bare ``//``, an omitted org, or a redundant separator
+    that resolution would otherwise normalise away. Round-tripping a
+    valid spec with its own :attr:`ResolvedSpec.ref` therefore
+    reproduces its source form character for character.
+
+    Three properties of the source form are, by definition, outside what
+    this returns, and callers must handle them:
+
+    1. Any trailing comment. :func:`split_comment` removed it, and
+       comment rewriting belongs to the caller.
+    2. Whitespace around the spec, which
+       :func:`resolve_spec` strips before parsing.
+    3. A ref that the author omitted. Rendering with a real ref adds
+       ``@<ref>``; that is the point of the function. The ref is only
+       omitted when it is ``HEAD`` *and* the author wrote no ``@`` --
+       so a spec that named ``@HEAD`` explicitly keeps it.
+
+    Args:
+        spec: A previously resolved spec.
+        ref: The ref to emit. ``HEAD`` requests the default branch.
+
+    Returns:
+        The source form, without any trailing comment. It is never
+        empty: an empty source implies the author wrote a ref, so at
+        minimum ``@<ref>`` is emitted.
+
+    Raises:
+        SpecError: ``ref`` is not a valid git ref.
+    """
+    _validate_ref(ref)
+    source = spec.source.repospec
+    if spec.source.has_subpath:
+        source = f"{source}//{spec.source.subpath}"
+    if ref == HEAD_REF and spec.source.ref == "":
+        return source
+    return f"{source}@{ref}"

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+import dataclasses
 from dataclasses import dataclass
 import json
 import logging
@@ -37,6 +38,8 @@ import typer
 from . import exit_codes
 from ._version import __version__
 from .allow_list_check import AllowListChecker, AllowListOutcome
+from .allow_list_fix import AppliedFix
+from .allow_list_fix import apply_fixes as apply_allow_list_fixes
 from .allow_list_report import (
     build_json as build_allow_list_json,
 )
@@ -453,6 +456,8 @@ def _apply_cli_overrides(
         config.allow_list.enabled = options.allow_list
     if options.verify_allow_list:
         config.allow_list.verify = True
+    if options.update_allow_list:
+        config.allow_list.update = True
     if options.show_suppressed:
         config.allow_list.show_suppressed = True
     if options.allow_list_org is not None:
@@ -697,6 +702,14 @@ def lint(
             "(or 4 if the latest release cannot be resolved)"
         ),
     ),
+    update_allow_list: bool = typer.Option(
+        False,
+        "--update-allow-list",
+        help=(
+            "Rewrite stale allow-list pins in place. Pins carrying an "
+            "'allow-list-pin-ok' directive are never rewritten"
+        ),
+    ),
     show_suppressed: bool = typer.Option(
         False,
         "--show-suppressed",
@@ -859,6 +872,7 @@ def lint(
             verify_actions=verify_actions,
             allow_list=allow_list,
             verify_allow_list=verify_allow_list,
+            update_allow_list=update_allow_list,
             show_suppressed=show_suppressed,
             allow_list_org=allow_list_org,
         )
@@ -1339,13 +1353,12 @@ def _emit_results(
             autofix.stale_actions_summary,
         )
         if allow_list is not None and not options.quiet:
-            # Remediation lands in a later phase, so do not advertise a
-            # flag that does not exist yet.
+            # Only suggest remediation when it has not already run.
             render_allow_list(
                 allow_list,
                 root=options.path,
                 show_suppressed=config.allow_list.show_suppressed,
-                update_hint=False,
+                update_hint=not config.allow_list.update,
             )
 
 
@@ -1390,7 +1403,10 @@ def _run_allow_list_stage(
     try:
         paths = _allow_list_paths(config, options, scanner)
         checker = AllowListChecker(config, shared_cache)
-        return asyncio.run(checker.check(paths, options.path))
+        outcome = asyncio.run(checker.check(paths, options.path))
+        if config.allow_list.update:
+            outcome = _apply_allow_list_fixes(outcome, options)
+        return outcome
     except Exception as e:  # noqa: BLE001 - advisory unless enforcing
         logger.warning(f"Allow-list check failed: {e}")
         if not config.allow_list.verify:
@@ -1412,6 +1428,81 @@ def _run_allow_list_stage(
             suppressed_count=0,
             checked=True,
         )
+
+
+def _apply_allow_list_fixes(
+    outcome: AllowListOutcome,
+    options: CLIOptions,
+) -> AllowListOutcome:
+    """Rewrite stale pins and fold the result back into the outcome.
+
+    Only unsuppressed findings are offered to the fixer: a suppression
+    that survived detection but lost to remediation would be worse than
+    none at all.
+
+    Args:
+        outcome: The outcome of the detection pass.
+        options: Resolved CLI options, for reporting paths.
+
+    Returns:
+        The outcome with ``fixed_lines`` populated.
+    """
+    logger = logging.getLogger(__name__)
+    fixes = apply_allow_list_fixes(outcome.unsuppressed)
+
+    for finding, reason in fixes.skipped:
+        logger.debug(
+            f"Not rewriting {finding.pin.file_path}:"
+            f"{finding.pin.line_number}: {reason}"
+        )
+
+    if not fixes.applied:
+        return outcome
+
+    if not options.quiet:
+        _display_allow_list_fixes(fixes.applied, options)
+
+    return dataclasses.replace(
+        outcome,
+        fixed_lines=frozenset(
+            (str(fix.finding.pin.file_path), fix.line_number)
+            for fix in fixes.applied
+        ),
+    )
+
+
+def _display_allow_list_fixes(
+    applied: list[AppliedFix],
+    options: CLIOptions,
+) -> None:
+    """Report the allow-list pins that remediation rewrote.
+
+    Args:
+        applied: The fixes written to disk.
+        options: Resolved CLI options, for relative paths.
+    """
+    console.print("\n[green]Updated allow-list pins ✅[/green]")
+    by_file: dict[Path, list[AppliedFix]] = defaultdict(list)
+    for fix in applied:
+        by_file[fix.finding.pin.file_path].append(fix)
+
+    for file_path in sorted(by_file):
+        relative = _get_relative_path(file_path, options.path)
+        console.print(f"\n  [bold]{relative}[/bold]")
+        for fix in by_file[file_path]:
+            pad = " " * len(str(fix.line_number))
+            console.print(
+                f"    line {fix.line_number}   "
+                f"[red]{fix.old_line.strip()}[/red]"
+            )
+            console.print(
+                f"    {pad}        [green]{fix.new_line.strip()}[/green]"
+            )
+
+    console.print(
+        "\n[yellow]Files have been modified; please review the changes "
+        "and commit them ⚠️[/yellow]"
+    )
 
 
 def _allow_list_paths(
@@ -1505,11 +1596,18 @@ def _determine_exit_code(
     # Allow-list findings are advisory unless --verify-allow-list is set.
     # An unresolved check outranks a stale one: enforcement that silently
     # degrades to "pass" when the network is down is worse than useless.
-    if allow_list is not None and config.allow_list.verify:
-        if allow_list.unresolved:
-            codes.append(exit_codes.ALLOW_LIST_UNRESOLVED)
-        elif allow_list.unsuppressed:
-            codes.append(exit_codes.ALLOW_LIST_STALE)
+    if allow_list is not None:
+        if allow_list.fixed_count:
+            # Files changed on disk, so the caller must notice, exactly as
+            # for the action-call fixer.
+            codes.append(exit_codes.DEFECTS_FOUND)
+        if config.allow_list.verify:
+            if allow_list.unresolved:
+                codes.append(exit_codes.ALLOW_LIST_UNRESOLVED)
+            elif allow_list.outstanding:
+                # Anything remediation already rewrote is no longer a
+                # problem, so only what remains can fail the run.
+                codes.append(exit_codes.ALLOW_LIST_STALE)
 
     return exit_codes.combine(*codes) if codes else exit_codes.SUCCESS
 

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -1407,6 +1407,11 @@ def _run_allow_list_stage(
         if config.allow_list.update:
             outcome = _apply_allow_list_fixes(outcome, options)
         return outcome
+    except ConfigurationError:
+        # A bad setting is a usage error, not a transient failure. It
+        # must surface in advisory mode too, or a typo in
+        # --allow-list-org would silently disable the whole check.
+        raise
     except Exception as e:  # noqa: BLE001 - advisory unless enforcing
         logger.warning(f"Allow-list check failed: {e}")
         if not config.allow_list.verify:

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -1302,6 +1302,7 @@ def _emit_results(
     scanner: WorkflowScanner,
     validation: _ValidationOutcome,
     autofix: _AutoFixOutcome,
+    config: Config,
     allow_list: AllowListOutcome | None = None,
 ) -> None:
     """Generate and display the scan/validation results."""
@@ -1343,9 +1344,15 @@ def _emit_results(
             render_allow_list(
                 allow_list,
                 root=options.path,
-                show_suppressed=options.show_suppressed,
+                show_suppressed=config.allow_list.show_suppressed,
                 update_hint=False,
             )
+
+
+#: Sentinel host key used when the allow-list stage itself fails, rather
+#: than a specific host repository failing to resolve. Keeps the failure
+#: visible to exit-code determination without inventing a repository name.
+STAGE_FAILURE_HOST = "<allow-list check>"
 
 
 def _run_allow_list_stage(
@@ -1356,9 +1363,14 @@ def _run_allow_list_stage(
     """Detect stale harden-runner allow-list pins.
 
     Allow-list pins are an ``lfreleng-actions`` convention rather than
-    GitHub-native syntax, so a failure here must never break a run that
-    would otherwise have succeeded. Any unexpected error is logged and
-    swallowed; the check is simply skipped.
+    GitHub-native syntax, so in the default advisory mode a failure here
+    must never break a run that would otherwise have succeeded: the error
+    is logged and the check skipped.
+
+    Under ``allow_list.verify`` the opposite holds. The caller asked for
+    enforcement, and enforcement that degrades to "pass" when the check
+    cannot run is worse than useless, so the failure is reported as an
+    unresolved host and becomes exit status ``ALLOW_LIST_UNRESOLVED``.
 
     Args:
         config: Resolved configuration.
@@ -1366,7 +1378,8 @@ def _run_allow_list_stage(
         shared_cache: Cache shared with validation and auto-fix.
 
     Returns:
-        The outcome, or None when checking is disabled or failed.
+        The outcome, or None when checking is disabled, or when it failed
+        while running in advisory mode.
     """
     if not config.allow_list.enabled:
         return None
@@ -1378,9 +1391,27 @@ def _run_allow_list_stage(
         paths = _allow_list_paths(config, options, scanner)
         checker = AllowListChecker(config, shared_cache)
         return asyncio.run(checker.check(paths, options.path))
-    except Exception as e:  # noqa: BLE001 - advisory check, never fatal
+    except Exception as e:  # noqa: BLE001 - advisory unless enforcing
         logger.warning(f"Allow-list check failed: {e}")
-        return None
+        if not config.allow_list.verify:
+            # Advisory mode: a developer offline on a train must still be
+            # able to commit, so the check is skipped entirely.
+            return None
+        # Enforcement was requested. Reporting "pass" because the check
+        # itself broke is worse than useless, so surface the failure as
+        # an unresolved host and let the caller exit with
+        # ALLOW_LIST_UNRESOLVED.
+        if not options.quiet:
+            console.print(
+                f"[red]Allow-list verification could not run: {e} ❌[/red]"
+            )
+        return AllowListOutcome(
+            findings=[],
+            hosts={},
+            unresolved={STAGE_FAILURE_HOST: str(e)},
+            suppressed_count=0,
+            checked=True,
+        )
 
 
 def _allow_list_paths(
@@ -1531,7 +1562,7 @@ def run_linter(config: Config, options: CLIOptions) -> int:
 
     allow_list = _run_allow_list_stage(config, options, shared_cache)
 
-    _emit_results(options, scanner, validation, autofix, allow_list)
+    _emit_results(options, scanner, validation, autofix, config, allow_list)
 
     # Report outdated actions when auto-fix repaired validation errors but
     # version bumps were only detected, not applied. This is presentation

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -36,6 +36,13 @@ import typer
 
 from . import exit_codes
 from ._version import __version__
+from .allow_list_check import AllowListChecker, AllowListOutcome
+from .allow_list_report import (
+    build_json as build_allow_list_json,
+)
+from .allow_list_report import (
+    render_text as render_allow_list,
+)
 from .auto_fix import AutoFixer
 from .cache import CachePrimeReport, ValidationCache
 from .config import ConfigManager
@@ -255,6 +262,7 @@ def _preprocess_args_for_default_command(
         "--format",
         "-f",
         "--files",
+        "--allow-list-org",
     }
 
     # No args at all: behave like the explicit `lint` subcommand.
@@ -437,6 +445,18 @@ def _apply_cli_overrides(
     if options.cache_ttl is not None:
         config.cache.default_ttl_seconds = options.cache_ttl
         logger.debug(f"Cache TTL overridden to {options.cache_ttl} seconds")
+
+    # Allow-list pin checking. Only --allow-list is tri-state; the rest are
+    # opt-in switches that a config file may also enable, so a CLI False
+    # must not clobber a configured True.
+    if options.allow_list is not None:
+        config.allow_list.enabled = options.allow_list
+    if options.verify_allow_list:
+        config.allow_list.verify = True
+    if options.show_suppressed:
+        config.allow_list.show_suppressed = True
+    if options.allow_list_org is not None:
+        config.allow_list.org = options.allow_list_org
 
 
 def _configure_validation_backend(
@@ -661,6 +681,39 @@ def lint(
             "fail the run"
         ),
     ),
+    allow_list: bool | None = typer.Option(
+        None,
+        "--allow-list/--no-allow-list",
+        help=(
+            "Detect stale harden-runner allow-list pins (default: enabled). "
+            "Findings are advisory unless --verify-allow-list is given"
+        ),
+    ),
+    verify_allow_list: bool = typer.Option(
+        False,
+        "--verify-allow-list",
+        help=(
+            "Treat stale allow-list pins as errors and exit with status 3 "
+            "(or 4 if the latest release cannot be resolved)"
+        ),
+    ),
+    show_suppressed: bool = typer.Option(
+        False,
+        "--show-suppressed",
+        help=(
+            "Report allow-list pins silenced by an 'allow-list-pin-ok' "
+            "directive. Never affects the exit code"
+        ),
+    ),
+    allow_list_org: str | None = typer.Option(
+        None,
+        "--allow-list-org",
+        help=(
+            "Organisation used to resolve the '@<sha>' allow-list shorthand. "
+            "Inferred from GITHUB_REPOSITORY_OWNER, then the 'upstream' git "
+            "remote, then 'origin', when not given"
+        ),
+    ),
     _help: bool = typer.Option(
         False,
         "--help",
@@ -804,6 +857,10 @@ def lint(
             cooldown=cooldown,
             files=files,
             verify_actions=verify_actions,
+            allow_list=allow_list,
+            verify_allow_list=verify_allow_list,
+            show_suppressed=show_suppressed,
+            allow_list_org=allow_list_org,
         )
 
         # Apply CLI overrides to config
@@ -1245,6 +1302,7 @@ def _emit_results(
     scanner: WorkflowScanner,
     validation: _ValidationOutcome,
     autofix: _AutoFixOutcome,
+    allow_list: AllowListOutcome | None = None,
 ) -> None:
     """Generate and display the scan/validation results."""
     scan_summary = scanner.get_scan_summary(validation.workflow_calls)
@@ -1266,6 +1324,7 @@ def _emit_results(
             validation_summary,
             validation.validation_errors,
             options.path,
+            allow_list,
         )
     else:
         output_text_results(
@@ -1278,12 +1337,93 @@ def _emit_results(
             autofix.redirect_stats,
             autofix.stale_actions_summary,
         )
+        if allow_list is not None and not options.quiet:
+            # Remediation lands in a later phase, so do not advertise a
+            # flag that does not exist yet.
+            render_allow_list(
+                allow_list,
+                root=options.path,
+                show_suppressed=options.show_suppressed,
+                update_hint=False,
+            )
+
+
+def _run_allow_list_stage(
+    config: Config,
+    options: CLIOptions,
+    shared_cache: ValidationCache,
+) -> AllowListOutcome | None:
+    """Detect stale harden-runner allow-list pins.
+
+    Allow-list pins are an ``lfreleng-actions`` convention rather than
+    GitHub-native syntax, so a failure here must never break a run that
+    would otherwise have succeeded. Any unexpected error is logged and
+    swallowed; the check is simply skipped.
+
+    Args:
+        config: Resolved configuration.
+        options: Resolved CLI options.
+        shared_cache: Cache shared with validation and auto-fix.
+
+    Returns:
+        The outcome, or None when checking is disabled or failed.
+    """
+    if not config.allow_list.enabled:
+        return None
+
+    logger = logging.getLogger(__name__)
+    scanner = WorkflowScanner(config)
+
+    try:
+        paths = _allow_list_paths(config, options, scanner)
+        checker = AllowListChecker(config, shared_cache)
+        return asyncio.run(checker.check(paths, options.path))
+    except Exception as e:  # noqa: BLE001 - advisory check, never fatal
+        logger.warning(f"Allow-list check failed: {e}")
+        return None
+
+
+def _allow_list_paths(
+    config: Config,
+    options: CLIOptions,
+    scanner: WorkflowScanner,
+) -> list[Path]:
+    """Collect the files the allow-list check should read.
+
+    Honours ``--files`` so the check covers the same scope as validation.
+    Otherwise it adds ``allow_list.extra_globs`` to the usual discovery:
+    example caller workflows live outside ``.github/workflows`` and are
+    not found by the standard scan, but they carry pins too.
+
+    Args:
+        config: Resolved configuration.
+        options: Resolved CLI options.
+        scanner: Scanner providing the standard discovery.
+
+    Returns:
+        Deduplicated file paths, in discovery order.
+    """
+    if options.files:
+        return list(
+            scanner.scan_directory(options.path, specific_files=options.files)
+        )
+
+    paths: list[Path] = list(scanner.find_workflow_files(options.path))
+    seen = set(paths)
+    for pattern in config.allow_list.extra_globs:
+        for path in sorted(options.path.glob(pattern)):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                paths.append(path)
+    return paths
 
 
 def _determine_exit_code(
     options: CLIOptions,
     validation: _ValidationOutcome,
     autofix: _AutoFixOutcome,
+    config: Config,
+    allow_list: AllowListOutcome | None = None,
 ) -> int:
     """Compute the process exit code from fixes and validation errors.
 
@@ -1296,6 +1436,8 @@ def _determine_exit_code(
         options: Resolved CLI options.
         validation: Outcome of the scan/validate stage.
         autofix: Outcome of the auto-fix stage.
+        config: Resolved configuration.
+        allow_list: Outcome of the allow-list stage, when it ran.
 
     Returns:
         A code from :mod:`gha_workflow_linter.exit_codes`.
@@ -1328,6 +1470,15 @@ def _determine_exit_code(
     # caller opted in with --verify-actions.
     if options.verify_actions and _has_outdated_actions(autofix):
         codes.append(exit_codes.ACTIONS_OUTDATED)
+
+    # Allow-list findings are advisory unless --verify-allow-list is set.
+    # An unresolved check outranks a stale one: enforcement that silently
+    # degrades to "pass" when the network is down is worse than useless.
+    if allow_list is not None and config.allow_list.verify:
+        if allow_list.unresolved:
+            codes.append(exit_codes.ALLOW_LIST_UNRESOLVED)
+        elif allow_list.unsuppressed:
+            codes.append(exit_codes.ALLOW_LIST_STALE)
 
     return exit_codes.combine(*codes) if codes else exit_codes.SUCCESS
 
@@ -1378,7 +1529,9 @@ def run_linter(config: Config, options: CLIOptions) -> int:
 
     autofix = _run_auto_fix_stage(config, options, shared_cache, validation)
 
-    _emit_results(options, scanner, validation, autofix)
+    allow_list = _run_allow_list_stage(config, options, shared_cache)
+
+    _emit_results(options, scanner, validation, autofix, allow_list)
 
     # Report outdated actions when auto-fix repaired validation errors but
     # version bumps were only detected, not applied. This is presentation
@@ -1394,7 +1547,9 @@ def run_linter(config: Config, options: CLIOptions) -> int:
             autofix.stale_actions_summary, options
         )
 
-    return _determine_exit_code(options, validation, autofix)
+    return _determine_exit_code(
+        options, validation, autofix, config, allow_list
+    )
 
 
 def _create_scan_summary_table(
@@ -1850,6 +2005,7 @@ def output_json_results(
     validation_summary: dict[str, Any],
     errors: list[Any],
     scan_path: Path,
+    allow_list: AllowListOutcome | None = None,
 ) -> None:
     """
     Output results in JSON format.
@@ -1859,6 +2015,8 @@ def output_json_results(
         validation_summary: Validation statistics
         errors: List of validation errors
         scan_path: Base path for computing relative paths
+        allow_list: Allow-list outcome, merged in under an ``allow_list``
+            key when the check ran
     """
     result = {
         "scan_summary": scan_summary,
@@ -1881,6 +2039,9 @@ def output_json_results(
             for error in errors
         ],
     }
+
+    if allow_list is not None:
+        result.update(build_allow_list_json(allow_list, root=scan_path))
 
     # Use plain print() to avoid Rich formatting/ANSI codes in JSON output
     print(json.dumps(result, indent=2))

--- a/src/gha_workflow_linter/config.py
+++ b/src/gha_workflow_linter/config.py
@@ -213,6 +213,20 @@ two_space_comments: {config_dict["two_space_comments"]}
 # Skip scanning action.yaml/action.yml files
 skip_actions: {config_dict["skip_actions"]}
 
+# Harden-runner allow-list pin checking. These pins are an
+# lfreleng-actions convention rather than GitHub-native syntax, so the
+# check is advisory by default: it reports stale pins but never changes
+# the exit code. Set verify to true to enforce (exit status 3, or 4 when
+# the latest release cannot be resolved).
+allow_list:
+  enabled: true
+  verify: false
+  show_suppressed: false
+  # Organisation used to resolve the '@<sha>' shorthand. When empty the
+  # tool infers it from GITHUB_REPOSITORY_OWNER, then the 'upstream' git
+  # remote, then 'origin'. Forks should set this explicitly.
+  org: ""
+
 # Network configuration
 network:
   # Timeout for network requests (seconds)

--- a/src/gha_workflow_linter/github_api.py
+++ b/src/gha_workflow_linter/github_api.py
@@ -23,6 +23,11 @@ from .exceptions import (
     TemporaryAPIError,
 )
 from .git_refs import AnnotatedTagPeel
+from .latest_release import (
+    LatestRelease,
+    ReleasePolicy,
+    resolve_latest_releases_chunk,
+)
 from .models import (
     APICallStats,
     GitHubAPIConfig,
@@ -421,6 +426,85 @@ class GitHubGraphQLClient:
         )
 
         for batch_result in batch_results_list:
+            results.update(batch_result)
+
+        return results
+
+    async def resolve_latest_releases_batch(
+        self,
+        repo_keys: list[str],
+        policy: ReleasePolicy | None = None,
+    ) -> dict[str, LatestRelease | None]:
+        """
+        Resolve each repository's latest release tag and peeled commit SHA.
+
+        Repositories are chunked by ``max_repositories_per_query`` and the
+        chunks run concurrently under the same worker limit as the other
+        batch methods. Every chunk is a single query returning both the
+        repository's releases and its tag refs, so an annotated tag peels
+        to its commit without a second round trip -- the distinction that
+        decides whether a pin is stale.
+
+        Args:
+            repo_keys: Repository keys in format "owner/repo". Duplicates
+                are not de-duplicated here; callers resolving allow-list
+                pins should pass distinct host repositories.
+            policy: Draft/prerelease and cooldown policy. Defaults to
+                excluding prereleases with no cooldown.
+
+        Returns:
+            Dictionary mapping every supplied repository key to its latest
+            release, or ``None`` where none could be resolved (unknown
+            repository, no releases, or a cooldown excluding everything).
+
+        Raises:
+            AuthenticationError: If the token is missing or rejected.
+            RateLimitError: If the API rate limit is exhausted.
+            NetworkError: If the request could not be completed.
+            GitHubAPIError: If the API reported a fatal error.
+        """
+        if not repo_keys:
+            return {}
+
+        effective_policy = policy or ReleasePolicy()
+        batch_size = max(1, self.config.max_repositories_per_query)
+        batches = [
+            repo_keys[i : i + batch_size]
+            for i in range(0, len(repo_keys), batch_size)
+        ]
+
+        semaphore = asyncio.Semaphore(self.parallel_workers)
+
+        async def process_batch_with_limit(
+            batch: list[str],
+        ) -> dict[str, LatestRelease | None]:
+            """Resolve one batch under the shared concurrency limit."""
+            async with semaphore:
+                await self._check_rate_limit()
+                try:
+                    return await resolve_latest_releases_chunk(
+                        self._execute_graphql_query, batch, effective_policy
+                    )
+                except (
+                    NetworkError,
+                    GitHubAPIError,
+                    AuthenticationError,
+                    RateLimitError,
+                ):
+                    # Re-raise real API/network errors so the caller can
+                    # tell "could not check" from "nothing to report".
+                    raise
+                except Exception as e:
+                    self.logger.error(
+                        f"Unexpected error resolving latest releases: {e}"
+                    )
+                    self.api_stats.increment_failed_call()
+                    return dict.fromkeys(batch, None)
+
+        results: dict[str, LatestRelease | None] = {}
+        for batch_result in await asyncio.gather(
+            *[process_batch_with_limit(batch) for batch in batches]
+        ):
             results.update(batch_result)
 
         return results

--- a/src/gha_workflow_linter/latest_release.py
+++ b/src/gha_workflow_linter/latest_release.py
@@ -1,0 +1,502 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Latest-release records, the GraphQL behind them, and their selection.
+
+A harden-runner allow-list pin names a *commit* of a host repository
+(normally ``<org>/.github``), and it is stale when that commit is not the
+one behind the host repository's latest release. Answering that question
+needs three things, and this module holds all three so both validation
+backends share one definition:
+
+* :class:`LatestRelease` -- the answer: a tag plus its **peeled commit**,
+  and the commit-to-tag map of every release that was in the running, so
+  a caller can ask "which release does *this* commit belong to?".
+* :func:`build_latest_releases_query` / :func:`parse_latest_releases_response`
+  -- one aliased GraphQL round trip that returns each repository's
+  releases *and* its tag refs, so annotated tags peel without a second
+  request.
+* :func:`select_latest_release` -- the backend-agnostic policy (drafts,
+  prereleases, cooldown) applied to whatever candidates a backend found.
+
+The commit-to-tag map exists because a cooldown makes "latest" a moving
+target in both directions: when the newest release is still warming, the
+selected release is deliberately an *older* one, and a pin sitting on a
+newer release is ahead rather than stale. Answering that needs the
+position of the pinned commit, which only the resolving backend has seen.
+
+Peeling is the subtle part. ``lfreleng-actions`` releases use annotated
+tags, so ``refs/tags/v0.12.2`` names a *tag object*
+(``8f363565...``) whose target is the commit (``bf6642f6...``). Pins carry
+the commit. Comparing a pin against the tag-object SHA would report every
+correctly-pinned reference as stale, which is why the tag-ref selection
+here nests ``target { oid ... on Tag { target { oid } } }`` -- the same
+shape :meth:`~gha_workflow_linter.auto_fix_resolution._ReferenceResolutionMixin._extract_sha_from_ref_data`
+already relies on.
+
+Note that the GraphQL ``Tag`` type exposes ``name``, not ``tagName``;
+``tagName`` exists on ``Release`` only. Selecting it on a ``Tag`` makes
+the whole query fail at run time.
+
+This module deliberately depends on nothing inside the package beyond
+:mod:`patterns` and :mod:`version_utils`, so it can sit underneath both
+:mod:`github_api` and :mod:`allow_list_resolver` without a cycle.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from .patterns import ActionCallPatterns
+from .version_utils import (
+    _get_version_specificity,
+    _parse_iso_datetime,
+    _parse_version,
+    _select_version_with_cooldown,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Mapping, Sequence
+    from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+#: Tag refs requested per repository. Ordered by tag-commit date descending,
+#: so the newest releases are covered even for repositories with a long tag
+#: history.
+_TAG_REFS_PER_REPO = 100
+
+#: Releases requested per repository. Only enough to let a cooldown fall
+#: back to an older, already-warm release; the newest few always suffice.
+_RELEASES_PER_REPO = 20
+
+#: Owner and repository names GitHub actually permits. Repository keys are
+#: interpolated into the query, so anything outside this set is dropped
+#: rather than escaped: a key that cannot name a real repository has no
+#: business reaching the API.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclasses.dataclass(frozen=True)
+class LatestRelease:
+    """The latest release of a repository, resolved to a commit.
+
+    Attributes:
+        tag: Release tag name, for example ``v0.12.2``.
+        commit_sha: SHA of the commit the tag points at. For an annotated
+            tag this is the *peeled* commit, never the tag object.
+        published_at: When the release was published, or ``None`` when the
+            backend cannot supply a date (the Git backend never can) or
+            when the value was restored from the cache, which does not
+            persist it.
+        commit_tags: Reverse map of lowercased commit SHA to the tag of
+            the policy-eligible release behind it, covering every release
+            the backend considered and not only the selected one. Empty
+            when the record was restored from the cache, which persists
+            only ``(tag, sha)``. Excluded from equality and ``repr``: it
+            is derived context about the repository, not part of the
+            identity of the release. Prefer :meth:`tag_for_commit` over
+            indexing it directly.
+    """
+
+    tag: str
+    commit_sha: str
+    published_at: datetime | None = None
+    commit_tags: Mapping[str, str] = dataclasses.field(
+        default_factory=dict, compare=False, repr=False
+    )
+
+    def tag_for_commit(self, commit_sha: str) -> str | None:
+        """Return the release tag a commit of this repository belongs to.
+
+        Every tag this can return passed
+        :attr:`~gha_workflow_linter.patterns.ActionCallPatterns.VERSION_TAG_PATTERN`,
+        so it is safe to hand to
+        :func:`~gha_workflow_linter.version_utils._parse_version`.
+
+        Args:
+            commit_sha: A commit SHA, in either case.
+
+        Returns:
+            The tag of the release whose peeled commit is ``commit_sha``,
+            or ``None`` when the commit belongs to no eligible release --
+            including when :attr:`commit_tags` is empty because the record
+            came from the cache.
+        """
+        return self.commit_tags.get(commit_sha.strip().lower())
+
+
+@dataclasses.dataclass(frozen=True)
+class ReleasePolicy:
+    """Which releases a caller is willing to accept as "latest".
+
+    Attributes:
+        allow_prerelease: Include releases GitHub marks as prereleases.
+            Drafts are never eligible regardless of this setting.
+        cooldown_days: Minimum age, in days, before a release becomes
+            eligible. ``0`` disables the cooldown. A candidate with no
+            known publication date is skipped while a cooldown is active,
+            because its age cannot be verified.
+    """
+
+    allow_prerelease: bool = False
+    cooldown_days: int = 0
+
+
+@dataclasses.dataclass(frozen=True)
+class ReleaseCandidate:
+    """One release (or bare tag) a backend offered for consideration.
+
+    Attributes:
+        tag: Tag name.
+        commit_sha: Peeled commit SHA behind the tag.
+        published_at: Publication timestamp, or ``None`` when unknown.
+        is_draft: Whether GitHub marks the release as a draft.
+        is_prerelease: Whether GitHub marks the release as a prerelease.
+    """
+
+    tag: str
+    commit_sha: str
+    published_at: datetime | None = None
+    is_draft: bool = False
+    is_prerelease: bool = False
+
+
+def build_latest_releases_query(
+    repo_keys: Sequence[str],
+) -> tuple[str, dict[str, str]]:
+    """Build one aliased GraphQL query covering several repositories.
+
+    Each repository contributes its ``latestRelease``, a page of recent
+    releases (for their publication dates and draft/prerelease flags) and
+    a page of tag refs (for the peeled commit behind each tag).
+
+    Args:
+        repo_keys: Repository keys, ``owner/repo`` or ``owner/repo/path``.
+            Any trailing action subpath is ignored; keys that cannot name
+            a real repository are skipped.
+
+    Returns:
+        Two-tuple of the query document and a mapping of GraphQL alias to
+        the originating repository key. ``("", {})`` when no key was
+        usable, so callers can skip the request entirely.
+    """
+    query_parts: list[str] = []
+    aliases: dict[str, str] = {}
+
+    for index, repo_key in enumerate(repo_keys):
+        owner, _, remainder = repo_key.partition("/")
+        name = remainder.split("/")[0]
+        if not _SAFE_NAME.match(owner) or not _SAFE_NAME.match(name):
+            logger.warning(f"Invalid repository format: {repo_key}")
+            continue
+
+        alias = f"repo_{index}"
+        aliases[alias] = repo_key
+        query_parts.append(
+            f'{alias}: repository(owner: "{owner}", name: "{name}") {{ '
+            f"latestRelease {{ tagName publishedAt isDraft isPrerelease }} "
+            f"releases(first: {_RELEASES_PER_REPO}, "
+            f"orderBy: {{field: CREATED_AT, direction: DESC}}) "
+            f"{{ nodes {{ tagName publishedAt isDraft isPrerelease }} }} "
+            f'refs(refPrefix: "refs/tags/", first: {_TAG_REFS_PER_REPO}, '
+            f"orderBy: {{field: TAG_COMMIT_DATE, direction: DESC}}) "
+            f"{{ nodes {{ name target {{ oid ... on Tag "
+            f"{{ target {{ oid }} }} }} }} }} }}"
+        )
+
+    if not query_parts:
+        return "", {}
+
+    return f"query {{ {' '.join(query_parts)} }}", aliases
+
+
+def _peeled_sha(target: Any) -> str | None:
+    """Extract the commit SHA from a tag ref's GraphQL ``target``.
+
+    Args:
+        target: The ``target`` payload of a ``refs.nodes`` entry.
+
+    Returns:
+        The commit SHA: the nested ``target.target.oid`` for an annotated
+        tag, or the direct ``target.oid`` for a lightweight tag. ``None``
+        when neither is present.
+    """
+    if not isinstance(target, dict):
+        return None
+
+    nested = target.get("target")
+    if isinstance(nested, dict) and nested.get("oid"):
+        return str(nested["oid"])
+
+    oid = target.get("oid")
+    return str(oid) if oid else None
+
+
+def _tag_commit_shas(repo_data: Mapping[str, Any]) -> dict[str, str]:
+    """Map tag name to peeled commit SHA for one repository's tag refs.
+
+    Args:
+        repo_data: The per-repository GraphQL response fragment.
+
+    Returns:
+        Dictionary mapping tag name to commit SHA. Tags whose target could
+        not be peeled are omitted.
+    """
+    refs = repo_data.get("refs")
+    nodes = refs.get("nodes") if isinstance(refs, dict) else None
+
+    shas: dict[str, str] = {}
+    for node in nodes or []:
+        if not isinstance(node, dict):
+            continue
+        name = node.get("name")
+        sha = _peeled_sha(node.get("target"))
+        if name and sha:
+            shas[str(name)] = sha
+
+    return shas
+
+
+def tag_candidates(tag_shas: Mapping[str, str]) -> list[ReleaseCandidate]:
+    """Build undated candidates from a tag-to-commit mapping.
+
+    Used by the Git backend, which sees tags but no releases, and as the
+    GraphQL fallback for a repository that publishes tags without cutting
+    releases. Every candidate is undated, so an active cooldown rejects
+    them all rather than guessing at their age.
+
+    Args:
+        tag_shas: Mapping of tag name to commit SHA, already peeled.
+
+    Returns:
+        One :class:`ReleaseCandidate` per tag carrying a SHA.
+    """
+    return [
+        ReleaseCandidate(tag=tag, commit_sha=sha)
+        for tag, sha in tag_shas.items()
+        if sha
+    ]
+
+
+def _release_candidates(
+    repo_data: Mapping[str, Any],
+) -> list[ReleaseCandidate]:
+    """Collect the release candidates for one repository's response.
+
+    Releases are matched to a tag ref to obtain the peeled commit SHA; a
+    release whose tag has no ref (a draft, typically, since GitHub only
+    creates the tag on publication) is dropped. A repository with no
+    usable releases falls back to its bare tags, mirroring the preference
+    order in ``auto_fix_versions``.
+
+    Args:
+        repo_data: The per-repository GraphQL response fragment.
+
+    Returns:
+        Candidates in no particular order; :func:`select_latest_release`
+        does the ranking.
+    """
+    tag_shas = _tag_commit_shas(repo_data)
+
+    payloads: list[Any] = []
+    releases = repo_data.get("releases")
+    if isinstance(releases, dict):
+        payloads.extend(releases.get("nodes") or [])
+    payloads.append(repo_data.get("latestRelease"))
+
+    candidates: dict[str, ReleaseCandidate] = {}
+    for payload in payloads:
+        if not isinstance(payload, dict):
+            continue
+        tag = str(payload.get("tagName") or "")
+        sha = tag_shas.get(tag)
+        if not tag or not sha or tag in candidates:
+            continue
+        candidates[tag] = ReleaseCandidate(
+            tag=tag,
+            commit_sha=sha,
+            published_at=_parse_iso_datetime(payload.get("publishedAt")),
+            is_draft=bool(payload.get("isDraft")),
+            is_prerelease=bool(payload.get("isPrerelease")),
+        )
+
+    return list(candidates.values()) or tag_candidates(tag_shas)
+
+
+def parse_latest_releases_response(
+    response_data: Mapping[str, Any], aliases: Mapping[str, str]
+) -> dict[str, list[ReleaseCandidate]]:
+    """Map a batched release query response back to repository keys.
+
+    Args:
+        response_data: The decoded GraphQL response body.
+        aliases: Mapping of GraphQL alias to repository key, as returned
+            by :func:`build_latest_releases_query`.
+
+    Returns:
+        Dictionary mapping repository key to its candidates. A repository
+        GitHub could not resolve (its alias is ``null``) maps to an empty
+        list rather than being absent, so callers see "no latest release"
+        rather than "not asked".
+    """
+    root = response_data.get("data") or {}
+
+    results: dict[str, list[ReleaseCandidate]] = {}
+    for alias, repo_key in aliases.items():
+        repo_data = root.get(alias) if isinstance(root, dict) else None
+        if not isinstance(repo_data, dict):
+            logger.debug(f"No repository data for {repo_key}")
+            results[repo_key] = []
+            continue
+        results[repo_key] = _release_candidates(repo_data)
+
+    return results
+
+
+def _is_eligible(candidate: ReleaseCandidate, policy: ReleasePolicy) -> bool:
+    """Report whether a candidate may be selected under a policy.
+
+    Args:
+        candidate: The candidate under consideration.
+        policy: The caller's release policy.
+
+    Returns:
+        ``True`` when the candidate carries a SHA, is not a draft, is not
+        an excluded prerelease, and has a clean version tag. The tag check
+        also guarantees :func:`_parse_version` cannot raise later.
+    """
+    if candidate.is_draft or not candidate.commit_sha:
+        return False
+    if candidate.is_prerelease and not policy.allow_prerelease:
+        return False
+
+    return bool(ActionCallPatterns.VERSION_TAG_PATTERN.match(candidate.tag))
+
+
+def _commit_tags(
+    ordered: Sequence[ReleaseCandidate],
+) -> dict[str, str]:
+    """Build the commit-to-tag map of a ranked candidate list.
+
+    Several tags can name one commit (``v8`` alongside ``v8.0.0``), so
+    the first entry wins and the candidates are expected pre-ranked:
+    highest version, then highest specificity.
+
+    Args:
+        ordered: Policy-eligible candidates, ranked newest first.
+
+    Returns:
+        Dictionary mapping lowercased commit SHA to tag name.
+    """
+    commit_tags: dict[str, str] = {}
+    for candidate in ordered:
+        commit_tags.setdefault(candidate.commit_sha.lower(), candidate.tag)
+    return commit_tags
+
+
+def select_latest_release(
+    candidates: Sequence[ReleaseCandidate],
+    policy: ReleasePolicy,
+    now: datetime | None = None,
+) -> LatestRelease | None:
+    """Pick the newest policy-eligible candidate.
+
+    Ranking reuses the existing version helpers rather than introducing a
+    second notion of "newest": candidates are ordered by parsed version
+    then tag specificity, both descending, and the cooldown window is
+    applied by :func:`~gha_workflow_linter.version_utils._select_version_with_cooldown`.
+
+    The result carries the commit-to-tag map of every eligible candidate,
+    not just the selected one, because a cooldown can select a release
+    that is *older* than one a caller's pin already names.
+
+    Args:
+        candidates: Candidates gathered by a backend, in any order.
+        policy: Draft/prerelease and cooldown policy to apply.
+        now: Reference time for the cooldown window (defaults to the
+            current UTC time); primarily an injection point for tests.
+
+    Returns:
+        The selected release, or ``None`` when nothing is eligible --
+        including when a cooldown leaves every candidate still warming.
+    """
+    eligible = [c for c in candidates if _is_eligible(c, policy)]
+    if not eligible:
+        return None
+
+    ordered = sorted(
+        eligible,
+        key=lambda c: (
+            _parse_version(c.tag),
+            _get_version_specificity(c.tag),
+        ),
+        reverse=True,
+    )
+
+    selected = _select_version_with_cooldown(
+        [(c.tag, c.commit_sha, c.published_at) for c in ordered],
+        policy.cooldown_days,
+        now=now,
+    )
+    if selected is None:
+        return None
+
+    tag, commit_sha = selected
+    published_at = next((c.published_at for c in ordered if c.tag == tag), None)
+
+    return LatestRelease(
+        tag=tag,
+        commit_sha=commit_sha,
+        published_at=published_at,
+        commit_tags=_commit_tags(ordered),
+    )
+
+
+async def resolve_latest_releases_chunk(
+    execute: Callable[[str], Awaitable[dict[Any, Any]]],
+    repo_keys: Sequence[str],
+    policy: ReleasePolicy,
+) -> dict[str, LatestRelease | None]:
+    """Resolve one query-sized chunk of repositories.
+
+    Args:
+        execute: Coroutine function issuing a GraphQL query and returning
+            the decoded response body. Supplied by the API client so this
+            module needs no dependency on it.
+        repo_keys: Repository keys for this chunk.
+        policy: Draft/prerelease and cooldown policy to apply.
+
+    Returns:
+        Dictionary mapping every supplied repository key to its latest
+        release, or ``None`` where none could be resolved.
+
+    Raises:
+        Exception: Whatever ``execute`` raises; the caller decides which
+            API failures are fatal and which degrade to ``None``.
+    """
+    query, aliases = build_latest_releases_query(repo_keys)
+    if not query:
+        return dict.fromkeys(repo_keys, None)
+
+    candidates = parse_latest_releases_response(await execute(query), aliases)
+
+    return {
+        repo_key: select_latest_release(candidates.get(repo_key, []), policy)
+        for repo_key in repo_keys
+    }
+
+
+__all__ = [
+    "LatestRelease",
+    "ReleaseCandidate",
+    "ReleasePolicy",
+    "build_latest_releases_query",
+    "parse_latest_releases_response",
+    "resolve_latest_releases_chunk",
+    "select_latest_release",
+    "tag_candidates",
+]

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -102,6 +102,57 @@ def result_category(result: ValidationResult) -> Category | None:
     return _RESULT_CATEGORIES.get(result)
 
 
+class AllowListFindingKind(str, Enum):
+    """What is wrong with a detected allow-list pin.
+
+    ``STALE`` and ``UNPINNED`` are currency findings: the pin works, but
+    a newer allow-list exists. The remainder are defects that are wrong
+    now. Only currency findings may be silenced by an
+    ``allow-list-pin-ok`` directive, because that directive asserts "this
+    pin is deliberately at this version" -- a statement about currency,
+    not about correctness.
+    """
+
+    STALE = "stale"
+    UNPINNED = "unpinned"
+    COMMENT_MISMATCH = "comment_mismatch"
+    UNRESOLVABLE = "unresolvable"
+    INVALID_SPEC = "invalid_spec"
+
+
+#: Finding kinds an ``allow-list-pin-ok`` directive may silence. A pin
+#: whose comment lies, whose SHA does not exist, or whose spec is
+#: malformed is broken regardless of intent, so those are never
+#: suppressible.
+SUPPRESSIBLE_ALLOW_LIST_KINDS: frozenset[AllowListFindingKind] = frozenset(
+    {
+        AllowListFindingKind.STALE,
+        AllowListFindingKind.UNPINNED,
+    }
+)
+
+
+_ALLOW_LIST_CATEGORIES: dict[AllowListFindingKind, Category] = {
+    AllowListFindingKind.STALE: Category.CURRENCY,
+    AllowListFindingKind.UNPINNED: Category.CURRENCY,
+    AllowListFindingKind.COMMENT_MISMATCH: Category.DEFECT,
+    AllowListFindingKind.UNRESOLVABLE: Category.DEFECT,
+    AllowListFindingKind.INVALID_SPEC: Category.DEFECT,
+}
+
+
+def allow_list_category(kind: AllowListFindingKind) -> Category:
+    """Return the category of an allow-list finding kind.
+
+    Args:
+        kind: The finding kind to classify.
+
+    Returns:
+        The finding category.
+    """
+    return _ALLOW_LIST_CATEGORIES[kind]
+
+
 class ActionCallType(str, Enum):
     """Type of action call detected."""
 
@@ -433,6 +484,77 @@ class CacheConfig(BaseModel):
         return self.cache_dir / self.cache_file
 
 
+class AllowListConfig(BaseModel):
+    """Configuration for harden-runner allow-list pin checking.
+
+    Allow-list pins are an ``lfreleng-actions`` convention rather than
+    GitHub-native syntax, so the check is advisory by default: it reports
+    stale pins but never changes the exit code. ``verify`` opts in to
+    enforcement.
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description="Detect harden-runner allow-list pins",
+    )
+    verify: bool = Field(
+        default=False,
+        description=(
+            "Treat stale allow-list pins as errors and exit with the "
+            "ALLOW_LIST_STALE status"
+        ),
+    )
+    update: bool = Field(
+        default=False,
+        description="Rewrite stale allow-list pins in place",
+    )
+    show_suppressed: bool = Field(
+        default=False,
+        description=(
+            "Report suppressed pins as notices. Never affects the exit code"
+        ),
+    )
+    org: str = Field(
+        default="",
+        description=(
+            "Workflow organisation used to resolve the '@<sha>' shorthand. "
+            "When empty the tool infers it from GITHUB_REPOSITORY_OWNER, "
+            "then the 'upstream' git remote, then 'origin'"
+        ),
+    )
+    filename: str = Field(
+        default="allow_list.txt",
+        description=(
+            "Conventional allow-list filename, used by the recogniser for "
+            "scalars whose key name gives no clue. There is deliberately no "
+            "per-consumer registry: every consumer shares one grammar, one "
+            "host repository, and one staleness condition"
+        ),
+    )
+    key_patterns: list[str] = Field(
+        default_factory=lambda: [
+            "*allow_list*",
+            "*allowlist*",
+            "*allow-list*",
+        ],
+        description=(
+            "Key-name patterns recognised as allow-list coordinates in "
+            "workflow_call input defaults and reusable-workflow 'with' blocks"
+        ),
+    )
+    extra_globs: list[str] = Field(
+        default_factory=lambda: [
+            "examples/**/*.yaml",
+            "examples/**/*.yml",
+        ],
+        description=(
+            "Extra globs scanned only by the allow-list checker. Example "
+            "caller workflows live outside .github/workflows and are "
+            "otherwise not discovered"
+        ),
+    )
+
+
 class Config(BaseModel):
     """Main configuration model."""
 
@@ -508,6 +630,10 @@ class Config(BaseModel):
     cache: CacheConfig = Field(
         default_factory=CacheConfig,
         description="Cache configuration",
+    )
+    allow_list: AllowListConfig = Field(
+        default_factory=AllowListConfig,
+        description="Allow-list pin checking configuration",
     )
 
     @property
@@ -593,6 +719,25 @@ class CLIOptions(BaseModel):
             "Treat outdated action calls as errors and exit with the "
             "ACTIONS_OUTDATED status"
         ),
+    )
+    allow_list: bool | None = Field(
+        default=None, description="Enable allow-list pin detection"
+    )
+    verify_allow_list: bool = Field(
+        default=False,
+        description="Treat stale allow-list pins as errors",
+    )
+    update_allow_list: bool = Field(
+        default=False,
+        description="Rewrite stale allow-list pins in place",
+    )
+    show_suppressed: bool = Field(
+        default=False,
+        description="Report suppressed allow-list pins as notices",
+    )
+    allow_list_org: str | None = Field(
+        default=None,
+        description="Workflow organisation for '@<sha>' shorthand resolution",
     )
 
     @field_validator("output_format")

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -504,6 +504,13 @@ class AllowListConfig(BaseModel):
             "ALLOW_LIST_STALE status"
         ),
     )
+    update: bool = Field(
+        default=False,
+        description=(
+            "Rewrite stale allow-list pins in place. Suppressed pins are "
+            "never rewritten"
+        ),
+    )
     show_suppressed: bool = Field(
         default=False,
         description=(
@@ -722,6 +729,10 @@ class CLIOptions(BaseModel):
     verify_allow_list: bool = Field(
         default=False,
         description="Treat stale allow-list pins as errors",
+    )
+    update_allow_list: bool = Field(
+        default=False,
+        description="Rewrite stale allow-list pins in place",
     )
     show_suppressed: bool = Field(
         default=False,

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -504,10 +504,6 @@ class AllowListConfig(BaseModel):
             "ALLOW_LIST_STALE status"
         ),
     )
-    update: bool = Field(
-        default=False,
-        description="Rewrite stale allow-list pins in place",
-    )
     show_suppressed: bool = Field(
         default=False,
         description=(
@@ -726,10 +722,6 @@ class CLIOptions(BaseModel):
     verify_allow_list: bool = Field(
         default=False,
         description="Treat stale allow-list pins as errors",
-    )
-    update_allow_list: bool = Field(
-        default=False,
-        description="Rewrite stale allow-list pins in place",
     )
     show_suppressed: bool = Field(
         default=False,

--- a/src/gha_workflow_linter/scanner.py
+++ b/src/gha_workflow_linter/scanner.py
@@ -48,6 +48,9 @@ class WorkflowScanner:
         self.config = config
         self.logger = logging.getLogger(__name__)
         self._patterns = ActionCallPatterns()
+        # Memoises "is this directory a repository root?" for the life of
+        # the scanner; a deep tree asks about the same ancestors often.
+        self._repository_roots: dict[Path, bool] = {}
 
     def find_workflow_files(
         self,
@@ -135,14 +138,78 @@ class WorkflowScanner:
         # Search for .github/workflows directories recursively
         try:
             for github_dir in root_path.rglob(".github"):
-                if github_dir.is_dir():
-                    workflows_dir = github_dir / "workflows"
-                    if workflows_dir.exists() and workflows_dir.is_dir():
-                        workflow_dirs.add(workflows_dir)
+                if not github_dir.is_dir():
+                    continue
+                if self._crosses_repository_boundary(github_dir, root_path):
+                    continue
+                workflows_dir = github_dir / "workflows"
+                if workflows_dir.exists() and workflows_dir.is_dir():
+                    workflow_dirs.add(workflows_dir)
         except (PermissionError, OSError) as e:
             self.logger.warning(f"Error scanning directory {root_path}: {e}")
 
         return workflow_dirs
+
+    def _crosses_repository_boundary(self, path: Path, root_path: Path) -> bool:
+        """Report whether a path lies inside a nested repository.
+
+        Git worktrees, submodules and vendored clones all place a ``.git``
+        entry (a directory for a clone, a gitdir pointer file for a
+        worktree or submodule) at their own root. Anything beneath such a
+        directory belongs to a different repository, or to a second
+        checkout of this one, so its workflows are not the scanned
+        repository's concern.
+
+        Without this, scanning a repository that keeps worktrees under
+        ``.worktrees/`` reports every finding several times over, once per
+        checked-out branch, against files the working tree does not
+        contain. Remediation would then rewrite stale duplicates.
+
+        The scan root itself is never treated as a boundary: it is the
+        repository being scanned.
+
+        Args:
+            path: Candidate path, at or below ``root_path``.
+            root_path: Root of the scan.
+
+        Returns:
+            True when a nested repository sits between ``root_path`` and
+            ``path``.
+        """
+        try:
+            relative = path.relative_to(root_path)
+        except ValueError:
+            return False
+
+        current = root_path
+        for part in relative.parts:
+            current = current / part
+            if current == path and not path.is_dir():
+                break
+            if self._is_repository_root(current):
+                return True
+        return False
+
+    def _is_repository_root(self, path: Path) -> bool:
+        """Report whether a directory is the root of a Git repository.
+
+        Results are cached for the lifetime of the scanner: a deep tree
+        asks about the same ancestors repeatedly.
+
+        Args:
+            path: Directory to test.
+
+        Returns:
+            True when the directory contains a ``.git`` entry.
+        """
+        cached = self._repository_roots.get(path)
+        if cached is None:
+            try:
+                cached = (path / ".git").exists()
+            except OSError:
+                cached = False
+            self._repository_roots[path] = cached
+        return cached
 
     def _find_action_files(self, root_path: Path) -> Iterator[Path]:
         """
@@ -167,9 +234,14 @@ class WorkflowScanner:
                 # Find recursively (rglob includes root directory)
                 for action_file in root_path.rglob(action_name):
                     # Yield only real action files outside .github/workflows
-                    # (paths under .github/workflows are workflow files).
-                    if action_file.is_file() and not self._is_in_workflows_dir(
-                        action_file
+                    # (paths under .github/workflows are workflow files),
+                    # and outside any nested repository.
+                    if (
+                        action_file.is_file()
+                        and not self._is_in_workflows_dir(action_file)
+                        and not self._crosses_repository_boundary(
+                            action_file, root_path
+                        )
                     ):
                         self.logger.debug(f"Found action file: {action_file}")
                         yield action_file

--- a/tests/fixtures/allow_list/comment_positions.yaml
+++ b/tests/fixtures/allow_list/comment_positions.yaml
@@ -1,0 +1,42 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# yamllint disable rule:line-length
+
+# Every quoting style and both comment positions, one step each.
+name: Comment positions
+
+on:
+  workflow_dispatch:
+
+jobs:
+  quoting:
+    runs-on: ubuntu-24.04
+    steps:
+      # Single quotes, version in a YAML comment outside them (form A).
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Double quotes, version inside them (form B).
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: "@8f4f0cf83e6a015957e83261ed379fd811fc060e # v0.5.1"
+
+      # Unquoted, no comment at all.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@bf6642f68d58c1b81bbe993e676d6cc339ac3654
+
+      # Both positions at once. The in-scalar comment is the one the
+      # action itself sees, so it wins.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e # v0.5.1'  # v0.2.1
+
+      # A folded block scalar spans several lines: recorded, but never
+      # rewritten.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: >-
+            lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@bf6642f68d58c1b81bbe993e676d6cc339ac3654

--- a/tests/fixtures/allow_list/internal_step_config.yaml
+++ b/tests/fixtures/allow_list/internal_step_config.yaml
@@ -1,0 +1,20 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# yamllint disable rule:line-length
+
+# The shape every internal workflow uses: the shorthand '@<sha>' form,
+# whose host org comes from the workflow org, with the version in a
+# YAML comment outside the quotes (form A of design section 2).
+name: Internal workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1

--- a/tests/fixtures/allow_list/no_pins.yaml
+++ b/tests/fixtures/allow_list/no_pins.yaml
@@ -1,0 +1,22 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# yamllint disable rule:line-length
+
+# A perfectly ordinary workflow with no allow-list coordinate anywhere.
+# The 'config' input here belongs to an unrelated action and does not
+# parse as a spec, so it is skipped rather than reported.
+name: No pins
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: some-org/unrelated-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v1.2.3
+        with:
+          config: ./config/settings/unrelated.json
+          verbose: 'true'

--- a/tests/fixtures/allow_list/reusable_caller.yaml
+++ b/tests/fixtures/allow_list/reusable_caller.yaml
@@ -1,0 +1,26 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# yamllint disable rule:line-length
+
+# A reusable-workflow caller. Location 3 puts the coordinate in the
+# job's own 'with:' block, under a key the workflow author chose.
+name: Caller workflow
+
+on:
+  push:
+
+jobs:
+  call:
+    uses: lfreleng-actions/.github/.github/workflows/reusable.yaml@bf6642f68d58c1b81bbe993e676d6cc339ac3654  # v0.12.2
+    with:
+      harden_runner_allowlist: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@bf6642f68d58c1b81bbe993e676d6cc339ac3654'  # v0.12.2
+      audit_level: 'moderate'
+
+  expression:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          # Resolved at run time, so there is nothing here to pin.
+          config: ${{ inputs.harden_runner_allowlist }}

--- a/tests/fixtures/allow_list/suppression.yaml
+++ b/tests/fixtures/allow_list/suppression.yaml
@@ -1,0 +1,49 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# yamllint disable rule:line-length
+
+# The two suppression forms of design section 7.4, separately and
+# together, plus an unsuppressed pin for contrast.
+name: Suppression forms
+
+on:
+  workflow_dispatch:
+
+jobs:
+  suppressed:
+    runs-on: ubuntu-24.04
+    steps:
+      # Form 1: a directive on the immediately preceding line.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          # gha-workflow-linter: allow-list-pin-ok -- waiting for a release
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Form 2: an inline keyword after the version token.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1 allow-list-pin-ok -- upstream is broken
+
+      # Both forms at once: idempotent, not an error.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          # gha-workflow-linter: allow-list-pin-ok -- preceding reason
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1 allow-list-pin-ok -- inline reason
+
+      # A directive carried by the in-scalar comment instead.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e # v0.5.1 allow-list-pin-ok'
+
+      # A blank line between the directive and the pin breaks the bind.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          # gha-workflow-linter: allow-list-pin-ok
+
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # No directive anywhere.
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1

--- a/tests/fixtures/allow_list/workflow_call_defaults.yaml
+++ b/tests/fixtures/allow_list/workflow_call_defaults.yaml
@@ -1,0 +1,45 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# yamllint disable rule:line-length
+
+# Reusable-workflow input defaults, in the explicit path form. The bare
+# 'on:' key below is a YAML 1.1 boolean once constructed, which is the
+# gotcha the walker has to survive.
+#
+# 'audit_config' proves design section 5.4: a python-audit allow-list is
+# detected with no code change, no registry entry and a key name that
+# matches none of the recogniser's patterns. Only the conventional
+# filename in the path identifies it.
+name: Reusable workflow
+
+on:
+  workflow_call:
+    inputs:
+      harden_runner_allowlist:
+        description: 'Harden-runner egress allow-list coordinate'
+        required: false
+        type: string
+        default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@bf6642f68d58c1b81bbe993e676d6cc339ac3654'  # v0.12.2
+      audit_config:
+        description: 'python-audit allow-list coordinate'
+        required: false
+        type: string
+        default: 'lfreleng-actions//.github/python-audit/lfreleng-actions/allow_list.txt@bf6642f68d58c1b81bbe993e676d6cc339ac3654'  # v0.12.2
+      # Parses as a spec (an org, taking every default) but names no
+      # allow-list file and sits under an unrecognised key: not a pin.
+      build_timeout:
+        required: false
+        type: string
+        default: '30'
+      # Fails the grammar outright: '.' is not valid in an org name.
+      python_version:
+        required: false
+        type: string
+        default: '3.11'
+
+jobs:
+  noop:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "nothing to do"

--- a/tests/test_allow_list_check.py
+++ b/tests/test_allow_list_check.py
@@ -1,0 +1,1039 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for allow-list pin classification.
+
+Every SHA below is real. ``lfreleng-actions/.github`` releases with
+annotated tags, so the commit an allow-list pin carries at ``v0.12.2``
+is the *peeled* commit ``bf6642f6...`` and never the tag object
+``8f363565...``. A classifier that compared against the tag object would
+report every correctly-pinned reference as stale, so the distinction is
+asserted rather than assumed.
+
+The scanner and the resolver are already covered by their own suites.
+What is tested here is the join between them: which pin plus which
+latest release yields which finding, at which severity, and when a
+directive silences it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from gha_workflow_linter import allow_list_check
+from gha_workflow_linter.allow_list_check import (
+    ORG_ENV_VAR,
+    UNRESOLVED_REASON,
+    AllowListChecker,
+    AllowListFinding,
+    AllowListOutcome,
+    _owner_from_remote_url,
+    classify_pins,
+    host_key,
+    resolve_workflow_org,
+)
+from gha_workflow_linter.allow_list_resolver import AllowListResolver
+from gha_workflow_linter.allow_list_scanner import (
+    AllowListPin,
+    AllowListScanner,
+    CommentPosition,
+    QuoteStyle,
+)
+from gha_workflow_linter.allow_list_spec import SpecError, resolve_spec
+from gha_workflow_linter.cache import ValidationCache
+from gha_workflow_linter.directives import Directive, SuppressionSource
+from gha_workflow_linter.latest_release import LatestRelease
+from gha_workflow_linter.models import (
+    SUPPRESSIBLE_ALLOW_LIST_KINDS,
+    AllowListFindingKind,
+    CacheConfig,
+    Category,
+    Config,
+    Severity,
+    allow_list_category,
+)
+from gha_workflow_linter.version_utils import _parse_version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+FIXTURES = Path(__file__).parent / "fixtures" / "allow_list"
+
+WORKFLOW_ORG = "lfreleng-actions"
+HOST_REPO = f"{WORKFLOW_ORG}/.github"
+
+# v0.1.1 of lfreleng-actions/.github: the version the estate is pinned to.
+STALE_SHA = "18d9c4446bea555d0783e850f6d295f844fe8f67"
+STALE_TAG = "v0.1.1"
+
+# v0.12.2, the current release. The tag is annotated, so the commit and
+# the tag object have different SHAs.
+CURRENT_SHA = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+CURRENT_TAG = "v0.12.2"
+TAG_OBJECT_SHA = "8f363565e79650362c3359ee23b6d6fd295866ee"
+
+LATEST = LatestRelease(tag=CURRENT_TAG, commit_sha=CURRENT_SHA)
+
+# v0.7.0: the newest release at least seven days old while the whole
+# v0.12.x series is still inside a Dependabot-style cooldown window, and
+# therefore what the resolver legitimately selects as the target. Moving
+# a pin from v0.12.2 to v0.7.0 would be a downgrade.
+COOLDOWN_SHA = "d46590dd8f51bdd71494eb9d2afa3bade1457a62"
+COOLDOWN_TAG = "v0.7.0"
+
+#: Commit-to-tag map of the releases above, in the shape the resolver
+#: surfaces on :class:`LatestRelease`. Direction is decided through this
+#: rather than through the version comment, which may lie.
+RELEASE_COMMITS = {
+    CURRENT_SHA: CURRENT_TAG,
+    COOLDOWN_SHA: COOLDOWN_TAG,
+    STALE_SHA: STALE_TAG,
+}
+
+#: What a cooldown-constrained resolution yields: v0.7.0 as the target,
+#: with v0.12.2 still known to be a release of the same repository.
+COOLDOWN_TARGET = LatestRelease(
+    tag=COOLDOWN_TAG,
+    commit_sha=COOLDOWN_SHA,
+    commit_tags=RELEASE_COMMITS,
+)
+
+#: The unconstrained case: v0.12.2 as the target, same map.
+CURRENT_TARGET = LatestRelease(
+    tag=CURRENT_TAG,
+    commit_sha=CURRENT_SHA,
+    commit_tags=RELEASE_COMMITS,
+)
+
+ALLOW = Directive.ALLOW_LIST_PIN_OK
+
+#: Every kind, so the suppression matrix is asserted exhaustively rather
+#: than for a convenient subset.
+ALL_KINDS: tuple[AllowListFindingKind, ...] = tuple(AllowListFindingKind)
+
+
+def make_pin(
+    *,
+    ref: str = STALE_SHA,
+    version_comment: str | None = STALE_TAG,
+    directives: frozenset[Directive] = frozenset(),
+    reason: str | None = None,
+    line_number: int = 116,
+    file_path: Path | None = None,
+    repospec: str = "",
+) -> AllowListPin:
+    """Build a pin without going through the scanner.
+
+    Args:
+        ref: The ref the pin names.
+        version_comment: Version token of the trailing comment.
+        directives: Suppression directives in force.
+        reason: Free text the suppression carried.
+        line_number: 1-based source line.
+        file_path: File the pin sits in.
+        repospec: Repository part of the spec; empty means the shorthand
+            form, which takes its host org from the workflow org.
+
+    Returns:
+        The pin.
+    """
+    spec = resolve_spec(f"{repospec}@{ref}", workflow_org=WORKFLOW_ORG)
+    return AllowListPin(
+        file_path=file_path or Path("/repo/.github/workflows/publish.yaml"),
+        line_number=line_number,
+        column=10,
+        key_path=("jobs", "publish", "steps", "0", "with", "config"),
+        raw_line=f"          config: '@{ref}'  # {version_comment}",
+        raw_value=f"@{ref}",
+        quote_style=QuoteStyle.SINGLE,
+        version_comment=version_comment,
+        comment_position=CommentPosition.YAML,
+        directives=directives,
+        suppressed_by=(
+            SuppressionSource.INLINE_COMMENT if directives else None
+        ),
+        suppression_reason=reason,
+        spec=spec,
+        auto_fixable=True,
+    )
+
+
+def classify_one(
+    pin: AllowListPin,
+    latest: LatestRelease | None = LATEST,
+    *,
+    verify: bool = False,
+) -> AllowListFinding | None:
+    """Classify a single pin and return its finding, if any.
+
+    Args:
+        pin: The pin to classify.
+        latest: The host repository's latest release.
+        verify: Whether enforcement was requested.
+
+    Returns:
+        The finding, or ``None`` when the pin produced none.
+    """
+    findings = classify_pins([pin], {host_key(pin): latest}, verify=verify)
+    return findings[0] if findings else None
+
+
+class TestClassification:
+    """The three classification rules of design section 7.2."""
+
+    def test_current_sha_produces_no_finding(self) -> None:
+        """A pin at the latest commit, with a truthful comment, is fine."""
+        pin = make_pin(ref=CURRENT_SHA, version_comment=CURRENT_TAG)
+
+        assert classify_one(pin) is None
+
+    def test_older_sha_is_stale(self) -> None:
+        """A SHA other than the latest release commit is stale."""
+        finding = classify_one(make_pin())
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.STALE
+        assert finding.current_sha == STALE_SHA
+        assert finding.target_sha == CURRENT_SHA
+        assert finding.target_version == CURRENT_TAG
+
+    def test_tag_object_sha_is_stale_not_current(self) -> None:
+        """The annotated tag object is not the release commit.
+
+        ``v0.12.2`` is an annotated tag, so its ref names a tag object
+        that GitHub Actions cannot check out. Treating the two SHAs as
+        interchangeable would silently bless a broken pin.
+        """
+        finding = classify_one(
+            make_pin(ref=TAG_OBJECT_SHA, version_comment=CURRENT_TAG)
+        )
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.STALE
+
+    @pytest.mark.parametrize("ref", ["main", "HEAD", "v0.12.2", "develop"])
+    def test_non_sha_refs_are_unpinned(self, ref: str) -> None:
+        """A branch or tag ref floats, whatever it points at today."""
+        finding = classify_one(make_pin(ref=ref, version_comment=None))
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.UNPINNED
+        assert finding.current_sha is None
+        assert finding.target_sha == CURRENT_SHA
+
+    def test_omitted_ref_is_unpinned(self) -> None:
+        """An omitted ref resolves to ``HEAD``, which is not a pin."""
+        spec = resolve_spec("lfreleng-actions", workflow_org=WORKFLOW_ORG)
+        assert spec.ref == "HEAD"
+
+        finding = classify_one(make_pin(ref="HEAD", version_comment=None))
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.UNPINNED
+
+    def test_current_sha_with_lying_comment_is_a_mismatch(self) -> None:
+        """A truthful SHA with an untruthful comment is still a defect."""
+        finding = classify_one(
+            make_pin(ref=CURRENT_SHA, version_comment=STALE_TAG)
+        )
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.COMMENT_MISMATCH
+        assert finding.current_sha == CURRENT_SHA
+        assert finding.target_sha == CURRENT_SHA
+        assert finding.target_version == CURRENT_TAG
+
+    def test_current_sha_without_a_comment_is_not_a_mismatch(self) -> None:
+        """A pin carrying no comment cannot lie."""
+        assert (
+            classify_one(make_pin(ref=CURRENT_SHA, version_comment=None))
+            is None
+        )
+
+    @pytest.mark.parametrize("comment", ["0.12.2", "V0.12.2", " v0.12.2 "])
+    def test_comment_comparison_tolerates_the_v_prefix(
+        self, comment: str
+    ) -> None:
+        """``0.12.2`` and ``v0.12.2`` name the same release."""
+        assert (
+            classify_one(make_pin(ref=CURRENT_SHA, version_comment=comment))
+            is None
+        )
+
+    def test_sha_comparison_is_case_insensitive(self) -> None:
+        """Hexadecimal case is not a difference in commit identity."""
+        assert (
+            classify_one(
+                make_pin(ref=CURRENT_SHA.upper(), version_comment=CURRENT_TAG)
+            )
+            is None
+        )
+
+    def test_stale_beats_comment_mismatch(self) -> None:
+        """A stale pin with a stale comment is reported once, as stale.
+
+        The comment is consistent with what the pin actually names, so
+        there is nothing misleading about it; the pin is simply old.
+        """
+        finding = classify_one(make_pin(version_comment=STALE_TAG))
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.STALE
+
+    def test_categories_follow_the_taxonomy(self) -> None:
+        """Currency findings are advisory; defects are not."""
+        stale = classify_one(make_pin())
+        mismatch = classify_one(
+            make_pin(ref=CURRENT_SHA, version_comment=STALE_TAG)
+        )
+        unpinned = classify_one(make_pin(ref="main", version_comment=None))
+
+        assert stale is not None
+        assert mismatch is not None
+        assert unpinned is not None
+        assert stale.category is Category.CURRENCY
+        assert unpinned.category is Category.CURRENCY
+        assert mismatch.category is Category.DEFECT
+
+
+class TestCooldownDirection:
+    """Staleness has a direction, and a cooldown must respect it.
+
+    A cooldown deliberately selects an *older* release than the newest
+    one in existence, so the resolved target is not a ceiling. Comparing
+    a pin against it by SHA equality alone reports a repository that is
+    correctly pinned to v0.12.2 as stale and tells its owner to move to
+    v0.7.0 -- a downgrade, presented as a fix. Direction is therefore
+    established from the host repository's own commit-to-tag map, never
+    from the version comment, which section 7.2 exists because it lies.
+    """
+
+    def test_a_pin_ahead_of_a_cooldown_target_is_not_stale(self) -> None:
+        """The exact regression: v0.12.2 against a v0.7.0 target.
+
+        Every pin in the ``java-workflows`` estate sits at v0.12.2 and a
+        seven-day cooldown resolves the target to v0.7.0. The user is
+        ahead of the target, which is fine, and there is nothing to say.
+        """
+        finding = classify_one(
+            make_pin(ref=CURRENT_SHA, version_comment=CURRENT_TAG),
+            latest=COOLDOWN_TARGET,
+        )
+
+        assert finding is None
+
+    def test_a_pin_behind_the_target_is_still_stale(self) -> None:
+        """Genuine staleness is unaffected by the direction check."""
+        finding = classify_one(
+            make_pin(ref=STALE_SHA, version_comment=STALE_TAG),
+            latest=CURRENT_TARGET,
+        )
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.STALE
+        assert finding.current_sha == STALE_SHA
+        assert finding.target_sha == CURRENT_SHA
+        assert finding.target_version == CURRENT_TAG
+
+    def test_a_pin_equal_to_the_target_produces_no_finding(self) -> None:
+        """Sitting exactly on the cooldown-selected release is correct."""
+        finding = classify_one(
+            make_pin(ref=COOLDOWN_SHA, version_comment=COOLDOWN_TAG),
+            latest=COOLDOWN_TARGET,
+        )
+
+        assert finding is None
+
+    def test_a_commit_belonging_to_no_release_is_stale(self) -> None:
+        """An unplaceable commit gets the best advice available.
+
+        The annotated tag object of v0.12.2 is not the commit of any
+        release, so its position cannot be established and the target
+        remains the only thing worth recommending.
+        """
+        finding = classify_one(
+            make_pin(ref=TAG_OBJECT_SHA, version_comment=CURRENT_TAG),
+            latest=COOLDOWN_TARGET,
+        )
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.STALE
+        assert finding.target_version == COOLDOWN_TAG
+
+    def test_direction_ignores_the_version_comment(self) -> None:
+        """A lying comment can neither create nor conceal staleness."""
+        ahead = classify_one(
+            make_pin(ref=CURRENT_SHA, version_comment=STALE_TAG),
+            latest=COOLDOWN_TARGET,
+        )
+        behind = classify_one(
+            make_pin(ref=STALE_SHA, version_comment="v9.9.9"),
+            latest=CURRENT_TARGET,
+        )
+
+        assert ahead is None
+        assert behind is not None
+        assert behind.kind is AllowListFindingKind.STALE
+
+    def test_version_comparison_is_numeric_not_lexicographic(self) -> None:
+        """``v0.12.2`` is newer than ``v0.7.0``, whatever ``str`` thinks.
+
+        Sorting these two tags as text puts v0.12.2 *before* v0.7.0,
+        which is exactly the shape that hides a direction bug: the
+        comparison must go through ``_parse_version``.
+        """
+        assert CURRENT_TAG < COOLDOWN_TAG
+        assert _parse_version(CURRENT_TAG) > _parse_version(COOLDOWN_TAG)
+
+        ahead = classify_one(
+            make_pin(ref=CURRENT_SHA, version_comment=CURRENT_TAG),
+            latest=COOLDOWN_TARGET,
+        )
+        behind = classify_one(
+            make_pin(ref=COOLDOWN_SHA, version_comment=COOLDOWN_TAG),
+            latest=CURRENT_TARGET,
+        )
+
+        assert ahead is None
+        assert behind is not None
+        assert behind.kind is AllowListFindingKind.STALE
+
+    def test_a_target_without_a_commit_map_reports_staleness(self) -> None:
+        """A record carrying no map degrades to plain SHA comparison.
+
+        The resolver only omits the map when it restored the record from
+        the cache, which it refuses to do while a cooldown is active, so
+        the target really is the newest release in that case.
+        """
+        finding = classify_one(make_pin(ref=STALE_SHA), latest=LATEST)
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.STALE
+
+
+class TestCachedTargetDirection:
+    """A warm cache must not reintroduce the downgrade recommendation.
+
+    ``ValidationCache`` persists only ``(tag, sha)``, so a restored
+    target carries no commit map and cannot place a pinned commit. The
+    resolver therefore bypasses the cache entirely while a cooldown is
+    active, which is the only situation in which the target can be older
+    than something a pin already names.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_cooldown_run_ignores_a_cached_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cached v0.7.0 target is re-resolved, map and all."""
+        config = Config(
+            cooldown_days=7,
+            cache=CacheConfig(enabled=True, cache_dir=tmp_path),
+        )
+        cache = ValidationCache(config.cache)
+        cache.put_latest_version(HOST_REPO, COOLDOWN_TAG, COOLDOWN_SHA)
+        resolver = AllowListResolver(config, cache)
+        resolved: list[list[str]] = []
+
+        async def fake_uncached(
+            repo_keys: list[str],
+        ) -> dict[str, LatestRelease | None]:
+            """Answer with the same target, but carrying its commit map.
+
+            Args:
+                repo_keys: Keys the resolver could not answer locally.
+
+            Returns:
+                The cooldown-shifted target for every key.
+            """
+            resolved.append(repo_keys)
+            return dict.fromkeys(repo_keys, COOLDOWN_TARGET)
+
+        monkeypatch.setattr(resolver, "_resolve_uncached", fake_uncached)
+        hosts = await resolver.resolve([HOST_REPO])
+
+        pin = make_pin(ref=CURRENT_SHA, version_comment=CURRENT_TAG)
+        assert resolved == [[HOST_REPO]]
+        assert classify_pins([pin], hosts, verify=False) == []
+
+    @pytest.mark.asyncio
+    async def test_a_cache_hit_without_a_cooldown_is_still_free(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing is ahead of an unconstrained target, so the map is
+        unnecessary and the cache is used exactly as before.
+        """
+        config = Config(
+            cooldown_days=0,
+            cache=CacheConfig(enabled=True, cache_dir=tmp_path),
+        )
+        cache = ValidationCache(config.cache)
+        cache.put_latest_version(HOST_REPO, CURRENT_TAG, CURRENT_SHA)
+        resolver = AllowListResolver(config, cache)
+
+        async def explode(repo_keys: list[str]) -> dict[str, object]:
+            """Fail if the resolver reaches a backend at all.
+
+            Args:
+                repo_keys: Keys the resolver tried to resolve.
+
+            Raises:
+                AssertionError: Always.
+            """
+            raise AssertionError(f"unexpected resolution of {repo_keys}")
+
+        monkeypatch.setattr(resolver, "_resolve_uncached", explode)
+        hosts = await resolver.resolve([HOST_REPO])
+
+        pin = make_pin(ref=CURRENT_SHA, version_comment=CURRENT_TAG)
+        assert classify_pins([pin], hosts, verify=False) == []
+
+
+class TestOutOfScopeKinds:
+    """``INVALID_SPEC`` and ``UNRESOLVABLE`` are never manufactured."""
+
+    @pytest.mark.parametrize(
+        "ref",
+        [STALE_SHA, CURRENT_SHA, TAG_OBJECT_SHA, "main", "HEAD"],
+    )
+    def test_no_defect_kinds_are_invented(self, ref: str) -> None:
+        """Neither kind can be substantiated in this phase.
+
+        Proving a SHA absent from the host repository needs a lookup the
+        resolver does not perform, and the scanner never hands over a
+        scalar that failed the grammar.
+        """
+        finding = classify_one(make_pin(ref=ref, version_comment=None))
+
+        if finding is not None:
+            assert finding.kind not in {
+                AllowListFindingKind.UNRESOLVABLE,
+                AllowListFindingKind.INVALID_SPEC,
+            }
+
+
+class TestSeverity:
+    """Default severities, and promotion under enforcement."""
+
+    @pytest.mark.parametrize(
+        ("pin_kwargs", "kind", "severity"),
+        [
+            ({}, AllowListFindingKind.STALE, Severity.WARNING),
+            (
+                {"ref": CURRENT_SHA, "version_comment": STALE_TAG},
+                AllowListFindingKind.COMMENT_MISMATCH,
+                Severity.WARNING,
+            ),
+            (
+                {"ref": "main", "version_comment": None},
+                AllowListFindingKind.UNPINNED,
+                Severity.NOTICE,
+            ),
+        ],
+    )
+    def test_default_severities(
+        self,
+        pin_kwargs: dict[str, Any],
+        kind: AllowListFindingKind,
+        severity: Severity,
+    ) -> None:
+        """Without enforcement, nothing is an error."""
+        finding = classify_one(make_pin(**pin_kwargs))
+
+        assert finding is not None
+        assert finding.kind is kind
+        assert finding.severity is severity
+
+    @pytest.mark.parametrize(
+        "pin_kwargs",
+        [
+            {},
+            {"ref": CURRENT_SHA, "version_comment": STALE_TAG},
+            {"ref": "main", "version_comment": None},
+        ],
+    )
+    def test_verify_promotes_every_unsuppressed_finding(
+        self, pin_kwargs: dict[str, Any]
+    ) -> None:
+        """Under ``verify`` every unsuppressed finding is an error."""
+        finding = classify_one(make_pin(**pin_kwargs), verify=True)
+
+        assert finding is not None
+        assert finding.severity is Severity.ERROR
+
+    def test_verify_never_promotes_a_suppressed_finding(self) -> None:
+        """Enforcement must not defeat a suppression."""
+        finding = classify_one(
+            make_pin(directives=frozenset({ALLOW})), verify=True
+        )
+
+        assert finding is not None
+        assert finding.suppressed is True
+        assert finding.severity is Severity.WARNING
+
+
+class TestSuppressionMatrix:
+    """The applicability matrix of design section 7.4."""
+
+    def test_the_suppressible_set_is_exactly_stale_and_unpinned(self) -> None:
+        """The directive is a claim about currency, not correctness."""
+        suppressible = set(SUPPRESSIBLE_ALLOW_LIST_KINDS)
+        assert suppressible == {
+            AllowListFindingKind.STALE,
+            AllowListFindingKind.UNPINNED,
+        }
+
+    @pytest.mark.parametrize("kind", ALL_KINDS)
+    def test_suppressibility_matches_the_category(
+        self, kind: AllowListFindingKind
+    ) -> None:
+        """Only currency kinds may be silenced.
+
+        Asserted over every member of the enum, so a kind added later
+        cannot quietly become suppressible.
+        """
+        suppressible = kind in SUPPRESSIBLE_ALLOW_LIST_KINDS
+        assert suppressible is (allow_list_category(kind) is Category.CURRENCY)
+
+    def test_stale_is_suppressible(self) -> None:
+        """The exact condition the directive asserts."""
+        finding = classify_one(make_pin(directives=frozenset({ALLOW})))
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.STALE
+        assert finding.suppressed is True
+
+    def test_unpinned_is_suppressible(self) -> None:
+        """Tracking a branch can be a deliberate development choice."""
+        finding = classify_one(
+            make_pin(
+                ref="main",
+                version_comment=None,
+                directives=frozenset({ALLOW}),
+            )
+        )
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.UNPINNED
+        assert finding.suppressed is True
+
+    def test_comment_mismatch_is_not_suppressible(self) -> None:
+        """A comment that lies is a defect regardless of intent."""
+        finding = classify_one(
+            make_pin(
+                ref=CURRENT_SHA,
+                version_comment=STALE_TAG,
+                directives=frozenset({ALLOW}),
+            )
+        )
+
+        assert finding is not None
+        assert finding.kind is AllowListFindingKind.COMMENT_MISMATCH
+        assert finding.suppressed is False
+
+    def test_comment_mismatch_is_promoted_despite_the_directive(self) -> None:
+        """Enforcement still reaches a non-suppressible kind."""
+        finding = classify_one(
+            make_pin(
+                ref=CURRENT_SHA,
+                version_comment=STALE_TAG,
+                directives=frozenset({ALLOW}),
+            ),
+            verify=True,
+        )
+
+        assert finding is not None
+        assert finding.severity is Severity.ERROR
+
+    def test_suppressed_findings_are_still_produced(self) -> None:
+        """Suppression hides a finding from the exit code, not from view."""
+        pins = [
+            make_pin(directives=frozenset({ALLOW}), line_number=10),
+            make_pin(line_number=20),
+        ]
+        findings = classify_pins(pins, {HOST_REPO: LATEST}, verify=False)
+
+        assert [finding.suppressed for finding in findings] == [True, False]
+
+
+class TestResolutionFailure:
+    """Fail-soft behaviour of design section 6.4."""
+
+    def test_unresolved_host_produces_no_findings(self) -> None:
+        """Guessing under uncertainty is the one forbidden behaviour."""
+        assert classify_one(make_pin(), latest=None) is None
+
+    @pytest.mark.asyncio
+    async def test_check_records_the_reason(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unresolved host is recorded, not silently dropped."""
+        outcome = await run_check(
+            tmp_path, monkeypatch, hosts={HOST_REPO: None}
+        )
+
+        assert outcome.checked is True
+        assert outcome.findings == []
+        assert outcome.unresolved == {HOST_REPO: UNRESOLVED_REASON}
+        assert outcome.resolved is False
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_is_not_a_verdict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The outcome states the facts and decides nothing.
+
+        Under ``--verify-allow-list`` the caller maps this to exit code
+        ``4``; in default mode it is a notice. Both readings must be
+        available from the same outcome.
+        """
+        outcome = await run_check(
+            tmp_path,
+            monkeypatch,
+            hosts={HOST_REPO: None},
+            verify=True,
+        )
+
+        assert outcome.unresolved
+        assert outcome.unsuppressed == []
+
+
+class _RecordingResolver:
+    """Resolver double that records the keys it was asked for."""
+
+    calls: list[list[str]] = []
+    hosts: dict[str, LatestRelease | None] = {}
+
+    def __init__(self, config: Config, cache: ValidationCache) -> None:
+        """Accept the real resolver's constructor arguments.
+
+        Args:
+            config: Linter configuration.
+            cache: Validation cache.
+        """
+        self.config = config
+        self.cache = cache
+
+    async def resolve(
+        self, repo_keys: Iterable[str]
+    ) -> dict[str, LatestRelease | None]:
+        """Record the request and answer from the configured mapping.
+
+        Args:
+            repo_keys: Host repository keys the checker asked for.
+
+        Returns:
+            The configured latest release of each key.
+        """
+        keys = list(repo_keys)
+        type(self).calls.append(keys)
+        return {key: type(self).hosts.get(key) for key in keys}
+
+
+async def run_check(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    hosts: dict[str, LatestRelease | None] | None = None,
+    verify: bool = False,
+    files: Iterable[Path] | None = None,
+) -> AllowListOutcome:
+    """Run a check with the resolver replaced by a recording double.
+
+    Args:
+        root: Repository root handed to the checker.
+        monkeypatch: Fixture used to install the double.
+        hosts: Latest release of each host repository.
+        verify: Whether enforcement was requested.
+        files: Files to scan; the standard fixture when omitted.
+
+    Returns:
+        The check outcome.
+    """
+    _RecordingResolver.calls = []
+    _RecordingResolver.hosts = {HOST_REPO: LATEST} if hosts is None else hosts
+    monkeypatch.setattr(
+        allow_list_check, "AllowListResolver", _RecordingResolver
+    )
+    monkeypatch.delenv(ORG_ENV_VAR, raising=False)
+
+    config = Config()
+    config.allow_list.org = WORKFLOW_ORG
+    config.allow_list.verify = verify
+    cache = ValidationCache(CacheConfig(enabled=False, cache_dir=root))
+    checker = AllowListChecker(config, cache)
+
+    paths = [FIXTURES / "internal_step_config.yaml"] if files is None else files
+    return await checker.check(paths, root)
+
+
+class TestChecker:
+    """End-to-end behaviour of :class:`AllowListChecker`."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_check_reports_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A disabled check must not be mistaken for a clean one."""
+        _RecordingResolver.calls = []
+        monkeypatch.setattr(
+            allow_list_check, "AllowListResolver", _RecordingResolver
+        )
+        config = Config()
+        config.allow_list.enabled = False
+        cache = ValidationCache(CacheConfig(enabled=False, cache_dir=tmp_path))
+
+        outcome = await AllowListChecker(config, cache).check(
+            [FIXTURES / "internal_step_config.yaml"], tmp_path
+        )
+
+        assert outcome.checked is False
+        assert outcome.findings == []
+        assert _RecordingResolver.calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_pins_is_not_checked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A file holding no pin resolves nothing at all."""
+        outcome = await run_check(
+            tmp_path, monkeypatch, files=[FIXTURES / "no_pins.yaml"]
+        )
+
+        assert outcome.checked is False
+        assert _RecordingResolver.calls == []
+
+    @pytest.mark.asyncio
+    async def test_one_lookup_per_distinct_host(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Six pins sharing a host cost exactly one lookup.
+
+        The fixture carries six ``config:`` pins, every one of them
+        naming ``lfreleng-actions/.github`` through the shorthand form.
+        """
+        outcome = await run_check(
+            tmp_path, monkeypatch, files=[FIXTURES / "suppression.yaml"]
+        )
+
+        assert len(outcome.findings) == 6
+        assert _RecordingResolver.calls == [[HOST_REPO]]
+
+    @pytest.mark.asyncio
+    async def test_suppression_is_read_from_the_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both authoring forms of the directive reach the finding.
+
+        The fixture's six pins are, in order: preceding-line form,
+        inline form, both forms, an in-scalar inline form, a directive
+        separated by a blank line (which does not bind), and no
+        directive at all.
+        """
+        outcome = await run_check(
+            tmp_path, monkeypatch, files=[FIXTURES / "suppression.yaml"]
+        )
+
+        assert [f.suppressed for f in outcome.findings] == [
+            True,
+            True,
+            True,
+            True,
+            False,
+            False,
+        ]
+        assert outcome.suppressed_count == 4
+        assert len(outcome.unsuppressed) == 2
+
+    @pytest.mark.asyncio
+    async def test_suppression_reasons_survive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A suppression carries its own justification into the report."""
+        outcome = await run_check(
+            tmp_path, monkeypatch, files=[FIXTURES / "suppression.yaml"]
+        )
+
+        reasons = [f.pin.suppression_reason for f in outcome.findings[:3]]
+        assert reasons == [
+            "waiting for a release",
+            "upstream is broken",
+            "inline reason",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_findings_name_their_host_repository(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The shorthand form takes its host org from the workflow org."""
+        outcome = await run_check(tmp_path, monkeypatch)
+
+        assert [f.host_repo for f in outcome.findings] == [HOST_REPO]
+        assert HOST_REPO in outcome.hosts
+
+    @pytest.mark.asyncio
+    async def test_messages_name_the_host_and_the_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Messages are printable verbatim, with no further lookup."""
+        outcome = await run_check(tmp_path, monkeypatch)
+
+        message = outcome.findings[0].message
+        assert HOST_REPO in message
+        assert CURRENT_TAG in message
+
+
+class TestWorkflowOrgPrecedence:
+    """The precedence chain of design section 6.3."""
+
+    @staticmethod
+    def _git_repo(root: Path, remotes: dict[str, str]) -> None:
+        """Initialise a repository with the given remotes.
+
+        Args:
+            root: Directory to initialise.
+            remotes: Mapping of remote name to URL.
+        """
+        subprocess.run(
+            ["git", "-c", "init.defaultBranch=main", "init", "-q", str(root)],
+            check=True,
+            capture_output=True,
+        )
+        for name, url in remotes.items():
+            subprocess.run(
+                ["git", "-C", str(root), "remote", "add", name, url],
+                check=True,
+                capture_output=True,
+            )
+
+    def test_configuration_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit setting beats everything below it."""
+        monkeypatch.setenv(ORG_ENV_VAR, "env-org")
+        self._git_repo(tmp_path, {"upstream": "git@github.com:up-org/r.git"})
+
+        assert (
+            resolve_workflow_org(tmp_path, configured="  config-org  ")
+            == "config-org"
+        )
+
+    def test_environment_beats_the_remotes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``GITHUB_REPOSITORY_OWNER`` is authoritative inside Actions."""
+        monkeypatch.setenv(ORG_ENV_VAR, "env-org")
+        self._git_repo(tmp_path, {"upstream": "git@github.com:up-org/r.git"})
+
+        assert resolve_workflow_org(tmp_path) == "env-org"
+
+    def test_upstream_beats_origin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The load-bearing rule: contributors work from forks.
+
+        ``origin`` is the contributor's personal fork, whose owner has no
+        ``.github`` repository at all, so resolving to it would make
+        every shorthand pin unresolvable.
+        """
+        monkeypatch.delenv(ORG_ENV_VAR, raising=False)
+        self._git_repo(
+            tmp_path,
+            {
+                "origin": (
+                    "https://github.com/modeseven-lfreleng-actions/r.git"
+                ),
+                "upstream": "https://github.com/lfreleng-actions/r.git",
+            },
+        )
+
+        assert resolve_workflow_org(tmp_path) == "lfreleng-actions"
+
+    def test_origin_is_used_when_upstream_is_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A clone with no fork still resolves."""
+        monkeypatch.delenv(ORG_ENV_VAR, raising=False)
+        self._git_repo(
+            tmp_path,
+            {"origin": "https://github.com/lfreleng-actions/r.git"},
+        )
+
+        assert resolve_workflow_org(tmp_path) == "lfreleng-actions"
+
+    def test_unresolvable_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not a repository, no environment: no org, and no exception."""
+        monkeypatch.delenv(ORG_ENV_VAR, raising=False)
+
+        assert resolve_workflow_org(tmp_path) == ""
+
+    def test_empty_environment_value_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty variable is absent, not an answer."""
+        monkeypatch.setenv(ORG_ENV_VAR, "   ")
+        self._git_repo(
+            tmp_path,
+            {"origin": "https://github.com/lfreleng-actions/r.git"},
+        )
+
+        assert resolve_workflow_org(tmp_path) == "lfreleng-actions"
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://github.com/lfreleng-actions/r.git", "lfreleng-actions"),
+            ("https://github.com/lfreleng-actions/r", "lfreleng-actions"),
+            ("git@github.com:lfreleng-actions/r.git", "lfreleng-actions"),
+            (
+                "ssh://git@github.com/lfreleng-actions/r.git",
+                "lfreleng-actions",
+            ),
+            ("https://github.com/lfreleng-actions/r/", "lfreleng-actions"),
+            (
+                "https://token@github.com/lfreleng-actions/r",
+                "lfreleng-actions",
+            ),
+            ("git@github.com:lfreleng-actions/.github.git", "lfreleng-actions"),
+            ("not-a-url", ""),
+            ("", ""),
+            ("https://github.com/repo-only", ""),
+        ],
+    )
+    def test_remote_url_forms(self, url: str, expected: str) -> None:
+        """Every remote URL form in everyday use is understood."""
+        assert _owner_from_remote_url(url) == expected
+
+    def test_a_remote_url_form_survives_a_real_remote(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The parsing above is reached through a genuine Git remote."""
+        monkeypatch.delenv(ORG_ENV_VAR, raising=False)
+        self._git_repo(
+            tmp_path,
+            {"origin": "git@github.com:lfreleng-actions/.github.git"},
+        )
+
+        assert resolve_workflow_org(tmp_path) == "lfreleng-actions"
+
+    def test_a_missing_org_skips_shorthand_pins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unresolvable org is not an error; the pins are skipped.
+
+        The scanner cannot parse ``@<sha>`` without a host org, so it
+        drops the coordinate with a debug log, which is exactly the
+        documented fail-soft behaviour.
+        """
+        monkeypatch.delenv(ORG_ENV_VAR, raising=False)
+        scanner = AllowListScanner(Config(), "")
+        assert scanner.scan_file(FIXTURES / "internal_step_config.yaml") == []
+
+        with pytest.raises(SpecError):
+            resolve_spec(f"@{STALE_SHA}", workflow_org="")

--- a/tests/test_allow_list_check.py
+++ b/tests/test_allow_list_check.py
@@ -49,6 +49,7 @@ from gha_workflow_linter.allow_list_scanner import (
 from gha_workflow_linter.allow_list_spec import SpecError, resolve_spec
 from gha_workflow_linter.cache import ValidationCache
 from gha_workflow_linter.directives import Directive, SuppressionSource
+from gha_workflow_linter.exceptions import ConfigurationError
 from gha_workflow_linter.latest_release import LatestRelease
 from gha_workflow_linter.models import (
     SUPPRESSIBLE_ALLOW_LIST_KINDS,
@@ -1131,3 +1132,62 @@ def _no_release_resolver() -> Any:
         return dict.fromkeys(repo_keys)
 
     return _resolve
+
+
+class TestConfiguredOrgIsValidated:
+    """An invalid explicit org must not silently disable the check.
+
+    resolve_workflow_org returned `configured` verbatim, and
+    resolve_spec validates the workflow org, so a typo made EVERY spec
+    raise and be skipped -- including explicit-path specs that do not
+    need the org at all. --verify-allow-list then passed with zero
+    findings: the third instance of enforcement degrading to "pass".
+    """
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "lfreleng--actions",  # consecutive hyphens
+            "-leading-hyphen",
+            "trailing-hyphen-",
+            "not a valid org!",
+            "a" * 40,  # over the 39-character limit
+        ],
+    )
+    def test_invalid_configured_org_is_rejected(
+        self, tmp_path: Path, bad: str
+    ) -> None:
+        with pytest.raises(ConfigurationError, match="Invalid allow-list"):
+            resolve_workflow_org(tmp_path, configured=bad)
+
+    def test_error_names_the_offending_value(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="lfreleng--actions"):
+            resolve_workflow_org(tmp_path, configured="lfreleng--actions")
+
+    @pytest.mark.parametrize(
+        "good", ["lfreleng-actions", "onap", "a", "a" * 39, "org123"]
+    )
+    def test_valid_configured_org_passes_through(
+        self, tmp_path: Path, good: str
+    ) -> None:
+        assert resolve_workflow_org(tmp_path, configured=good) == good
+
+    def test_surrounding_whitespace_tolerated(self, tmp_path: Path) -> None:
+        assert (
+            resolve_workflow_org(tmp_path, configured="  lfreleng-actions  ")
+            == "lfreleng-actions"
+        )
+
+    def test_invalid_inferred_org_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An inferred value was never asked for, so it may be skipped.
+
+        This is the deliberate asymmetry: silently replacing an explicit
+        setting would check the wrong repository and report confidently
+        wrong results, but falling through an unusable inferred value is
+        exactly what the precedence chain is for.
+        """
+        monkeypatch.setenv(ORG_ENV_VAR, "not--valid")
+
+        assert resolve_workflow_org(tmp_path) == ""

--- a/tests/test_allow_list_check.py
+++ b/tests/test_allow_list_check.py
@@ -18,15 +18,18 @@ directive silences it.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 import subprocess
 from typing import TYPE_CHECKING, Any
+from unittest import mock
 
 import pytest
 
 from gha_workflow_linter import allow_list_check
 from gha_workflow_linter.allow_list_check import (
     ORG_ENV_VAR,
+    UNKNOWN_ORG_HOST,
     UNRESOLVED_REASON,
     AllowListChecker,
     AllowListFinding,
@@ -1037,3 +1040,94 @@ class TestWorkflowOrgPrecedence:
 
         with pytest.raises(SpecError):
             resolve_spec(f"@{STALE_SHA}", workflow_org="")
+
+
+class TestUnknownWorkflowOrg:
+    """An unknown org must not read as a clean result.
+
+    An empty workflow organisation makes every candidate in-repo path
+    unresolvable, so the scanner finds nothing at all. Returning an empty
+    outcome would let --verify-allow-list pass without having checked
+    anything, which is the failure mode the flag exists to prevent.
+    """
+
+    @staticmethod
+    def _workflow(tmp_path: Path) -> Path:
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        target = workflows / "ci.yaml"
+        target.write_text(
+            "---\n"
+            "name: T\n"
+            "on: [push]\n"
+            "jobs:\n"
+            "  b:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: lfreleng-actions/harden-runner-block-action@abc\n"
+            "        with:\n"
+            "          config: "
+            "'@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1\n"
+        )
+        return target
+
+    def _check(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> AllowListOutcome:
+        # No configured org, no environment, and a directory that is not a
+        # git repository, so every resolution route comes up empty.
+        monkeypatch.delenv("GITHUB_REPOSITORY_OWNER", raising=False)
+        target = self._workflow(tmp_path)
+        config = Config()
+        return asyncio.run(
+            AllowListChecker(config, ValidationCache(config.cache)).check(
+                [target], tmp_path
+            )
+        )
+
+    def test_reports_unresolved_rather_than_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        outcome = self._check(tmp_path, monkeypatch)
+
+        assert outcome.checked is True
+        assert outcome.unresolved
+        assert not outcome.resolved
+
+    def test_names_the_remedy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        outcome = self._check(tmp_path, monkeypatch)
+
+        assert "--allow-list-org" in "".join(outcome.unresolved.values())
+
+    def test_configured_org_resolves_normally(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With an org supplied, the pin is found and no sentinel appears."""
+        monkeypatch.delenv("GITHUB_REPOSITORY_OWNER", raising=False)
+        target = self._workflow(tmp_path)
+        config = Config()
+        config.allow_list.org = "lfreleng-actions"
+
+        with mock.patch.object(
+            AllowListResolver, "resolve", new=_no_release_resolver()
+        ):
+            outcome = asyncio.run(
+                AllowListChecker(config, ValidationCache(config.cache)).check(
+                    [target], tmp_path
+                )
+            )
+
+        assert UNKNOWN_ORG_HOST not in outcome.unresolved
+
+
+def _no_release_resolver() -> Any:
+    """Return a resolve() stub reporting no release for every host."""
+
+    async def _resolve(
+        _self: AllowListResolver, repo_keys: Any
+    ) -> dict[str, Any]:
+        return dict.fromkeys(repo_keys)
+
+    return _resolve

--- a/tests/test_allow_list_fix.py
+++ b/tests/test_allow_list_fix.py
@@ -1,0 +1,910 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for in-place remediation of stale allow-list pins.
+
+Every assertion here is made against ``read_bytes()`` on a real file
+written into ``tmp_path``, because the whole point of the fixer is what
+the *bytes* look like afterwards. A test that compared parsed fields
+would pass for a rewrite that silently reformatted a comment, moved it
+out of a scalar, or re-quoted a value -- the three failures the design
+of :mod:`gha_workflow_linter.allow_list_fix` exists to prevent.
+
+Pins come from the real scanner and findings from the real classifier
+wherever possible, so the columns, quoting and comment positions under
+test are the ones the pipeline actually produces. Hand-built pins appear
+only where a defect must be simulated that the scanner cannot emit.
+
+The SHAs are real: ``18d9c444`` is ``v0.1.1`` of
+``lfreleng-actions/.github``, the version most of the estate is pinned
+to, and ``bf6642f6`` is ``v0.12.2``, the peeled commit of its annotated
+tag.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from gha_workflow_linter import allow_list_fix, file_edit
+from gha_workflow_linter.allow_list_check import (
+    AllowListFinding,
+    classify_pins,
+)
+from gha_workflow_linter.allow_list_fix import (
+    REASON_COMMENT_CHANGED,
+    REASON_COMMENT_NOT_FOUND,
+    REASON_INVALID_REF,
+    REASON_MULTILINE,
+    REASON_NO_TARGET,
+    REASON_SPEC_NOT_FOUND,
+    REASON_SUPPRESSED,
+    DuplicateFixError,
+    apply_fixes,
+)
+from gha_workflow_linter.allow_list_scanner import (
+    AllowListPin,
+    AllowListScanner,
+    CommentPosition,
+    QuoteStyle,
+)
+from gha_workflow_linter.allow_list_spec import resolve_spec
+from gha_workflow_linter.directives import Directive, SuppressionSource
+from gha_workflow_linter.latest_release import LatestRelease
+from gha_workflow_linter.models import (
+    AllowListFindingKind,
+    Config,
+    Severity,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+WORKFLOW_ORG = "lfreleng-actions"
+HOST_REPO = f"{WORKFLOW_ORG}/.github"
+
+#: v0.1.1: what the estate is pinned to.
+STALE_SHA = "18d9c4446bea555d0783e850f6d295f844fe8f67"
+STALE_TAG = "v0.1.1"
+
+#: v0.12.2: the peeled commit of the current release's annotated tag.
+CURRENT_SHA = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+CURRENT_TAG = "v0.12.2"
+
+#: v0.5.1: a second stale release, for multi-pin files.
+OTHER_SHA = "8f4f0cf83e6a015957e83261ed379fd811fc060e"
+OTHER_TAG = "v0.5.1"
+
+#: The action each fixture step calls. Never an allow-list candidate;
+#: it is here so the fixtures are shaped like real workflows.
+USES_SHA = "6db537b3e6d060c3287c5a3ce2c28b55b0af330d"
+
+#: The explicit-path form of a coordinate, written out in full.
+EXPLICIT = (
+    "lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt"
+)
+
+TARGET = LatestRelease(tag=CURRENT_TAG, commit_sha=CURRENT_SHA)
+
+ALLOW = Directive.ALLOW_LIST_PIN_OK
+
+HEADER = "\n".join(
+    [
+        "---",
+        "name: Fixture",
+        "",
+        "on:",
+        "  workflow_dispatch:",
+        "",
+        "jobs:",
+        "  build:",
+        "    runs-on: ubuntu-24.04",
+        "    steps:",
+        "",
+    ]
+)
+
+STEP = f"      - uses: lfreleng-actions/harden-runner-block-action@{USES_SHA}\n        with:\n"
+
+
+def build_source(*steps: str) -> str:
+    """Assemble a workflow whose steps carry the given source blocks.
+
+    Args:
+        steps: One block per step, each holding the step's ``config``
+            line and any comment line above it, without a trailing
+            newline.
+
+    Returns:
+        The complete file content, ending in a single newline.
+    """
+    return HEADER + "".join(f"{STEP}{step}\n" for step in steps)
+
+
+def write_workflow(
+    tmp_path: Path,
+    *steps: str,
+    name: str = "workflow.yaml",
+    newline: str = "\n",
+    final_newline: bool = True,
+) -> Path:
+    """Write a workflow fixture with byte-exact content.
+
+    Args:
+        tmp_path: Directory to write into.
+        steps: One source block per step.
+        name: Filename to write.
+        newline: Line terminator to use throughout.
+        final_newline: Whether the file ends with a terminator.
+
+    Returns:
+        The path written.
+    """
+    text = build_source(*steps)
+    if not final_newline:
+        text = text[:-1]
+    path = tmp_path / name
+    path.write_bytes(text.replace("\n", newline).encode())
+    return path
+
+
+def findings_for(
+    path: Path, latest: LatestRelease = TARGET
+) -> list[AllowListFinding]:
+    """Scan and classify one file, exactly as the pipeline does.
+
+    Args:
+        path: File to scan.
+        latest: Target release of the host repository.
+
+    Returns:
+        The findings, in scan order.
+    """
+    scanner = AllowListScanner(Config(), WORKFLOW_ORG)
+    pins = scanner.scan_file(path)
+    return classify_pins(pins, {HOST_REPO: latest}, verify=False)
+
+
+def fix_file(path: Path) -> allow_list_fix.FixOutcome:
+    """Scan, classify and remediate one file.
+
+    Args:
+        path: File to remediate.
+
+    Returns:
+        The outcome of the remediation pass.
+    """
+    return apply_fixes(findings_for(path))
+
+
+def config_line(
+    value: str,
+    *,
+    quote: str = "'",
+    spacing: str = "  ",
+    comment: str | None = STALE_TAG,
+    indent: str = "          ",
+) -> str:
+    """Compose one ``config:`` source line.
+
+    Args:
+        value: The scalar's content, without quotes.
+        quote: Quote character, or ``""`` for a plain scalar.
+        spacing: Whitespace between the scalar and the ``#``.
+        comment: Comment body, or ``None`` for no comment.
+        indent: Leading whitespace.
+
+    Returns:
+        The line, without a terminator.
+    """
+    line = f"{indent}config: {quote}{value}{quote}"
+    if comment is not None:
+        line = f"{line}{spacing}# {comment}"
+    return line
+
+
+def make_pin(
+    *,
+    raw_line: str,
+    raw_value: str,
+    file_path: Path,
+    line_number: int = 12,
+    column: int = 18,
+    quote_style: QuoteStyle = QuoteStyle.SINGLE,
+    version_comment: str | None = STALE_TAG,
+    comment_position: CommentPosition = CommentPosition.YAML,
+    directives: frozenset[Directive] = frozenset(),
+    auto_fixable: bool = True,
+) -> AllowListPin:
+    """Build a pin directly, bypassing the scanner.
+
+    Used only for defects the scanner cannot produce, such as a line
+    that no longer holds the value recorded against it.
+
+    Args:
+        raw_line: The source line the pin claims.
+        raw_value: The scalar, comment removed.
+        file_path: File the pin sits in.
+        line_number: 1-based source line.
+        column: 0-based column of the scalar's first character.
+        quote_style: Quoting of the scalar.
+        version_comment: Version token of the trailing comment.
+        comment_position: Which position carries the comment.
+        directives: Suppression directives in force.
+        auto_fixable: ``False`` for a multi-line scalar.
+
+    Returns:
+        The pin.
+    """
+    return AllowListPin(
+        file_path=file_path,
+        line_number=line_number,
+        column=column,
+        key_path=("jobs", "build", "steps", "0", "with", "config"),
+        raw_line=raw_line,
+        raw_value=raw_value,
+        quote_style=quote_style,
+        version_comment=version_comment,
+        comment_position=comment_position,
+        directives=directives,
+        suppressed_by=(
+            SuppressionSource.INLINE_COMMENT if directives else None
+        ),
+        suppression_reason=None,
+        spec=resolve_spec(raw_value.strip(), workflow_org=WORKFLOW_ORG),
+        auto_fixable=auto_fixable,
+    )
+
+
+def make_finding(
+    pin: AllowListPin,
+    *,
+    kind: AllowListFindingKind = AllowListFindingKind.STALE,
+    target_sha: str | None = CURRENT_SHA,
+    target_version: str | None = CURRENT_TAG,
+    suppressed: bool = False,
+) -> AllowListFinding:
+    """Build a finding directly, bypassing the classifier.
+
+    Args:
+        pin: The pin the finding concerns.
+        kind: What is wrong with it.
+        target_sha: Commit the pin should name.
+        target_version: Release tag that commit belongs to.
+        suppressed: Whether a directive applies.
+
+    Returns:
+        The finding.
+    """
+    return AllowListFinding(
+        pin=pin,
+        kind=kind,
+        severity=Severity.WARNING,
+        message="synthetic finding",
+        current_sha=pin.spec.ref,
+        target_sha=target_sha,
+        target_version=target_version,
+        suppressed=suppressed,
+    )
+
+
+def reasons(outcome: allow_list_fix.FixOutcome) -> list[str]:
+    """Return just the skip reasons from an outcome.
+
+    Args:
+        outcome: The outcome to summarise.
+
+    Returns:
+        One reason per skipped finding, in order.
+    """
+    return [reason for _finding, reason in outcome.skipped]
+
+
+def lines_of(path: Path) -> list[str]:
+    """Return a file's lines, terminators removed.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The lines, without terminators.
+    """
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+class TestSpecForms:
+    """Both coordinate forms move their ref and nothing else."""
+
+    def test_shorthand_form(self, tmp_path: Path) -> None:
+        """``'@<sha>'`` keeps its shorthand and gains the new SHA."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+
+        outcome = fix_file(path)
+
+        assert len(outcome.applied) == 1
+        assert (
+            path.read_bytes()
+            == build_source(
+                config_line(f"@{CURRENT_SHA}", comment=CURRENT_TAG)
+            ).encode()
+        )
+
+    def test_explicit_path_form(self, tmp_path: Path) -> None:
+        """A full coordinate keeps every part before the ``@``."""
+        path = write_workflow(tmp_path, config_line(f"{EXPLICIT}@{STALE_SHA}"))
+
+        fix_file(path)
+
+        assert (
+            path.read_bytes()
+            == build_source(
+                config_line(f"{EXPLICIT}@{CURRENT_SHA}", comment=CURRENT_TAG)
+            ).encode()
+        )
+
+    def test_only_the_ref_and_version_change(self, tmp_path: Path) -> None:
+        """The two rewritten tokens are the only difference."""
+        before = config_line(f"{EXPLICIT}@{STALE_SHA}")
+        path = write_workflow(tmp_path, before)
+
+        fix_file(path)
+
+        after = lines_of(path)[-1]
+        assert (
+            after.replace(CURRENT_SHA, STALE_SHA).replace(
+                CURRENT_TAG, STALE_TAG
+            )
+            == before
+        )
+
+
+class TestQuoteStyles:
+    """The author's quoting is never rewritten."""
+
+    def test_single_quotes_survive(self, tmp_path: Path) -> None:
+        """A single-quoted scalar stays single quoted."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == config_line(
+            f"@{CURRENT_SHA}", comment=CURRENT_TAG
+        )
+
+    def test_double_quotes_survive(self, tmp_path: Path) -> None:
+        """A double-quoted scalar stays double quoted."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}", quote='"'))
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == config_line(
+            f"@{CURRENT_SHA}", quote='"', comment=CURRENT_TAG
+        )
+
+    def test_plain_scalar_is_not_quoted(self, tmp_path: Path) -> None:
+        """An unquoted scalar does not acquire quotes."""
+        path = write_workflow(
+            tmp_path, config_line(f"{EXPLICIT}@{STALE_SHA}", quote="")
+        )
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == config_line(
+            f"{EXPLICIT}@{CURRENT_SHA}", quote="", comment=CURRENT_TAG
+        )
+
+
+class TestCommentSpacing:
+    """Whatever separates the value from the ``#`` is left alone."""
+
+    @pytest.mark.parametrize("spacing", [" ", "  ", "   "])
+    def test_spacing_before_the_hash_survives(
+        self, tmp_path: Path, spacing: str
+    ) -> None:
+        """One, two and three spaces all round-trip."""
+        path = write_workflow(
+            tmp_path, config_line(f"@{STALE_SHA}", spacing=spacing)
+        )
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == config_line(
+            f"@{CURRENT_SHA}", spacing=spacing, comment=CURRENT_TAG
+        )
+
+    def test_spacing_after_the_hash_survives(self, tmp_path: Path) -> None:
+        """Padding between the ``#`` and the version is not squeezed."""
+        line = f"          config: '@{STALE_SHA}'  #   {STALE_TAG}"
+        path = write_workflow(tmp_path, line)
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == (
+            f"          config: '@{CURRENT_SHA}'  #   {CURRENT_TAG}"
+        )
+
+
+class TestCommentPositions:
+    """Each position is rewritten where it sits, never moved."""
+
+    def test_yaml_comment_stays_outside_the_quotes(
+        self, tmp_path: Path
+    ) -> None:
+        """A comment after the closing quote stays after it."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+
+        fix_file(path)
+
+        assert lines_of(path)[-1].endswith(f"'  # {CURRENT_TAG}")
+
+    def test_in_scalar_comment_stays_inside_the_quotes(
+        self, tmp_path: Path
+    ) -> None:
+        """A comment inside the scalar is rewritten in place."""
+        line = f'          config: "@{STALE_SHA} # {STALE_TAG}"'
+        path = write_workflow(tmp_path, line)
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == (
+            f'          config: "@{CURRENT_SHA} # {CURRENT_TAG}"'
+        )
+
+    def test_in_scalar_comment_wins_over_a_yaml_one(
+        self, tmp_path: Path
+    ) -> None:
+        """With both present, only the one the action sees is rewritten."""
+        line = f"          config: '@{STALE_SHA} # {STALE_TAG}'  # {OTHER_TAG}"
+        path = write_workflow(tmp_path, line)
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == (
+            f"          config: '@{CURRENT_SHA} # {CURRENT_TAG}'  # {OTHER_TAG}"
+        )
+
+    def test_missing_comment_is_added(self, tmp_path: Path) -> None:
+        """A pin with no comment gains one, two spaces out."""
+        path = write_workflow(
+            tmp_path, config_line(f"@{STALE_SHA}", comment=None)
+        )
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == (
+            f"          config: '@{CURRENT_SHA}'  # {CURRENT_TAG}"
+        )
+
+    def test_added_comment_keeps_trailing_whitespace(
+        self, tmp_path: Path
+    ) -> None:
+        """Trailing whitespace is not consumed by the new comment."""
+        line = f"          config: '@{STALE_SHA}'   "
+        path = write_workflow(tmp_path, line)
+
+        fix_file(path)
+
+        assert lines_of(path)[-1] == (
+            f"          config: '@{CURRENT_SHA}'     # {CURRENT_TAG}"
+        )
+
+
+class TestDirectivesSurvive:
+    """A repair never discards authored suppression content."""
+
+    def test_directive_and_reason_are_kept(self, tmp_path: Path) -> None:
+        """Only the version token changes; the tail carries through.
+
+        The finding is a ``COMMENT_MISMATCH``, which
+        ``allow-list-pin-ok`` does not suppress, so the directive is
+        present on a pin that is nonetheless rewritten -- exactly the
+        case in which losing it would silently re-enable churn.
+        """
+        comment = f"{STALE_TAG} allow-list-pin-ok -- upstream is broken"
+        path = write_workflow(
+            tmp_path, config_line(f"@{CURRENT_SHA}", comment=comment)
+        )
+
+        outcome = fix_file(path)
+
+        assert [finding.kind for finding in _findings(outcome)] == [
+            AllowListFindingKind.COMMENT_MISMATCH
+        ]
+        assert (
+            path.read_bytes()
+            == build_source(
+                config_line(
+                    f"@{CURRENT_SHA}",
+                    comment=(
+                        f"{CURRENT_TAG} allow-list-pin-ok -- upstream is broken"
+                    ),
+                )
+            ).encode()
+        )
+
+    def test_unrecognised_tokens_are_kept(self, tmp_path: Path) -> None:
+        """A token the parser does not know is not thrown away."""
+        path = write_workflow(
+            tmp_path,
+            config_line(f"@{STALE_SHA}", comment=f"{STALE_TAG} (pinned)"),
+        )
+
+        fix_file(path)
+
+        assert lines_of(path)[-1].endswith(f"# {CURRENT_TAG} (pinned)")
+
+
+class TestSuppression:
+    """A suppressed pin is never written at all."""
+
+    def test_suppressed_pin_leaves_the_file_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """Neither the bytes nor the modification time change."""
+        comment = f"{STALE_TAG} allow-list-pin-ok -- deliberate"
+        path = write_workflow(
+            tmp_path, config_line(f"@{STALE_SHA}", comment=comment)
+        )
+        before = path.read_bytes()
+        mtime = path.stat().st_mtime_ns
+
+        outcome = fix_file(path)
+
+        assert outcome.applied == []
+        assert reasons(outcome) == [REASON_SUPPRESSED]
+        assert path.read_bytes() == before
+        assert path.stat().st_mtime_ns == mtime
+
+    def test_suppression_is_checked_before_anything_else(
+        self, tmp_path: Path
+    ) -> None:
+        """A suppressed finding is skipped for that reason, not another."""
+        pin = make_pin(
+            raw_line="nothing like the value",
+            raw_value=f"@{STALE_SHA}",
+            file_path=tmp_path / "absent.yaml",
+            directives=frozenset({ALLOW}),
+            auto_fixable=False,
+        )
+
+        outcome = apply_fixes([make_finding(pin, suppressed=True)])
+
+        assert reasons(outcome) == [REASON_SUPPRESSED]
+
+
+class TestSkipped:
+    """Everything the fixer declines, and why."""
+
+    def test_multiline_scalar_is_skipped(self, tmp_path: Path) -> None:
+        """A block scalar is reported but never rewritten."""
+        block = f"          config: >-\n            {EXPLICIT}@{STALE_SHA}"
+        path = write_workflow(tmp_path, block)
+        before = path.read_bytes()
+
+        outcome = fix_file(path)
+
+        assert reasons(outcome) == [REASON_MULTILINE]
+        assert path.read_bytes() == before
+
+    def test_finding_without_a_target_is_skipped(self, tmp_path: Path) -> None:
+        """There is nothing to write, so nothing is written."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+        before = path.read_bytes()
+        pin = make_pin(
+            raw_line=config_line(f"@{STALE_SHA}"),
+            raw_value=f"@{STALE_SHA}",
+            file_path=path,
+        )
+
+        outcome = apply_fixes([make_finding(pin, target_sha=None)])
+
+        assert reasons(outcome) == [REASON_NO_TARGET]
+        assert path.read_bytes() == before
+
+    def test_absent_spec_is_skipped(self, tmp_path: Path) -> None:
+        """A line that no longer holds the value is left alone."""
+        pin = make_pin(
+            raw_line="          config: something else entirely",
+            raw_value=f"@{STALE_SHA}",
+            file_path=tmp_path / "workflow.yaml",
+        )
+
+        outcome = apply_fixes([make_finding(pin)])
+
+        assert reasons(outcome) == [REASON_SPEC_NOT_FOUND]
+
+    def test_spec_before_the_column_is_not_matched(
+        self, tmp_path: Path
+    ) -> None:
+        """The search starts at the scalar, so an earlier copy is ignored."""
+        pin = make_pin(
+            raw_line=f"          # was @{STALE_SHA}",
+            raw_value=f"@{STALE_SHA}",
+            file_path=tmp_path / "workflow.yaml",
+            column=40,
+        )
+
+        outcome = apply_fixes([make_finding(pin)])
+
+        assert reasons(outcome) == [REASON_SPEC_NOT_FOUND]
+
+    def test_invalid_target_ref_is_skipped(self, tmp_path: Path) -> None:
+        """A target that is not a usable ref is refused, not written."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+        before = path.read_bytes()
+        pin = make_pin(
+            raw_line=config_line(f"@{STALE_SHA}"),
+            raw_value=f"@{STALE_SHA}",
+            file_path=path,
+        )
+
+        outcome = apply_fixes([make_finding(pin, target_sha="not a ref!")])
+
+        assert reasons(outcome) == [REASON_INVALID_REF]
+        assert path.read_bytes() == before
+
+    def test_absent_comment_is_skipped(self, tmp_path: Path) -> None:
+        """A pin claiming a comment its line lacks is left alone."""
+        pin = make_pin(
+            raw_line=config_line(f"@{STALE_SHA}", comment=None),
+            raw_value=f"@{STALE_SHA}",
+            file_path=tmp_path / "workflow.yaml",
+        )
+
+        outcome = apply_fixes([make_finding(pin)])
+
+        assert reasons(outcome) == [REASON_COMMENT_NOT_FOUND]
+
+    def test_unfindable_closing_quote_is_skipped(self, tmp_path: Path) -> None:
+        """An in-scalar comment with no closing quote is not guessed at."""
+        pin = make_pin(
+            raw_line=f"          config: @{STALE_SHA} # {STALE_TAG}",
+            raw_value=f"@{STALE_SHA}",
+            file_path=tmp_path / "workflow.yaml",
+            column=18,
+            quote_style=QuoteStyle.NONE,
+            comment_position=CommentPosition.IN_SCALAR,
+        )
+
+        outcome = apply_fixes([make_finding(pin)])
+
+        assert reasons(outcome) == [REASON_COMMENT_NOT_FOUND]
+
+    def test_changed_comment_is_skipped(self, tmp_path: Path) -> None:
+        """A comment that says something else is not overwritten."""
+        pin = make_pin(
+            raw_line=config_line(f"@{STALE_SHA}"),
+            raw_value=f"@{STALE_SHA}",
+            file_path=tmp_path / "workflow.yaml",
+            version_comment="v9.9.9",
+        )
+
+        outcome = apply_fixes([make_finding(pin)])
+
+        assert reasons(outcome) == [REASON_COMMENT_CHANGED]
+
+    def test_target_without_a_version_leaves_the_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """The ref moves; an unnameable version does not blank the comment."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+        pin = make_pin(
+            raw_line=config_line(f"@{STALE_SHA}"),
+            raw_value=f"@{STALE_SHA}",
+            file_path=path,
+            line_number=len(lines_of(path)),
+        )
+
+        outcome = apply_fixes([make_finding(pin, target_version=None)])
+
+        assert len(outcome.applied) == 1
+        assert lines_of(path)[-1] == config_line(f"@{CURRENT_SHA}")
+
+
+class TestWholeFiles:
+    """Everything outside the two rewritten tokens survives."""
+
+    def test_several_pins_are_fixed_in_one_pass(self, tmp_path: Path) -> None:
+        """Three shapes in one file, all correct afterwards."""
+        path = write_workflow(
+            tmp_path,
+            config_line(f"@{STALE_SHA}"),
+            config_line(f"{EXPLICIT}@{OTHER_SHA}", quote='"', spacing="   "),
+            config_line(f"@{OTHER_SHA}", comment=None),
+        )
+
+        outcome = fix_file(path)
+
+        assert len(outcome.applied) == 3
+        assert (
+            path.read_bytes()
+            == build_source(
+                config_line(f"@{CURRENT_SHA}", comment=CURRENT_TAG),
+                config_line(
+                    f"{EXPLICIT}@{CURRENT_SHA}",
+                    quote='"',
+                    spacing="   ",
+                    comment=CURRENT_TAG,
+                ),
+                config_line(f"@{CURRENT_SHA}", comment=CURRENT_TAG),
+            ).encode()
+        )
+
+    def test_one_write_per_file(self, tmp_path: Path) -> None:
+        """Every pin in a file funnels into a single atomic write."""
+        path = write_workflow(
+            tmp_path,
+            config_line(f"@{STALE_SHA}"),
+            config_line(f"@{OTHER_SHA}", comment=OTHER_TAG),
+            config_line(f"@{STALE_SHA}"),
+        )
+        real = file_edit.replace_lines
+
+        with mock.patch.object(
+            allow_list_fix, "replace_lines", wraps=real
+        ) as writer:
+            outcome = apply_fixes(findings_for(path))
+
+        assert len(outcome.applied) == 3
+        assert writer.call_count == 1
+
+    def test_unusual_indentation_survives(self, tmp_path: Path) -> None:
+        """Indentation is untargeted text and is preserved exactly."""
+        path = write_workflow(
+            tmp_path,
+            config_line(f"@{STALE_SHA}", indent="              "),
+        )
+
+        fix_file(path)
+
+        assert lines_of(path)[-1].startswith("              config:")
+
+    def test_untouched_lines_are_byte_identical(self, tmp_path: Path) -> None:
+        """No line other than the pin's differs."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+        before = lines_of(path)
+
+        fix_file(path)
+
+        after = lines_of(path)
+        assert before[:-1] == after[:-1]
+        assert before[-1] != after[-1]
+
+    def test_two_files_are_each_rewritten(self, tmp_path: Path) -> None:
+        """Findings are grouped by file, not merged across them."""
+        first = write_workflow(
+            tmp_path, config_line(f"@{STALE_SHA}"), name="first.yaml"
+        )
+        second = write_workflow(
+            tmp_path, config_line(f"@{OTHER_SHA}"), name="second.yaml"
+        )
+
+        outcome = apply_fixes(findings_for(first) + findings_for(second))
+
+        assert len(outcome.applied) == 2
+        expected = build_source(
+            config_line(f"@{CURRENT_SHA}", comment=CURRENT_TAG)
+        ).encode()
+        assert first.read_bytes() == expected
+        assert second.read_bytes() == expected
+
+
+class TestLineEndings:
+    """The writer's guarantees, exercised through the fixer."""
+
+    def test_crlf_file_stays_crlf(self, tmp_path: Path) -> None:
+        """No line gains or loses a carriage return."""
+        path = write_workflow(
+            tmp_path, config_line(f"@{STALE_SHA}"), newline="\r\n"
+        )
+
+        fix_file(path)
+
+        expected = build_source(
+            config_line(f"@{CURRENT_SHA}", comment=CURRENT_TAG)
+        ).replace("\n", "\r\n")
+        assert path.read_bytes() == expected.encode()
+
+    def test_file_without_a_final_newline_does_not_gain_one(
+        self, tmp_path: Path
+    ) -> None:
+        """The pin is the last line, and it stays unterminated."""
+        path = write_workflow(
+            tmp_path, config_line(f"@{STALE_SHA}"), final_newline=False
+        )
+
+        fix_file(path)
+
+        expected = build_source(
+            config_line(f"@{CURRENT_SHA}", comment=CURRENT_TAG)
+        )[:-1]
+        assert path.read_bytes() == expected.encode()
+
+
+class TestDuplicateLines:
+    """Two edits for one line is a bug, and must be loud."""
+
+    def test_two_findings_on_one_line_raise(self, tmp_path: Path) -> None:
+        """The collision is refused rather than silently resolved."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+        findings = findings_for(path)
+
+        with pytest.raises(DuplicateFixError) as raised:
+            apply_fixes(findings + findings)
+
+        assert raised.value.file_path == path
+        assert raised.value.line_number == findings[0].pin.line_number
+
+    def test_nothing_is_written_when_a_collision_is_found(
+        self, tmp_path: Path
+    ) -> None:
+        """Planning completes before any file is opened."""
+        first = write_workflow(
+            tmp_path, config_line(f"@{STALE_SHA}"), name="first.yaml"
+        )
+        second = write_workflow(
+            tmp_path, config_line(f"@{OTHER_SHA}"), name="second.yaml"
+        )
+        before = first.read_bytes()
+        clash = findings_for(second)
+
+        with pytest.raises(DuplicateFixError):
+            apply_fixes(findings_for(first) + clash + clash)
+
+        assert first.read_bytes() == before
+
+
+class TestOutcome:
+    """What the caller gets back."""
+
+    def test_applied_reports_both_sides_of_the_edit(
+        self, tmp_path: Path
+    ) -> None:
+        """``old_line`` is what was on disk, ``new_line`` what replaced it."""
+        path = write_workflow(tmp_path, config_line(f"@{STALE_SHA}"))
+        findings = findings_for(path)
+
+        outcome = apply_fixes(findings)
+
+        applied = outcome.applied[0]
+        assert applied.finding is findings[0]
+        assert applied.line_number == findings[0].pin.line_number
+        assert applied.old_line == config_line(f"@{STALE_SHA}")
+        assert applied.new_line == config_line(
+            f"@{CURRENT_SHA}", comment=CURRENT_TAG
+        )
+
+    def test_order_follows_the_findings(self, tmp_path: Path) -> None:
+        """Applied and skipped both keep the caller's order."""
+        path = write_workflow(
+            tmp_path,
+            config_line(f"@{STALE_SHA}"),
+            f"          config: >-\n            {EXPLICIT}@{STALE_SHA}",
+            config_line(f"@{OTHER_SHA}", comment=OTHER_TAG),
+        )
+
+        outcome = fix_file(path)
+
+        assert [fix.line_number for fix in outcome.applied] == [13, 20]
+        assert reasons(outcome) == [REASON_MULTILINE]
+
+    def test_no_findings_is_a_no_op(self) -> None:
+        """An empty run touches nothing and reports nothing."""
+        outcome = apply_fixes([])
+
+        assert outcome.applied == []
+        assert outcome.skipped == []
+
+
+def _findings(outcome: allow_list_fix.FixOutcome) -> list[AllowListFinding]:
+    """Return the findings behind an outcome's applied fixes.
+
+    Args:
+        outcome: The outcome to summarise.
+
+    Returns:
+        One finding per applied fix, in order.
+    """
+    return [fix.finding for fix in outcome.applied]

--- a/tests/test_allow_list_report.py
+++ b/tests/test_allow_list_report.py
@@ -1,0 +1,682 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the two allow-list renderers.
+
+Text and JSON answer to different audiences, and the standing risk is
+that they drift: a suppressed pin that vanishes from the terminal must
+still appear in the JSON, and a deduplicated text block must not lose a
+line number. Both properties are asserted here.
+
+The shared console is replaced with one writing to a buffer at a fixed
+width, so the assertions are about what the renderer emits rather than
+about how a terminal happened to wrap it.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from gha_workflow_linter import allow_list_report
+from gha_workflow_linter.allow_list_check import (
+    AllowListFinding,
+    AllowListOutcome,
+    classify_pins,
+)
+from gha_workflow_linter.allow_list_report import build_json, render_text
+from gha_workflow_linter.allow_list_scanner import (
+    AllowListPin,
+    CommentPosition,
+    QuoteStyle,
+)
+from gha_workflow_linter.allow_list_spec import resolve_spec
+from gha_workflow_linter.directives import Directive, SuppressionSource
+from gha_workflow_linter.latest_release import LatestRelease
+
+WORKFLOW_ORG = "lfreleng-actions"
+HOST_REPO = f"{WORKFLOW_ORG}/.github"
+
+STALE_SHA = "18d9c4446bea555d0783e850f6d295f844fe8f67"
+STALE_TAG = "v0.1.1"
+CURRENT_SHA = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+CURRENT_TAG = "v0.12.2"
+
+LATEST = LatestRelease(tag=CURRENT_TAG, commit_sha=CURRENT_SHA)
+ALLOW = Directive.ALLOW_LIST_PIN_OK
+
+ROOT = Path("/repo")
+WORKFLOW = ROOT / ".github" / "workflows" / "zizmor-sarif-publish.yaml"
+OTHER = ROOT / ".github" / "workflows" / "other.yaml"
+
+
+@pytest.fixture
+def buffer(monkeypatch: pytest.MonkeyPatch) -> io.StringIO:
+    """Replace the shared console with a wide, buffered one.
+
+    Args:
+        monkeypatch: Fixture used to install the replacement.
+
+    Returns:
+        The buffer the renderer writes to.
+    """
+    stream = io.StringIO()
+    monkeypatch.setattr(
+        allow_list_report,
+        "console",
+        Console(file=stream, width=200, force_terminal=False, no_color=True),
+    )
+    return stream
+
+
+def make_pin(
+    *,
+    ref: str = STALE_SHA,
+    version_comment: str | None = STALE_TAG,
+    line_number: int = 116,
+    file_path: Path = WORKFLOW,
+    directives: frozenset[Directive] = frozenset(),
+    reason: str | None = None,
+    quote_style: QuoteStyle = QuoteStyle.SINGLE,
+) -> AllowListPin:
+    """Build a pin without going through the scanner.
+
+    Args:
+        ref: The ref the pin names.
+        version_comment: Version token of the trailing comment.
+        line_number: 1-based source line.
+        file_path: File the pin sits in.
+        directives: Suppression directives in force.
+        reason: Free text the suppression carried.
+        quote_style: Quoting the scalar was written with.
+
+    Returns:
+        The pin.
+    """
+    return AllowListPin(
+        file_path=file_path,
+        line_number=line_number,
+        column=10,
+        key_path=("jobs", "publish", "steps", "0", "with", "config"),
+        raw_line=f"          config: '@{ref}'  # {version_comment}",
+        raw_value=f"@{ref}",
+        quote_style=quote_style,
+        version_comment=version_comment,
+        comment_position=CommentPosition.YAML,
+        directives=directives,
+        suppressed_by=(
+            SuppressionSource.INLINE_COMMENT if directives else None
+        ),
+        suppression_reason=reason,
+        spec=resolve_spec(f"@{ref}", workflow_org=WORKFLOW_ORG),
+        auto_fixable=True,
+    )
+
+
+def make_outcome(
+    pins: list[AllowListPin],
+    *,
+    verify: bool = False,
+    hosts: dict[str, LatestRelease | None] | None = None,
+    unresolved: dict[str, str] | None = None,
+    checked: bool = True,
+) -> AllowListOutcome:
+    """Classify pins and wrap the findings in an outcome.
+
+    Args:
+        pins: The pins to classify.
+        verify: Whether enforcement was requested.
+        hosts: Latest release of each host repository.
+        unresolved: Hosts that could not be resolved, with reasons.
+        checked: Whether the check ran at all.
+
+    Returns:
+        The outcome.
+    """
+    resolved: dict[str, LatestRelease | None] = (
+        {HOST_REPO: LATEST} if hosts is None else hosts
+    )
+    findings = classify_pins(pins, resolved, verify=verify)
+    return AllowListOutcome(
+        findings=findings,
+        hosts=resolved,
+        unresolved={} if unresolved is None else unresolved,
+        suppressed_count=sum(1 for f in findings if f.suppressed),
+        checked=checked,
+    )
+
+
+def allow_list(outcome: AllowListOutcome) -> dict[str, Any]:
+    """Return the ``allow_list`` object of the JSON report.
+
+    Args:
+        outcome: The outcome to render.
+
+    Returns:
+        The single object the document carries.
+    """
+    document = build_json(outcome, root=ROOT)
+    assert set(document) == {"allow_list"}
+    section: dict[str, Any] = document["allow_list"]
+    return section
+
+
+class TestTextDeduplication:
+    """One block per ``(kind, current_sha, target_sha)`` per file."""
+
+    def test_identical_pins_collapse_to_one_block(
+        self, buffer: io.StringIO
+    ) -> None:
+        """Fifteen identical pins must read as one paragraph."""
+        pins = [make_pin(line_number=100 + n) for n in range(15)]
+        render_text(
+            make_outcome(pins),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert text.count("→") == 1
+        assert text.count("18d9c444…") == 1
+
+    def test_every_line_number_is_listed(self, buffer: io.StringIO) -> None:
+        """Deduplication removes repetition, never information."""
+        pins = [make_pin(line_number=n) for n in (349, 116, 292)]
+        render_text(
+            make_outcome(pins),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert "lines 116, 292, 349" in buffer.getvalue()
+
+    def test_a_single_pin_uses_the_singular_label(
+        self, buffer: io.StringIO
+    ) -> None:
+        """The design's own example is a single line."""
+        render_text(
+            make_outcome([make_pin(line_number=116)]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert "line 116   config: '@18d9c444…'  # v0.1.1" in text
+        assert "→ '@bf6642f6…'  # v0.12.2   (lfreleng-actions/.github)" in text
+
+    def test_files_are_reported_separately(self, buffer: io.StringIO) -> None:
+        """Deduplication is per file, not across the repository."""
+        pins = [
+            make_pin(line_number=116, file_path=WORKFLOW),
+            make_pin(line_number=116, file_path=OTHER),
+        ]
+        render_text(
+            make_outcome(pins),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert ".github/workflows/zizmor-sarif-publish.yaml" in text
+        assert ".github/workflows/other.yaml" in text
+        assert text.count("→") == 2
+
+    def test_distinct_targets_do_not_merge(self, buffer: io.StringIO) -> None:
+        """Two different current SHAs are two different problems."""
+        pins = [
+            make_pin(line_number=116),
+            make_pin(
+                line_number=200,
+                ref="8f4f0cf83e6a015957e83261ed379fd811fc060e",
+                version_comment="v0.5.1",
+            ),
+        ]
+        render_text(
+            make_outcome(pins),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert buffer.getvalue().count("→") == 2
+
+    def test_paths_are_relative_to_the_root(self, buffer: io.StringIO) -> None:
+        """Absolute paths in a report are noise."""
+        render_text(
+            make_outcome([make_pin()]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert "  .github/workflows/zizmor-sarif-publish.yaml" in text
+        assert "/repo/.github" not in text
+
+
+class TestTextSections:
+    """Each kind gets its own heading."""
+
+    def test_stale_heading(self, buffer: io.StringIO) -> None:
+        """The heading of the design's example report."""
+        render_text(
+            make_outcome([make_pin()]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert "Stale allow-list pins" in buffer.getvalue()
+
+    def test_comment_mismatch_has_its_own_section(
+        self, buffer: io.StringIO
+    ) -> None:
+        """A lying comment is not a footnote to staleness."""
+        pins = [
+            make_pin(),
+            make_pin(
+                line_number=200, ref=CURRENT_SHA, version_comment=STALE_TAG
+            ),
+        ]
+        render_text(
+            make_outcome(pins),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert "incorrect version comments" in text
+        assert "Stale allow-list pins" in text
+
+    def test_unpinned_shows_the_ref_it_names(self, buffer: io.StringIO) -> None:
+        """There is no SHA to abbreviate, so the ref is shown instead."""
+        render_text(
+            make_outcome([make_pin(ref="main", version_comment=None)]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert "config: '@main'" in text
+        assert "not pinned to a commit SHA" in text
+
+    def test_quoting_style_is_preserved(self, buffer: io.StringIO) -> None:
+        """An unquoted scalar is rendered unquoted."""
+        render_text(
+            make_outcome([make_pin(quote_style=QuoteStyle.NONE)]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert "config: @18d9c444…" in buffer.getvalue()
+
+    def test_nothing_is_printed_when_the_check_did_not_run(
+        self, buffer: io.StringIO
+    ) -> None:
+        """Silence, not a misleading all-clear."""
+        render_text(
+            make_outcome([], checked=False),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=True,
+        )
+
+        assert buffer.getvalue() == ""
+
+    def test_nothing_is_printed_when_everything_is_current(
+        self, buffer: io.StringIO
+    ) -> None:
+        """A clean run stays quiet, as the rest of the linter does."""
+        render_text(
+            make_outcome(
+                [make_pin(ref=CURRENT_SHA, version_comment=CURRENT_TAG)]
+            ),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=True,
+        )
+
+        assert buffer.getvalue() == ""
+
+
+class TestUpdateHint:
+    """The ``--update-allow-list`` advertisement."""
+
+    def test_hint_is_printed_when_repairable_findings_remain(
+        self, buffer: io.StringIO
+    ) -> None:
+        """The reader is told what to do next."""
+        render_text(
+            make_outcome([make_pin()]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=True,
+        )
+
+        assert "--update-allow-list" in buffer.getvalue()
+
+    def test_hint_is_withheld_on_request(self, buffer: io.StringIO) -> None:
+        """A caller that has already run the fixer suppresses it."""
+        render_text(
+            make_outcome([make_pin()]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert "--update-allow-list" not in buffer.getvalue()
+
+    def test_hint_is_withheld_when_only_suppressed_pins_remain(
+        self, buffer: io.StringIO
+    ) -> None:
+        """A suppressed pin is invisible to remediation, so say nothing."""
+        render_text(
+            make_outcome([make_pin(directives=frozenset({ALLOW}))]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=True,
+        )
+
+        assert "--update-allow-list" not in buffer.getvalue()
+
+
+class TestSuppressionVisibility:
+    """Suppressions must not become invisible forever."""
+
+    def test_suppressed_pins_are_not_listed_by_default(
+        self, buffer: io.StringIO
+    ) -> None:
+        """The default report shows what needs action."""
+        render_text(
+            make_outcome([make_pin(directives=frozenset({ALLOW}))]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert "Stale allow-list pins" not in text
+        assert "18d9c444…" not in text
+
+    def test_the_summary_line_is_always_emitted(
+        self, buffer: io.StringIO
+    ) -> None:
+        """The exact wording of design section 7.4."""
+        pins = [
+            make_pin(line_number=10, directives=frozenset({ALLOW})),
+            make_pin(line_number=20, directives=frozenset({ALLOW})),
+            make_pin(
+                line_number=30,
+                file_path=OTHER,
+                directives=frozenset({ALLOW}),
+            ),
+        ]
+        render_text(
+            make_outcome(pins),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert (
+            "3 allow-list pins suppressed (2 files) — use "
+            "--show-suppressed for detail" in buffer.getvalue()
+        )
+
+    def test_the_summary_line_is_singular_for_one_pin(
+        self, buffer: io.StringIO
+    ) -> None:
+        """Counting is not an excuse for bad English."""
+        render_text(
+            make_outcome([make_pin(directives=frozenset({ALLOW}))]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert "1 allow-list pin suppressed (1 file)" in buffer.getvalue()
+
+    def test_no_summary_when_nothing_is_suppressed(
+        self, buffer: io.StringIO
+    ) -> None:
+        """A quiet mechanism when it is not in use."""
+        render_text(
+            make_outcome([make_pin()]),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+
+        assert "suppressed" not in buffer.getvalue()
+
+    def test_show_suppressed_lists_them_with_reasons(
+        self, buffer: io.StringIO
+    ) -> None:
+        """A suppression carries its own justification."""
+        render_text(
+            make_outcome(
+                [
+                    make_pin(
+                        directives=frozenset({ALLOW}),
+                        reason="blocked on ONAP mirror rollout",
+                    )
+                ]
+            ),
+            root=ROOT,
+            show_suppressed=True,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert "Suppressed allow-list pins" in text
+        assert "suppressed: blocked on ONAP mirror rollout" in text
+        assert "--show-suppressed for detail" not in text
+
+    def test_show_suppressed_reports_a_missing_reason(
+        self, buffer: io.StringIO
+    ) -> None:
+        """A directive without a reason is still auditable."""
+        render_text(
+            make_outcome([make_pin(directives=frozenset({ALLOW}))]),
+            root=ROOT,
+            show_suppressed=True,
+            update_hint=False,
+        )
+
+        assert "suppressed: no reason given" in buffer.getvalue()
+
+
+class TestUnresolvedRendering:
+    """Resolution failure is reported, never silently swallowed."""
+
+    def test_the_reason_is_printed(self, buffer: io.StringIO) -> None:
+        """ "Could not check" must never read as "nothing to report"."""
+        render_text(
+            make_outcome(
+                [],
+                hosts={HOST_REPO: None},
+                unresolved={HOST_REPO: "rate limited"},
+            ),
+            root=ROOT,
+            show_suppressed=False,
+            update_hint=False,
+        )
+        text = buffer.getvalue()
+
+        assert f"Allow-list check skipped for {HOST_REPO}" in text
+        assert "rate limited" in text
+
+
+class TestJsonShape:
+    """The document of design section 9.4, exactly."""
+
+    def test_top_level_keys(self) -> None:
+        """The object carries exactly the documented keys."""
+        payload = allow_list(make_outcome([make_pin()]))
+
+        assert list(payload) == [
+            "checked",
+            "resolved",
+            "hosts",
+            "unresolved",
+            "findings",
+            "summary",
+        ]
+
+    def test_host_entry_shape(self) -> None:
+        """Each resolved host names its version and its commit."""
+        payload = allow_list(make_outcome([make_pin()]))
+
+        assert payload["hosts"] == {
+            HOST_REPO: {
+                "latest_version": CURRENT_TAG,
+                "latest_sha": CURRENT_SHA,
+            }
+        }
+
+    def test_finding_entry_shape(self) -> None:
+        """Every documented field, with the documented values."""
+        payload = allow_list(make_outcome([make_pin()]))
+
+        assert payload["findings"] == [
+            {
+                "file": ".github/workflows/zizmor-sarif-publish.yaml",
+                "line": 116,
+                "kind": "stale",
+                "severity": "warning",
+                "current_sha": STALE_SHA,
+                "current_version": STALE_TAG,
+                "target_sha": CURRENT_SHA,
+                "target_version": CURRENT_TAG,
+                "suppressed": False,
+                "fixed": False,
+            }
+        ]
+
+    def test_summary_shape(self) -> None:
+        """The buckets are present, in order, even when zero."""
+        pins = [make_pin(line_number=n) for n in (116, 292, 349)]
+        payload = allow_list(make_outcome(pins))
+
+        assert payload["summary"] == {
+            "stale": 3,
+            "comment_mismatch": 0,
+            "unpinned": 0,
+            "suppressed": 0,
+            "fixed": 0,
+        }
+        assert list(payload["summary"]) == [
+            "stale",
+            "comment_mismatch",
+            "unpinned",
+            "suppressed",
+            "fixed",
+        ]
+
+    def test_severity_reflects_enforcement(self) -> None:
+        """Promotion under ``verify`` reaches the JSON."""
+        payload = allow_list(make_outcome([make_pin()], verify=True))
+
+        assert payload["findings"][0]["severity"] == "error"
+
+    def test_unpinned_findings_carry_no_current_sha(self) -> None:
+        """``null`` is the honest answer when the pin names no commit."""
+        payload = allow_list(
+            make_outcome([make_pin(ref="main", version_comment=None)])
+        )
+        finding = payload["findings"][0]
+
+        assert finding["kind"] == "unpinned"
+        assert finding["current_sha"] is None
+        assert finding["current_version"] is None
+
+    def test_checked_is_false_when_the_check_did_not_run(self) -> None:
+        """An empty findings list is not a clean bill of health."""
+        payload = allow_list(make_outcome([], checked=False))
+
+        assert payload["checked"] is False
+        assert payload["findings"] == []
+
+    def test_unresolved_hosts_are_named_with_their_reason(self) -> None:
+        """``resolved`` alone does not say which host failed."""
+        payload = allow_list(
+            make_outcome(
+                [make_pin()],
+                hosts={HOST_REPO: None},
+                unresolved={HOST_REPO: "rate limited"},
+            )
+        )
+
+        assert payload["resolved"] is False
+        assert payload["hosts"] == {}
+        assert payload["unresolved"] == {HOST_REPO: "rate limited"}
+        assert payload["findings"] == []
+
+
+class TestJsonSuppression:
+    """Suppressed findings are hidden from the exit code, not the JSON."""
+
+    def test_suppressed_findings_are_always_present(self) -> None:
+        """Machine consumers see the full picture without a flag."""
+        payload = allow_list(
+            make_outcome(
+                [make_pin(directives=frozenset({ALLOW}), reason="deliberate")]
+            )
+        )
+
+        assert len(payload["findings"]) == 1
+        assert payload["findings"][0]["suppressed"] is True
+
+    def test_suppressed_findings_are_not_counted_as_failures(self) -> None:
+        """The kind buckets count what actually needs action."""
+        pins = [
+            make_pin(line_number=10, directives=frozenset({ALLOW})),
+            make_pin(line_number=20),
+        ]
+        payload = allow_list(make_outcome(pins))
+
+        assert payload["summary"]["stale"] == 1
+        assert payload["summary"]["suppressed"] == 1
+        assert len(payload["findings"]) == 2
+
+    def test_suppressed_findings_keep_their_default_severity(self) -> None:
+        """Enforcement must not defeat a suppression, even in JSON."""
+        payload = allow_list(
+            make_outcome([make_pin(directives=frozenset({ALLOW}))], verify=True)
+        )
+
+        assert payload["findings"][0]["severity"] == "warning"
+
+    def test_a_wholly_suppressed_run_reports_no_failures(self) -> None:
+        """Design section 9.3: all stale pins suppressed means exit 0."""
+        outcome = make_outcome(
+            [make_pin(directives=frozenset({ALLOW}))], verify=True
+        )
+        payload = allow_list(outcome)
+
+        assert outcome.unsuppressed == []
+        assert payload["summary"]["stale"] == 0
+        assert payload["summary"]["suppressed"] == 1
+
+
+class TestFindingHelpers:
+    """Small conveniences the CLI leans on."""
+
+    def test_findings_report_their_host_repository(self) -> None:
+        """The report prints the host beside every target."""
+        findings: list[AllowListFinding] = classify_pins(
+            [make_pin()], {HOST_REPO: LATEST}, verify=False
+        )
+
+        assert findings[0].host_repo == HOST_REPO

--- a/tests/test_allow_list_resolver.py
+++ b/tests/test_allow_list_resolver.py
@@ -1,0 +1,1122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for latest-release resolution behind allow-list pins.
+
+A harden-runner allow-list pin carries the **commit** SHA of a host
+repository, not the SHA of the annotated tag object that names it. The
+whole feature turns on that distinction: comparing a pin against the
+tag-object SHA would report every correctly-pinned reference as stale.
+The first tests here therefore pin the peel, using the real SHAs from
+``lfreleng-actions/.github`` at ``v0.12.2``.
+
+Mocking happens at the transport boundaries -- an ``httpx`` mock
+transport for the API backend and ``subprocess.run`` for the Git backend
+-- so the real query text, the real response parsing and the real error
+classification are all exercised, in the style of
+``tests/test_annotated_tag_reporting.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+import re
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+from gha_workflow_linter.allow_list_resolver import AllowListResolver
+from gha_workflow_linter.cache import ValidationCache
+from gha_workflow_linter.latest_release import (
+    LatestRelease,
+    ReleaseCandidate,
+    ReleasePolicy,
+    build_latest_releases_query,
+    select_latest_release,
+)
+from gha_workflow_linter.models import (
+    CacheConfig,
+    Config,
+    GitHubAPIConfig,
+    ValidationMethod,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Fixture data: real values from lfreleng-actions/.github and actions/checkout
+# ---------------------------------------------------------------------------
+
+ORGANIZATION = "lfreleng-actions"
+HOST_REPO = f"{ORGANIZATION}/.github"
+
+# v0.12.2 is an annotated tag: the ref names a tag object, whose target is
+# the commit an allow-list pin actually carries.
+TAG_NAME = "v0.12.2"
+TAG_OBJECT_SHA = "8f363565e79650362c3359ee23b6d6fd295866ee"
+PEELED_COMMIT_SHA = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+
+PREVIOUS_TAG = "v0.12.1"
+PREVIOUS_TAG_OBJECT_SHA = "9ed1afae6b1fbe656074fafc4ff80e6af41e140a"
+PREVIOUS_COMMIT_SHA = "60d8d71016f31c26775e5ec9380eba4264aa6f9e"
+
+# v0.7.0: far enough back to be outside any plausible cooldown window,
+# and the release a seven-day cooldown actually falls back to while the
+# whole v0.12.x series is still warming.
+COOLDOWN_TAG = "v0.7.0"
+COOLDOWN_TAG_OBJECT_SHA = "76aa85c978113dd3d8501ac95b613a54a54e5597"
+COOLDOWN_COMMIT_SHA = "d46590dd8f51bdd71494eb9d2afa3bade1457a62"
+
+# actions/checkout uses lightweight tags: the ref names the commit itself.
+LIGHTWEIGHT_REPO = "actions/checkout"
+LIGHTWEIGHT_TAG = "v7.0.1"
+LIGHTWEIGHT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+MISSING_REPO = f"{ORGANIZATION}/definitely-does-not-exist"
+
+BRANCH_COMMIT_SHA = "0000111122223333444455556666777788889999"
+
+LS_REMOTE_OUTPUT = (
+    f"{BRANCH_COMMIT_SHA}\trefs/heads/main\n"
+    f"{TAG_OBJECT_SHA}\trefs/tags/{TAG_NAME}\n"
+    f"{PEELED_COMMIT_SHA}\trefs/tags/{TAG_NAME}^{{}}\n"
+    f"{PREVIOUS_TAG_OBJECT_SHA}\trefs/tags/{PREVIOUS_TAG}\n"
+    f"{PREVIOUS_COMMIT_SHA}\trefs/tags/{PREVIOUS_TAG}^{{}}\n"
+)
+
+LS_REMOTE_LIGHTWEIGHT_OUTPUT = (
+    f"{LIGHTWEIGHT_SHA}\trefs/tags/{LIGHTWEIGHT_TAG}\n"
+    f"{LIGHTWEIGHT_SHA}\trefs/tags/v7\n"
+)
+
+_RATE_LIMIT_BODY: dict[str, Any] = {
+    "resources": {
+        "graphql": {"limit": 5000, "remaining": 5000, "reset": 0, "used": 0}
+    }
+}
+
+_REPO_ALIAS_RE = re.compile(
+    r'(repo_\d+): repository\(owner: "([^"]+)", name: "([^"]+)"\)'
+)
+
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+
+def _iso_days_ago(days: int) -> str:
+    """Render an ISO-8601 UTC timestamp a number of days in the past.
+
+    Args:
+        days: How many days ago the timestamp should be.
+
+    Returns:
+        A ``YYYY-MM-DDTHH:MM:SSZ`` string, as GitHub returns.
+    """
+    moment = datetime.now(timezone.utc) - timedelta(days=days)
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _annotated_ref(name: str, tag_object: str, commit: str) -> dict[str, Any]:
+    """Build the GraphQL ref node GitHub returns for an annotated tag.
+
+    Args:
+        name: Tag name.
+        tag_object: SHA of the tag object the ref names.
+        commit: SHA of the commit the tag object targets.
+
+    Returns:
+        A ``refs.nodes`` entry with a nested, peelable target.
+    """
+    return {
+        "name": name,
+        "target": {"oid": tag_object, "target": {"oid": commit}},
+    }
+
+
+def _lightweight_ref(name: str, commit: str) -> dict[str, Any]:
+    """Build the GraphQL ref node GitHub returns for a lightweight tag.
+
+    Args:
+        name: Tag name.
+        commit: SHA of the commit the ref names directly.
+
+    Returns:
+        A ``refs.nodes`` entry with a flat target.
+    """
+    return {"name": name, "target": {"oid": commit}}
+
+
+def _release(
+    tag: str,
+    published_at: str | None = None,
+    *,
+    is_draft: bool = False,
+    is_prerelease: bool = False,
+) -> dict[str, Any]:
+    """Build a GraphQL release node.
+
+    Args:
+        tag: Release tag name.
+        published_at: ISO-8601 publication timestamp, or None.
+        is_draft: Whether GitHub marks the release as a draft.
+        is_prerelease: Whether GitHub marks the release as a prerelease.
+
+    Returns:
+        A release payload shaped like GitHub's.
+    """
+    return {
+        "tagName": tag,
+        "publishedAt": published_at,
+        "isDraft": is_draft,
+        "isPrerelease": is_prerelease,
+    }
+
+
+def _repo_payload(
+    refs: list[dict[str, Any]],
+    releases: list[dict[str, Any]],
+    latest: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Assemble one repository's slice of a GraphQL response.
+
+    Args:
+        refs: Tag ref nodes.
+        releases: Release nodes, newest first.
+        latest: The ``latestRelease`` payload, or None.
+
+    Returns:
+        The per-repository response fragment.
+    """
+    return {
+        "latestRelease": latest,
+        "releases": {"nodes": releases},
+        "refs": {"nodes": refs},
+    }
+
+
+_HOST_REFS = [
+    _annotated_ref(TAG_NAME, TAG_OBJECT_SHA, PEELED_COMMIT_SHA),
+    _annotated_ref(PREVIOUS_TAG, PREVIOUS_TAG_OBJECT_SHA, PREVIOUS_COMMIT_SHA),
+]
+
+
+def _host_payload(
+    latest_published: str | None = None,
+    previous_published: str | None = None,
+) -> dict[str, Any]:
+    """Build the standard two-release payload for the host repository.
+
+    Args:
+        latest_published: Publication timestamp for ``v0.12.2``.
+        previous_published: Publication timestamp for ``v0.12.1``.
+
+    Returns:
+        The per-repository response fragment for ``<org>/.github``.
+    """
+    latest = _release(TAG_NAME, latest_published)
+    return _repo_payload(
+        refs=_HOST_REFS,
+        releases=[latest, _release(PREVIOUS_TAG, previous_published)],
+        latest=latest,
+    )
+
+
+_LIGHTWEIGHT_PAYLOAD = _repo_payload(
+    refs=[
+        _lightweight_ref(LIGHTWEIGHT_TAG, LIGHTWEIGHT_SHA),
+        _lightweight_ref("v7", LIGHTWEIGHT_SHA),
+    ],
+    releases=[_release(LIGHTWEIGHT_TAG)],
+    latest=_release(LIGHTWEIGHT_TAG),
+)
+
+
+def _three_release_payload() -> dict[str, Any]:
+    """Build the payload behind the live cooldown defect.
+
+    Reproduces ``lfreleng-actions/.github`` as it stood on 2026-08-04:
+    the v0.12.x series published within the last week, and v0.7.0 the
+    newest release old enough to clear a seven-day cooldown.
+
+    Returns:
+        The per-repository response fragment.
+    """
+    latest = _release(TAG_NAME, _iso_days_ago(6))
+    return _repo_payload(
+        refs=[
+            *_HOST_REFS,
+            _annotated_ref(
+                COOLDOWN_TAG, COOLDOWN_TAG_OBJECT_SHA, COOLDOWN_COMMIT_SHA
+            ),
+        ],
+        releases=[
+            latest,
+            _release(PREVIOUS_TAG, _iso_days_ago(5)),
+            _release(COOLDOWN_TAG, _iso_days_ago(11)),
+        ],
+        latest=latest,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transport doubles
+# ---------------------------------------------------------------------------
+
+
+def _graphql_body(
+    query: str, repos: Mapping[str, dict[str, Any] | None]
+) -> dict[str, Any]:
+    """Answer a batched release query from a repository fixture map.
+
+    Repositories absent from ``repos`` are reported the way GitHub does:
+    a null alias plus a NOT_FOUND error alongside the data.
+
+    Args:
+        query: The generated GraphQL document.
+        repos: Mapping of ``owner/repo`` to its response fragment.
+
+    Returns:
+        A response body shaped like GitHub's.
+    """
+    data: dict[str, Any] = {}
+    errors: list[dict[str, Any]] = []
+
+    for alias, owner, name in _REPO_ALIAS_RE.findall(query):
+        repo_key = f"{owner}/{name}"
+        payload = repos.get(repo_key)
+        data[alias] = payload
+        if payload is None:
+            errors.append(
+                {
+                    "type": "NOT_FOUND",
+                    "message": (
+                        "Could not resolve to a Repository with the name "
+                        f"'{repo_key}'."
+                    ),
+                }
+            )
+
+    body: dict[str, Any] = {"data": data}
+    if errors:
+        body["errors"] = errors
+
+    return body
+
+
+def _graphql_responder(
+    repos: Mapping[str, dict[str, Any] | None], queries: list[str]
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Build a mock transport handler serving the fixture repositories.
+
+    Args:
+        repos: Mapping of ``owner/repo`` to its response fragment.
+        queries: List every GraphQL document is appended to, so tests can
+            assert how many requests a resolution actually cost.
+
+    Returns:
+        A handler suitable for ``httpx.MockTransport``.
+    """
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/rate_limit"):
+            return httpx.Response(200, json=_RATE_LIMIT_BODY)
+        query = str(json.loads(request.content.decode())["query"])
+        queries.append(query)
+        return httpx.Response(200, json=_graphql_body(query, repos))
+
+    return respond
+
+
+def _install_http(
+    monkeypatch: pytest.MonkeyPatch,
+    responder: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    """Route every ``httpx.AsyncClient`` through a mock transport.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        responder: Handler answering each request.
+    """
+    original = httpx.AsyncClient
+
+    def factory(**kwargs: Any) -> httpx.AsyncClient:
+        return original(transport=httpx.MockTransport(responder), **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+class FakeCompleted:
+    """Minimal stand-in for ``subprocess.CompletedProcess``."""
+
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+        self.returncode = 0
+        self.stderr = ""
+
+
+def _install_ls_remote(
+    monkeypatch: pytest.MonkeyPatch,
+    outputs: Mapping[str, str],
+    calls: list[str],
+) -> None:
+    """Stub ``subprocess.run`` with canned ``git ls-remote`` output.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        outputs: Mapping of repository key to raw ls-remote stdout. A key
+            that is absent makes the fake ``git`` fail, as it does for a
+            repository that does not exist.
+        calls: List every invoked URL is appended to, so tests can assert
+            how many remote reads a resolution actually cost.
+    """
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> FakeCompleted:
+        url = cmd[-1]
+        calls.append(url)
+        for repo_key, stdout in outputs.items():
+            if url.endswith(f"/{repo_key}.git"):
+                return FakeCompleted(stdout)
+        raise subprocess.CalledProcessError(128, cmd, stderr="not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+# ---------------------------------------------------------------------------
+# Resolver construction
+# ---------------------------------------------------------------------------
+
+
+def _config(
+    method: ValidationMethod,
+    cache_dir: Path | None = None,
+    **overrides: Any,
+) -> Config:
+    """Build a configuration for the requested backend.
+
+    Args:
+        method: Validation method the resolver should use.
+        cache_dir: Directory for an enabled cache, or None to disable it.
+        **overrides: Additional ``Config`` field values.
+
+    Returns:
+        A configuration carrying a dummy token, so token discovery never
+        shells out to the GitHub CLI during a test.
+    """
+    cache = (
+        CacheConfig(enabled=True, cache_dir=cache_dir)
+        if cache_dir is not None
+        else CacheConfig(enabled=False)
+    )
+    return Config(
+        validation_method=method,
+        cache=cache,
+        github_api=GitHubAPIConfig(token="test-token"),
+        **overrides,
+    )
+
+
+def _resolver(config: Config) -> AllowListResolver:
+    """Build a resolver over a fresh cache for the given configuration.
+
+    Args:
+        config: The configuration to resolve with.
+
+    Returns:
+        An ``AllowListResolver``.
+    """
+    return AllowListResolver(config, ValidationCache(config.cache))
+
+
+def _api_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    repos: Mapping[str, dict[str, Any] | None],
+    queries: list[str] | None = None,
+    cache_dir: Path | None = None,
+    **overrides: Any,
+) -> AllowListResolver:
+    """Build an API-backed resolver wired to fixture repositories.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        repos: Mapping of ``owner/repo`` to its response fragment.
+        queries: Optional list collecting the issued GraphQL documents.
+        cache_dir: Directory for an enabled cache, or None to disable it.
+        **overrides: Additional ``Config`` field values.
+
+    Returns:
+        A resolver whose HTTP traffic is served from ``repos``.
+    """
+    _install_http(
+        monkeypatch,
+        _graphql_responder(repos, queries if queries is not None else []),
+    )
+    return _resolver(
+        _config(ValidationMethod.GITHUB_API, cache_dir, **overrides)
+    )
+
+
+def _git_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    outputs: Mapping[str, str],
+    calls: list[str] | None = None,
+    cache_dir: Path | None = None,
+    **overrides: Any,
+) -> AllowListResolver:
+    """Build a Git-backed resolver wired to canned ls-remote output.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        outputs: Mapping of repository key to raw ls-remote stdout.
+        calls: Optional list collecting the invoked remote URLs.
+        cache_dir: Directory for an enabled cache, or None to disable it.
+        **overrides: Additional ``Config`` field values.
+
+    Returns:
+        A resolver whose remote reads are served from ``outputs``.
+    """
+    _install_ls_remote(monkeypatch, outputs, calls if calls is not None else [])
+    return _resolver(_config(ValidationMethod.GIT, cache_dir, **overrides))
+
+
+# ---------------------------------------------------------------------------
+# The core correctness property: annotated tags peel to the commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_backend_peels_annotated_tag_to_the_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The API backend reports the commit, never the tag object."""
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: _host_payload()})
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release == LatestRelease(tag=TAG_NAME, commit_sha=PEELED_COMMIT_SHA)
+    assert release is not None
+    assert release.commit_sha != TAG_OBJECT_SHA
+
+
+@pytest.mark.asyncio
+async def test_git_backend_peels_annotated_tag_to_the_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Git backend reports the commit, never the tag object."""
+    resolver = _git_resolver(monkeypatch, {HOST_REPO: LS_REMOTE_OUTPUT})
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release == LatestRelease(tag=TAG_NAME, commit_sha=PEELED_COMMIT_SHA)
+    assert release is not None
+    assert release.commit_sha != TAG_OBJECT_SHA
+
+
+@pytest.mark.asyncio
+async def test_backends_agree_on_the_shared_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both backends resolve the same fixture to the same tag and commit."""
+    api = _api_resolver(monkeypatch, {HOST_REPO: _host_payload()})
+    via_api = (await api.resolve([HOST_REPO]))[HOST_REPO]
+
+    monkeypatch.undo()
+    git = _git_resolver(monkeypatch, {HOST_REPO: LS_REMOTE_OUTPUT})
+    via_git = (await git.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert via_api is not None
+    assert via_git is not None
+    assert (via_api.tag, via_api.commit_sha) == (
+        via_git.tag,
+        via_git.commit_sha,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lightweight_tag_resolves_to_its_single_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lightweight tag has one SHA, and both backends return it."""
+    api = _api_resolver(monkeypatch, {LIGHTWEIGHT_REPO: _LIGHTWEIGHT_PAYLOAD})
+    via_api = (await api.resolve([LIGHTWEIGHT_REPO]))[LIGHTWEIGHT_REPO]
+
+    monkeypatch.undo()
+    git = _git_resolver(
+        monkeypatch, {LIGHTWEIGHT_REPO: LS_REMOTE_LIGHTWEIGHT_OUTPUT}
+    )
+    via_git = (await git.resolve([LIGHTWEIGHT_REPO]))[LIGHTWEIGHT_REPO]
+
+    expected = LatestRelease(tag=LIGHTWEIGHT_TAG, commit_sha=LIGHTWEIGHT_SHA)
+    assert via_api == expected
+    assert via_git == expected
+
+
+def test_query_never_selects_tag_name_on_a_tag_object() -> None:
+    """``tagName`` exists on ``Release`` only; ``Tag`` exposes ``name``.
+
+    Selecting ``tagName`` inside a ``... on Tag`` fragment makes the whole
+    query fail at run time, and a mocked response would not notice. Guard
+    the generated document instead.
+    """
+    query, aliases = build_latest_releases_query([HOST_REPO])
+
+    assert aliases == {"repo_0": HOST_REPO}
+    assert "... on Tag { target { oid } }" in query
+    assert "on Tag { tagName" not in query
+    assert "latestRelease { tagName" in query
+
+
+def test_query_skips_repository_keys_that_cannot_name_a_repository() -> None:
+    """Unusable keys are dropped rather than interpolated into the query."""
+    query, aliases = build_latest_releases_query(
+        ["not-a-repo-key", 'evil"/x', HOST_REPO]
+    )
+
+    assert aliases == {"repo_2": HOST_REPO}
+    assert "evil" not in query
+
+
+# ---------------------------------------------------------------------------
+# Draft and prerelease filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_draft_release_is_never_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A draft release is skipped even when its tag ref already exists."""
+    draft_tag = "v0.12.3"
+    draft_sha = "aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+    payload = _repo_payload(
+        refs=[
+            _annotated_ref(draft_tag, "f" * 40, draft_sha),
+            *_HOST_REFS,
+        ],
+        releases=[
+            _release(draft_tag, is_draft=True),
+            _release(TAG_NAME, _iso_days_ago(10)),
+        ],
+        latest=_release(TAG_NAME, _iso_days_ago(10)),
+    )
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: payload})
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag == TAG_NAME
+    assert release.commit_sha == PEELED_COMMIT_SHA
+
+
+@pytest.mark.asyncio
+async def test_prerelease_is_excluded_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``allow_prerelease`` a prerelease loses to the last stable."""
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: _prerelease_payload()})
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag == PREVIOUS_TAG
+    assert release.commit_sha == PREVIOUS_COMMIT_SHA
+
+
+@pytest.mark.asyncio
+async def test_prerelease_is_selected_when_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``allow_prerelease`` the newer prerelease wins."""
+    resolver = _api_resolver(
+        monkeypatch, {HOST_REPO: _prerelease_payload()}, allow_prerelease=True
+    )
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag == TAG_NAME
+    assert release.commit_sha == PEELED_COMMIT_SHA
+
+
+def _prerelease_payload() -> dict[str, Any]:
+    """Build a payload whose newest release is marked as a prerelease.
+
+    Returns:
+        A per-repository fragment where ``v0.12.2`` is a prerelease and
+        ``v0.12.1`` is the newest stable release.
+    """
+    return _repo_payload(
+        refs=_HOST_REFS,
+        releases=[
+            _release(TAG_NAME, _iso_days_ago(1), is_prerelease=True),
+            _release(PREVIOUS_TAG, _iso_days_ago(20)),
+        ],
+        latest=_release(PREVIOUS_TAG, _iso_days_ago(20)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cooldown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cooldown_falls_back_to_an_older_warm_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A release still inside the cooldown yields to an older eligible one."""
+    payload = _host_payload(_iso_days_ago(1), _iso_days_ago(30))
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: payload}, cooldown_days=7)
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag == PREVIOUS_TAG
+    assert release.commit_sha == PREVIOUS_COMMIT_SHA
+
+
+@pytest.mark.asyncio
+async def test_cooldown_excluding_everything_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no release is warm enough the repository has no answer."""
+    payload = _host_payload(_iso_days_ago(1), _iso_days_ago(2))
+    resolver = _api_resolver(
+        monkeypatch, {HOST_REPO: payload}, cooldown_days=30
+    )
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.asyncio
+async def test_git_backend_declines_under_an_active_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git ls-remote`` exposes no dates, so a cooldown cannot be honoured.
+
+    Rather than guess at a release's age the Git backend reports nothing,
+    matching ``auto_fix_versions._get_latest_version_via_git``.
+    """
+    calls: list[str] = []
+    resolver = _git_resolver(
+        monkeypatch, {HOST_REPO: LS_REMOTE_OUTPUT}, calls, cooldown_days=7
+    )
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_git_backend_resolves_when_no_cooldown_applies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same Git fixture resolves cleanly once the cooldown is off."""
+    resolver = _git_resolver(
+        monkeypatch, {HOST_REPO: LS_REMOTE_OUTPUT}, cooldown_days=0
+    )
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag == TAG_NAME
+
+
+def test_undated_candidates_are_skipped_while_a_cooldown_is_active() -> None:
+    """The selection helper itself refuses to guess at an unknown age."""
+    candidates = [
+        ReleaseCandidate(tag=TAG_NAME, commit_sha=PEELED_COMMIT_SHA),
+        ReleaseCandidate(tag=PREVIOUS_TAG, commit_sha=PREVIOUS_COMMIT_SHA),
+    ]
+
+    assert (
+        select_latest_release(candidates, ReleasePolicy(cooldown_days=1))
+        is None
+    )
+    assert select_latest_release(candidates, ReleasePolicy()) == LatestRelease(
+        tag=TAG_NAME, commit_sha=PEELED_COMMIT_SHA
+    )
+
+
+# ---------------------------------------------------------------------------
+# The commit-to-tag map: where a pinned commit sits relative to the target
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_cooldown_target_still_places_the_newer_commits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cooldown-shifted target must not hide the releases above it.
+
+    The target is v0.7.0 because v0.12.x is still warming, but a pin at
+    v0.12.2 is ahead rather than stale, and only the map can say so.
+    """
+    resolver = _api_resolver(
+        monkeypatch, {HOST_REPO: _three_release_payload()}, cooldown_days=7
+    )
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag == COOLDOWN_TAG
+    assert release.commit_sha == COOLDOWN_COMMIT_SHA
+    assert release.tag_for_commit(PEELED_COMMIT_SHA) == TAG_NAME
+    assert release.tag_for_commit(PREVIOUS_COMMIT_SHA) == PREVIOUS_TAG
+    assert release.tag_for_commit(COOLDOWN_COMMIT_SHA) == COOLDOWN_TAG
+
+
+@pytest.mark.asyncio
+async def test_the_newest_release_wins_when_no_cooldown_applies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same fixture without a cooldown behaves exactly as before."""
+    resolver = _api_resolver(
+        monkeypatch, {HOST_REPO: _three_release_payload()}, cooldown_days=0
+    )
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag == TAG_NAME
+    assert release.commit_sha == PEELED_COMMIT_SHA
+    assert release.tag_for_commit(COOLDOWN_COMMIT_SHA) == COOLDOWN_TAG
+
+
+@pytest.mark.asyncio
+async def test_the_map_ignores_a_commit_no_release_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An annotated tag object is not the commit of any release."""
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: _host_payload()})
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag_for_commit(TAG_OBJECT_SHA) is None
+    assert release.tag_for_commit(BRANCH_COMMIT_SHA) is None
+
+
+@pytest.mark.asyncio
+async def test_the_map_prefers_the_most_specific_tag_for_a_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``v7`` and ``v7.0.1`` name one commit; the specific tag wins."""
+    resolver = _api_resolver(
+        monkeypatch, {LIGHTWEIGHT_REPO: _LIGHTWEIGHT_PAYLOAD}
+    )
+
+    release = (await resolver.resolve([LIGHTWEIGHT_REPO]))[LIGHTWEIGHT_REPO]
+
+    assert release is not None
+    assert release.tag_for_commit(LIGHTWEIGHT_SHA) == LIGHTWEIGHT_TAG
+
+
+@pytest.mark.asyncio
+async def test_commit_lookup_is_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hexadecimal case is not a difference in commit identity."""
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: _host_payload()})
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release is not None
+    assert release.tag_for_commit(PEELED_COMMIT_SHA.upper()) == TAG_NAME
+
+
+@pytest.mark.asyncio
+async def test_a_cooldown_run_bypasses_the_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cached ``(tag, sha)`` pair cannot answer a cooldown run.
+
+    The cache persists no commit map, so serving a cooldown-shifted
+    target from it would lose the ability to tell a pin that is behind
+    the target from one that is ahead of it -- and reporting the latter
+    as stale recommends a downgrade. Nothing is written back either, so
+    a later run without a cooldown cannot read a shifted target.
+    """
+    queries: list[str] = []
+    resolver = _api_resolver(
+        monkeypatch,
+        {HOST_REPO: _three_release_payload()},
+        queries,
+        tmp_path,
+        cooldown_days=7,
+    )
+    resolver.cache.put_latest_version(
+        HOST_REPO, COOLDOWN_TAG, COOLDOWN_COMMIT_SHA
+    )
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert resolver.cache_usable is False
+    assert len(queries) == 1
+    assert release is not None
+    assert release.tag == COOLDOWN_TAG
+    assert release.tag_for_commit(PEELED_COMMIT_SHA) == TAG_NAME
+
+
+@pytest.mark.asyncio
+async def test_a_cached_release_carries_no_commit_map(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The documented degradation of a cache hit, stated explicitly.
+
+    Without a cooldown the target *is* the newest release, so nothing can
+    be ahead of it and the missing map costs nothing.
+    """
+    config = _config(ValidationMethod.GITHUB_API, tmp_path, cooldown_days=0)
+    resolver = _resolver(config)
+    resolver.cache.put_latest_version(HOST_REPO, TAG_NAME, PEELED_COMMIT_SHA)
+
+    def _explode() -> Any:
+        raise AssertionError("the API client must not be constructed")
+
+    monkeypatch.setattr(resolver, "_make_github_client", _explode)
+
+    release = (await resolver.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert resolver.cache_usable is True
+    assert release is not None
+    assert release.commit_sha == PEELED_COMMIT_SHA
+    assert release.tag_for_commit(PEELED_COMMIT_SHA) is None
+
+
+# ---------------------------------------------------------------------------
+# Cost: one lookup per distinct host repository, zero on a cache hit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_many_pins_on_one_host_cost_a_single_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Twenty pins naming one host repository resolve it exactly once."""
+    queries: list[str] = []
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: _host_payload()}, queries)
+
+    results = await resolver.resolve([HOST_REPO] * 20)
+
+    assert list(results) == [HOST_REPO]
+    assert len(queries) == 1
+
+
+@pytest.mark.asyncio
+async def test_git_backend_also_resolves_a_shared_host_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """De-duplication happens before the backend, so Git benefits too."""
+    calls: list[str] = []
+    resolver = _git_resolver(monkeypatch, {HOST_REPO: LS_REMOTE_OUTPUT}, calls)
+
+    results = await resolver.resolve([HOST_REPO] * 20)
+
+    assert list(results) == [HOST_REPO]
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_costs_zero_api_calls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cached host repository never reaches the API client at all."""
+    config = _config(ValidationMethod.GITHUB_API, tmp_path)
+    resolver = _resolver(config)
+    resolver.cache.put_latest_version(HOST_REPO, TAG_NAME, PEELED_COMMIT_SHA)
+
+    def _explode() -> Any:
+        raise AssertionError("the API client must not be constructed")
+
+    monkeypatch.setattr(resolver, "_make_github_client", _explode)
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] == LatestRelease(
+        tag=TAG_NAME, commit_sha=PEELED_COMMIT_SHA
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_resolved_release_is_cached_for_the_next_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The second run within the TTL issues no query at all."""
+    queries: list[str] = []
+    first = _api_resolver(
+        monkeypatch, {HOST_REPO: _host_payload()}, queries, tmp_path
+    )
+    assert (await first.resolve([HOST_REPO]))[HOST_REPO] is not None
+    assert len(queries) == 1
+
+    second = _resolver(_config(ValidationMethod.GITHUB_API, tmp_path))
+    release = (await second.resolve([HOST_REPO]))[HOST_REPO]
+
+    assert release == LatestRelease(tag=TAG_NAME, commit_sha=PEELED_COMMIT_SHA)
+    assert len(queries) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_repository_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A transient failure must not be remembered as "no release"."""
+    resolver = _api_resolver(monkeypatch, {}, None, tmp_path)
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+    assert resolver.cache.get_latest_version(HOST_REPO) is None
+
+
+# ---------------------------------------------------------------------------
+# Failure modes: every one resolves to None instead of raising
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_repository_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A NOT_FOUND alias yields None without disturbing its neighbours."""
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: _host_payload()})
+
+    results = await resolver.resolve([HOST_REPO, MISSING_REPO])
+
+    assert results[MISSING_REPO] is None
+    assert results[HOST_REPO] is not None
+
+
+@pytest.mark.asyncio
+async def test_repository_without_releases_or_tags_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing to compare against is a None, not an error."""
+    payload = _repo_payload(refs=[], releases=[])
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: payload})
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.asyncio
+async def test_repository_with_only_unparsable_tags_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tags that are not clean versions cannot be ranked, so none wins."""
+    payload = _repo_payload(
+        refs=[_lightweight_ref("nightly", BRANCH_COMMIT_SHA)],
+        releases=[],
+    )
+    resolver = _api_resolver(monkeypatch, {HOST_REPO: payload})
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.parametrize(
+    ("status", "body"),
+    [
+        (401, "Bad credentials"),
+        (403, "API rate limit exceeded"),
+        (500, "Server Error"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_api_error_statuses_resolve_to_none(
+    monkeypatch: pytest.MonkeyPatch, status: int, body: str
+) -> None:
+    """Auth, rate-limit and server failures all degrade to None."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/rate_limit"):
+            return httpx.Response(200, json=_RATE_LIMIT_BODY)
+        return httpx.Response(status, text=body)
+
+    _install_http(monkeypatch, respond)
+    resolver = _resolver(_config(ValidationMethod.GITHUB_API))
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.asyncio
+async def test_network_failure_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable API is a None, not a traceback."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/rate_limit"):
+            return httpx.Response(200, json=_RATE_LIMIT_BODY)
+        raise httpx.ConnectError("connection refused", request=request)
+
+    _install_http(monkeypatch, respond)
+    resolver = _resolver(_config(ValidationMethod.GITHUB_API))
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_api_response_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A response that is not the expected shape yields None."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/rate_limit"):
+            return httpx.Response(200, json=_RATE_LIMIT_BODY)
+        return httpx.Response(200, json={"data": {"repo_0": "not-an-object"}})
+
+    _install_http(monkeypatch, respond)
+    resolver = _resolver(_config(ValidationMethod.GITHUB_API))
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.asyncio
+async def test_api_client_construction_failure_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even a failure before the first request degrades to None."""
+    resolver = _resolver(_config(ValidationMethod.GITHUB_API))
+
+    def _explode() -> Any:
+        raise RuntimeError("no token available")
+
+    monkeypatch.setattr(resolver, "_make_github_client", _explode)
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.asyncio
+async def test_git_remote_failure_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing ``git ls-remote`` yields None for that repository only."""
+    resolver = _git_resolver(monkeypatch, {HOST_REPO: LS_REMOTE_OUTPUT})
+
+    results = await resolver.resolve([HOST_REPO, MISSING_REPO])
+
+    assert results[MISSING_REPO] is None
+    assert results[HOST_REPO] is not None
+
+
+@pytest.mark.asyncio
+async def test_git_remote_without_tags_resolves_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repository advertising no tags has no latest release."""
+    resolver = _git_resolver(
+        monkeypatch, {HOST_REPO: f"{BRANCH_COMMIT_SHA}\trefs/heads/main\n"}
+    )
+
+    assert (await resolver.resolve([HOST_REPO]))[HOST_REPO] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_and_blank_repository_keys_are_ignored() -> None:
+    """No usable key means no work and no backend call."""
+    resolver = _resolver(_config(ValidationMethod.GITHUB_API))
+
+    assert await resolver.resolve([]) == {}
+    assert await resolver.resolve(["", ""]) == {}

--- a/tests/test_allow_list_scanner.py
+++ b/tests/test_allow_list_scanner.py
@@ -1,0 +1,716 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for allow-list pin detection.
+
+The fixtures under ``tests/fixtures/allow_list`` carry shapes copied from
+the real estate, so the line and column assertions below are assertions
+about workflows people actually wrote. Where a test names a line number
+it is 1-based, matching :attr:`AllowListPin.line_number`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gha_workflow_linter.allow_list_scanner import (
+    DEFAULT_KEY_PATTERNS,
+    AllowListPin,
+    AllowListScanner,
+    CommentPosition,
+    QuoteStyle,
+)
+from gha_workflow_linter.directives import Directive, SuppressionSource
+from gha_workflow_linter.models import Config
+
+FIXTURES = Path(__file__).parent / "fixtures" / "allow_list"
+
+#: Org owning every fixture workflow. The shorthand '@<sha>' form takes
+#: its host org from here.
+WORKFLOW_ORG = "lfreleng-actions"
+
+ALLOW = Directive.ALLOW_LIST_PIN_OK
+
+SHA_V0_1_1 = "18d9c4446bea555d0783e850f6d295f844fe8f67"
+SHA_V0_5_1 = "8f4f0cf83e6a015957e83261ed379fd811fc060e"
+SHA_V0_12_2 = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+
+
+@pytest.fixture
+def scanner() -> AllowListScanner:
+    """Return a scanner with default configuration and patterns."""
+    return AllowListScanner(Config(), WORKFLOW_ORG)
+
+
+def scan(scanner: AllowListScanner, name: str) -> list[AllowListPin]:
+    """Scan one fixture by filename.
+
+    Args:
+        scanner: The scanner under test.
+        name: Fixture filename within ``tests/fixtures/allow_list``.
+
+    Returns:
+        The pins found, in document order.
+    """
+    return scanner.scan_file(FIXTURES / name)
+
+
+def key_paths(pins: list[AllowListPin]) -> list[str]:
+    """Return each pin's key path, joined with dots.
+
+    Args:
+        pins: Pins to summarise.
+
+    Returns:
+        One dotted key path per pin, in order.
+    """
+    return [".".join(pin.key_path) for pin in pins]
+
+
+class TestDetectionLocations:
+    """All three locations of design section 5.1."""
+
+    def test_step_with_config(self, scanner: AllowListScanner) -> None:
+        """Location 1: an input named ``config`` on a step."""
+        pins = scan(scanner, "internal_step_config.yaml")
+
+        assert key_paths(pins) == ["jobs.build.steps.0.with.config"]
+        assert pins[0].spec.ref == SHA_V0_1_1
+
+    def test_workflow_call_input_default(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Location 2: a ``workflow_call`` input default."""
+        pins = scan(scanner, "workflow_call_defaults.yaml")
+
+        assert key_paths(pins) == [
+            "on.workflow_call.inputs.harden_runner_allowlist.default",
+            "on.workflow_call.inputs.audit_config.default",
+        ]
+
+    def test_reusable_workflow_caller_input(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Location 3: an input in a caller job's ``with`` block."""
+        pins = scan(scanner, "reusable_caller.yaml")
+
+        assert key_paths(pins) == ["jobs.call.with.harden_runner_allowlist"]
+        assert pins[0].spec.path_explicit is True
+
+    def test_step_index_is_the_sequence_position(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Steps are addressed by index, as decimal strings."""
+        pins = scan(scanner, "comment_positions.yaml")
+
+        assert [pin.key_path[3] for pin in pins] == ["0", "1", "2", "3", "4"]
+
+
+class TestYamlOneOneTriggerKey:
+    """The bare ``on:`` key, which YAML 1.1 resolves to a boolean."""
+
+    def test_pins_found_under_a_bare_on_key(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Detection survives the retagging of ``on``.
+
+        ``tests/test_scanner_yaml_tree`` documents the behaviour: the
+        composed key node keeps its raw text but carries the *bool* tag,
+        and a document constructed with ``yaml.safe_load`` has the key
+        ``True``. The walk matches raw text, so location 2 is reached.
+        """
+        path = FIXTURES / "workflow_call_defaults.yaml"
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+        # Confirm the hazard is real for this fixture, not assumed.
+        assert isinstance(loaded, dict)
+        assert True in loaded
+        assert "on" not in loaded
+
+        pins = scanner.scan_file(path)
+        assert pins
+        assert all(pin.key_path[0] == "on" for pin in pins)
+
+    def test_quoted_on_key_behaves_identically(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """Quoting ``on`` keeps the string tag and changes nothing."""
+        path = tmp_path / "quoted-on.yaml"
+        path.write_text(
+            "---\n"
+            '"on":\n'
+            "  workflow_call:\n"
+            "    inputs:\n"
+            "      harden_runner_allowlist:\n"
+            "        type: string\n"
+            f"        default: '@{SHA_V0_1_1}'  # v0.1.1\n",
+            encoding="utf-8",
+        )
+
+        pins = scanner.scan_file(path)
+
+        assert key_paths(pins) == [
+            "on.workflow_call.inputs.harden_runner_allowlist.default"
+        ]
+
+    def test_trigger_block_without_a_mapping_is_harmless(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """``on: [push]`` and ``on: push`` yield nothing, not an error."""
+        for text in ("on: [push]\n", "on: push\n"):
+            path = tmp_path / "trigger.yaml"
+            path.write_text(f"---\n{text}", encoding="utf-8")
+
+            assert scanner.scan_file(path) == []
+
+
+class TestRecogniserPredicate:
+    """Recognition where the key name is the author's choice."""
+
+    def test_conventional_filename_needs_no_registry(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """A python-audit pin is found with no code change.
+
+        Design section 5.4: consumers are data, not code. This pin sits
+        under a key matching none of the default patterns, so the only
+        thing that identifies it is the conventional filename at the end
+        of the path the author wrote. Nothing here knows what
+        ``python-audit`` is.
+        """
+        pins = scan(scanner, "workflow_call_defaults.yaml")
+        audit = pins[1]
+
+        assert audit.key_path[-2] == "audit_config"
+        assert not any(
+            pattern.strip("*") in "audit_config"
+            for pattern in DEFAULT_KEY_PATTERNS
+        )
+        assert audit.spec.candidates == (
+            ".github/python-audit/lfreleng-actions/allow_list.txt",
+        )
+
+    def test_key_name_pattern_recognises_shorthand(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """A shorthand default qualifies on its key name alone."""
+        path = tmp_path / "shorthand-default.yaml"
+        path.write_text(
+            "---\n"
+            "on:\n"
+            "  workflow_call:\n"
+            "    inputs:\n"
+            "      harden_runner_allow-list:\n"
+            "        type: string\n"
+            f"        default: '@{SHA_V0_12_2}'  # v0.12.2\n",
+            encoding="utf-8",
+        )
+
+        pins = scanner.scan_file(path)
+
+        assert len(pins) == 1
+        assert pins[0].spec.ref == SHA_V0_12_2
+
+    def test_key_name_matching_is_case_insensitive(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """``HardenRunnerAllowList`` matches ``*allowlist*``."""
+        path = tmp_path / "mixed-case.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  call:\n"
+            "    uses: org/repo/.github/workflows/w.yaml@main\n"
+            "    with:\n"
+            f"      HardenRunnerAllowList: '@{SHA_V0_1_1}'\n",
+            encoding="utf-8",
+        )
+
+        assert len(scanner.scan_file(path)) == 1
+
+    def test_parsable_scalar_under_unrelated_key_is_not_a_pin(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """A default that merely parses is not thereby a coordinate.
+
+        ``build_timeout: '30'`` resolves cleanly -- an org taking every
+        default -- so testing the resolved candidate chain would accept
+        it. The predicate tests what the author *wrote* instead.
+        """
+        pins = scan(scanner, "workflow_call_defaults.yaml")
+
+        assert "build_timeout" not in str(key_paths(pins))
+
+    def test_key_patterns_are_configurable(self, tmp_path: Path) -> None:
+        """A caller may supply its own key-name patterns."""
+        path = tmp_path / "custom-key.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  call:\n"
+            "    uses: org/repo/.github/workflows/w.yaml@main\n"
+            "    with:\n"
+            f"      egress_policy_source: '@{SHA_V0_1_1}'\n",
+            encoding="utf-8",
+        )
+
+        default_scanner = AllowListScanner(Config(), WORKFLOW_ORG)
+        custom = AllowListScanner(
+            Config(), WORKFLOW_ORG, key_patterns=["*egress*"]
+        )
+
+        assert default_scanner.scan_file(path) == []
+        assert len(custom.scan_file(path)) == 1
+
+    def test_filename_is_configurable(self, tmp_path: Path) -> None:
+        """The conventional filename may be overridden."""
+        path = tmp_path / "custom-filename.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  call:\n"
+            "    uses: org/repo/.github/workflows/w.yaml@main\n"
+            "    with:\n"
+            "      policy: 'lfreleng-actions"
+            f"//.github/harden-runner/endpoints.txt@{SHA_V0_12_2}'\n",
+            encoding="utf-8",
+        )
+
+        default_scanner = AllowListScanner(Config(), WORKFLOW_ORG)
+        custom = AllowListScanner(
+            Config(), WORKFLOW_ORG, filename="endpoints.txt"
+        )
+
+        assert default_scanner.scan_file(path) == []
+        assert len(custom.scan_file(path)) == 1
+
+    def test_step_config_needs_no_recogniser(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """Location 1 is anchored structurally, not by key pattern."""
+        path = tmp_path / "anchored.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: org/action@main\n"
+            "        with:\n"
+            "          config: 'lfreleng-actions@main'\n",
+            encoding="utf-8",
+        )
+
+        pins = scanner.scan_file(path)
+
+        assert len(pins) == 1
+        assert pins[0].spec.ref == "main"
+
+
+class TestSkipRules:
+    """Design section 5.2: what never becomes a finding."""
+
+    def test_github_expression_is_skipped(
+        self, scanner: AllowListScanner, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``${{ ... }}`` is resolved at run time and is not a pin."""
+        with caplog.at_level(logging.DEBUG):
+            pins = scan(scanner, "reusable_caller.yaml")
+
+        assert "jobs.expression.steps.0.with.config" not in key_paths(pins)
+        assert "GitHub expression" in caplog.text
+
+    def test_unparsable_scalar_is_skipped_silently(
+        self, scanner: AllowListScanner, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A value failing the grammar is a skip, never a finding.
+
+        Design section 5.4 is explicit that the failure mode for an
+        unrelated ``config:`` value is a skip. ``'3.11'`` cannot be an
+        org, so it is dropped with a debug log and nothing more.
+        """
+        with caplog.at_level(logging.DEBUG):
+            pins = scan(scanner, "workflow_call_defaults.yaml")
+
+        assert len(pins) == 2
+        assert "not a config spec" in caplog.text
+
+    def test_unrelated_step_config_is_skipped(
+        self, scanner: AllowListScanner, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Another action's ``config:`` input produces no finding."""
+        with caplog.at_level(logging.DEBUG):
+            assert scan(scanner, "no_pins.yaml") == []
+
+        assert "not a config spec" in caplog.text
+
+    def test_empty_workflow_org_skips_the_shorthand_form(
+        self, tmp_path: Path
+    ) -> None:
+        """Without an org the shorthand cannot resolve, so it is skipped."""
+        path = tmp_path / "shorthand.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: org/action@main\n"
+            "        with:\n"
+            f"          config: '@{SHA_V0_1_1}'\n",
+            encoding="utf-8",
+        )
+
+        assert AllowListScanner(Config(), "").scan_file(path) == []
+        assert (
+            len(AllowListScanner(Config(), WORKFLOW_ORG).scan_file(path)) == 1
+        )
+
+
+class TestSourceAnchors:
+    """Line, column and raw-line recovery."""
+
+    def test_line_numbers_are_one_based(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """The anchor names the line an editor would show."""
+        path = FIXTURES / "internal_step_config.yaml"
+        pin = scanner.scan_file(path)[0]
+        lines = path.read_text(encoding="utf-8").splitlines()
+
+        assert pin.line_number == 20
+        assert lines[pin.line_number - 1] == pin.raw_line
+        assert pin.raw_line.lstrip().startswith("config:")
+
+    def test_column_is_zero_based_at_the_opening_quote(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """A quoted scalar's column is its quote, not its first char."""
+        pin = scan(scanner, "internal_step_config.yaml")[0]
+
+        assert pin.column == 18
+        assert pin.raw_line[pin.column] == "'"
+
+    def test_raw_value_excludes_the_in_scalar_comment(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Form B's comment is not part of the recorded value."""
+        pin = scan(scanner, "comment_positions.yaml")[1]
+
+        assert pin.raw_value == f"@{SHA_V0_5_1}"
+        assert "#" not in pin.raw_value
+
+    def test_file_path_is_recorded(self, scanner: AllowListScanner) -> None:
+        """Each pin knows which file it came from."""
+        path = FIXTURES / "internal_step_config.yaml"
+
+        assert scanner.scan_file(path)[0].file_path == path
+
+    def test_multi_line_scalar_is_not_auto_fixable(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """A block scalar is recorded and reported, never rewritten."""
+        pins = scan(scanner, "comment_positions.yaml")
+        folded = pins[4]
+
+        assert folded.auto_fixable is False
+        assert folded.line_number == 41
+        assert folded.raw_line.strip() == "config: >-"
+        assert folded.spec.ref == SHA_V0_12_2
+
+    def test_single_line_scalars_are_auto_fixable(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Everything that fits on one line can be rewritten."""
+        pins = scan(scanner, "comment_positions.yaml")
+
+        assert [pin.auto_fixable for pin in pins[:4]] == [True] * 4
+
+
+class TestQuoteStyles:
+    """Quoting inferred from the source text at the anchor."""
+
+    def test_single_double_and_unquoted(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """All three styles are distinguished."""
+        pins = scan(scanner, "comment_positions.yaml")
+
+        assert [pin.quote_style for pin in pins[:3]] == [
+            QuoteStyle.SINGLE,
+            QuoteStyle.DOUBLE,
+            QuoteStyle.NONE,
+        ]
+
+    def test_block_scalar_reports_no_quoting(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """A block scalar's start mark is its indicator, not a quote."""
+        assert scan(scanner, "comment_positions.yaml")[4].quote_style is (
+            QuoteStyle.NONE
+        )
+
+
+class TestCommentPositions:
+    """Design section 2: the version comment sits in one of two places."""
+
+    def test_yaml_comment_outside_the_quotes(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Form A, which every pin in the estate uses."""
+        pin = scan(scanner, "comment_positions.yaml")[0]
+
+        assert pin.comment_position is CommentPosition.YAML
+        assert pin.version_comment == "v0.1.1"
+
+    def test_in_scalar_comment_inside_the_quotes(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Form B, which the action's own parser strips."""
+        pin = scan(scanner, "comment_positions.yaml")[1]
+
+        assert pin.comment_position is CommentPosition.IN_SCALAR
+        assert pin.version_comment == "v0.5.1"
+        assert pin.spec.comment == "v0.5.1"
+
+    def test_no_comment_at_all(self, scanner: AllowListScanner) -> None:
+        """A pin need not carry a version comment."""
+        pin = scan(scanner, "comment_positions.yaml")[2]
+
+        assert pin.comment_position is CommentPosition.NONE
+        assert pin.version_comment is None
+
+    def test_in_scalar_comment_wins_when_both_are_present(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """The comment the action sees is the effective one."""
+        pin = scan(scanner, "comment_positions.yaml")[3]
+
+        assert pin.comment_position is CommentPosition.IN_SCALAR
+        assert pin.version_comment == "v0.5.1"
+        assert pin.raw_line.endswith("# v0.2.1")
+
+    def test_in_scalar_separator_may_be_a_tab(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """The separator rule is the action's: spaces or tabs."""
+        path = tmp_path / "tab.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: org/action@main\n"
+            "        with:\n"
+            f"          config: '@{SHA_V0_1_1}\t# v0.1.1'\n",
+            encoding="utf-8",
+        )
+
+        pin = scanner.scan_file(path)[0]
+
+        assert pin.raw_value == f"@{SHA_V0_1_1}"
+        assert pin.comment_position is CommentPosition.IN_SCALAR
+        assert pin.version_comment == "v0.1.1"
+
+    def test_single_space_before_the_yaml_comment(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """One space is enough to start a comment outside the quotes."""
+        path = tmp_path / "one-space.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: org/action@main\n"
+            "        with:\n"
+            f"          config: '@{SHA_V0_1_1}' # v0.1.1\n",
+            encoding="utf-8",
+        )
+
+        pin = scanner.scan_file(path)[0]
+
+        assert pin.comment_position is CommentPosition.YAML
+        assert pin.version_comment == "v0.1.1"
+
+
+class TestSuppression:
+    """Design section 7.4: both directive forms, and neither."""
+
+    def test_preceding_line_directive(self, scanner: AllowListScanner) -> None:
+        """Form 1 binds to the immediately following line."""
+        pin = scan(scanner, "suppression.yaml")[0]
+
+        assert pin.directives == frozenset({ALLOW})
+        assert pin.suppressed_by is SuppressionSource.PRECEDING_LINE
+        assert pin.suppression_reason == "waiting for a release"
+
+    def test_inline_keyword_directive(self, scanner: AllowListScanner) -> None:
+        """Form 2 follows the version token in the trailing comment."""
+        pin = scan(scanner, "suppression.yaml")[1]
+
+        assert pin.directives == frozenset({ALLOW})
+        assert pin.suppressed_by is SuppressionSource.INLINE_COMMENT
+        assert pin.suppression_reason == "upstream is broken"
+        assert pin.version_comment == "v0.5.1"
+
+    def test_both_forms_together(self, scanner: AllowListScanner) -> None:
+        """Both forms are idempotent; the inline reason wins."""
+        pin = scan(scanner, "suppression.yaml")[2]
+
+        assert pin.directives == frozenset({ALLOW})
+        assert pin.suppressed_by is SuppressionSource.INLINE_COMMENT
+        assert pin.suppression_reason == "inline reason"
+
+    def test_directive_in_the_in_scalar_comment(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Either comment position may carry the keyword."""
+        pin = scan(scanner, "suppression.yaml")[3]
+
+        assert pin.directives == frozenset({ALLOW})
+        assert pin.suppressed_by is SuppressionSource.INLINE_COMMENT
+        assert pin.version_comment == "v0.5.1"
+
+    def test_blank_line_breaks_the_binding(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Form 1 must be the *immediately* preceding line."""
+        pin = scan(scanner, "suppression.yaml")[4]
+
+        assert pin.directives == frozenset()
+        assert pin.suppressed_by is None
+
+    def test_unsuppressed_pin(self, scanner: AllowListScanner) -> None:
+        """No directive means no suppression and no reason."""
+        pin = scan(scanner, "suppression.yaml")[5]
+
+        assert pin.directives == frozenset()
+        assert pin.suppressed_by is None
+        assert pin.suppression_reason is None
+
+    def test_directive_on_the_yaml_comment_when_a_scalar_one_exists(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """A directive outside the quotes still suppresses."""
+        path = tmp_path / "either.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: org/action@main\n"
+            "        with:\n"
+            f"          config: '@{SHA_V0_1_1} # v0.1.1'"
+            "  # allow-list-pin-ok\n",
+            encoding="utf-8",
+        )
+
+        pin = scanner.scan_file(path)[0]
+
+        assert pin.directives == frozenset({ALLOW})
+        assert pin.comment_position is CommentPosition.IN_SCALAR
+        assert pin.version_comment == "v0.1.1"
+
+    def test_preceding_directive_ignores_indentation(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """YAML permits comments at any column, so alignment is moot."""
+        path = tmp_path / "indent.yaml"
+        path.write_text(
+            "---\n"
+            "jobs:\n"
+            "  build:\n"
+            "    steps:\n"
+            "      - uses: org/action@main\n"
+            "        with:\n"
+            "# gha-workflow-linter: allow-list-pin-ok\n"
+            f"          config: '@{SHA_V0_1_1}'\n",
+            encoding="utf-8",
+        )
+
+        assert scanner.scan_file(path)[0].directives == frozenset({ALLOW})
+
+
+class TestFailureModes:
+    """Nothing about a bad file may raise."""
+
+    def test_file_with_no_pins(self, scanner: AllowListScanner) -> None:
+        """An ordinary workflow yields an empty list."""
+        assert scan(scanner, "no_pins.yaml") == []
+
+    def test_invalid_yaml_yields_no_pins(
+        self,
+        scanner: AllowListScanner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A file that fails to parse is reported and skipped."""
+        path = tmp_path / "broken.yaml"
+        path.write_text("name: Test\non: [push\njobs: {\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            assert scanner.scan_file(path) == []
+
+        assert "Invalid YAML" in caplog.text
+
+    def test_missing_file_yields_no_pins(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """A path that does not exist is not an error."""
+        assert scanner.scan_file(tmp_path / "absent.yaml") == []
+
+    def test_empty_file_yields_no_pins(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """An empty document composes to nothing at all."""
+        path = tmp_path / "empty.yaml"
+        path.write_text("", encoding="utf-8")
+
+        assert scanner.scan_file(path) == []
+
+    def test_non_mapping_document_yields_no_pins(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """A document that is a sequence is walked without complaint."""
+        path = tmp_path / "sequence.yaml"
+        path.write_text("---\n- one\n- two\n", encoding="utf-8")
+
+        assert scanner.scan_file(path) == []
+
+    def test_malformed_job_shapes_yield_no_pins(
+        self, scanner: AllowListScanner, tmp_path: Path
+    ) -> None:
+        """Unexpected node types below ``jobs`` are stepped over."""
+        path = tmp_path / "malformed.yaml"
+        path.write_text(
+            "---\njobs: not-a-mapping\n",
+            encoding="utf-8",
+        )
+
+        assert scanner.scan_file(path) == []
+
+
+class TestScanFiles:
+    """The multi-file entry point."""
+
+    def test_only_files_with_pins_appear(
+        self, scanner: AllowListScanner
+    ) -> None:
+        """Files without pins are omitted from the mapping."""
+        paths = [
+            FIXTURES / "internal_step_config.yaml",
+            FIXTURES / "no_pins.yaml",
+            FIXTURES / "workflow_call_defaults.yaml",
+        ]
+
+        results = scanner.scan_files(paths)
+
+        assert list(results) == [paths[0], paths[2]]
+        assert len(results[paths[2]]) == 2
+
+    def test_empty_input(self, scanner: AllowListScanner) -> None:
+        """No files means no results."""
+        assert scanner.scan_files([]) == {}

--- a/tests/test_allow_list_spec.py
+++ b/tests/test_allow_list_spec.py
@@ -1,0 +1,593 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for allow-list ``config`` coordinate parsing.
+
+The first half of this file is a port of the upstream conformance
+corpus: ``tests/test_resolve_config_source.py`` (the parsing sections,
+lines 1-180) in ``lfreleng-actions/harden-runner-block-action``, itself
+mirrored byte-for-byte into ``lfreleng-actions/python-audit-action``.
+
+Those cases are the *specification* for the grammar, not merely tests of
+this module. Keep them in step with upstream: when the grammar changes
+there, port the change here in the same cycle. Add local cases to the
+sections below the corpus rather than editing the corpus itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gha_workflow_linter.allow_list_spec import (
+    ResolvedSpec,
+    SpecError,
+    parse_spec,
+    render_spec,
+    resolve_spec,
+    split_comment,
+)
+
+# A real, verified pin from the estate: the shorthand form, which is
+# what every internal workflow uses.
+ESTATE_SHORTHAND = "@18d9c4446bea555d0783e850f6d295f844fe8f67"
+
+# A real, verified pin in fully explicit form. Split for line length;
+# the value is a single scalar.
+ESTATE_EXPLICIT = (
+    "lfreleng-actions"
+    "//.github/harden-runner/lfreleng-actions/allow_list.txt"
+    "@bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+)
+
+# The commit (not tag-object) SHA of .github v0.12.2.
+ESTATE_EXPLICIT_SHA = "bf6642f68d58c1b81bbe993e676d6cc339ac3654"
+
+
+def _resolve(
+    spec: str, org: str = "onap", family: str = "python-audit"
+) -> ResolvedSpec:
+    """Resolve with the upstream corpus defaults.
+
+    Args:
+        spec: The config spec to resolve.
+        org: Workflow org.
+        family: Config family.
+
+    Returns:
+        The resolved spec.
+    """
+    return resolve_spec(spec, workflow_org=org, family=family)
+
+
+# ---------------------------------------------------------------------
+# Upstream corpus: comment splitting
+# ---------------------------------------------------------------------
+
+
+class TestSplitComment:
+    """Ported from the upstream ``test_split_comment`` corpus."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_spec", "expected_comment"),
+        [
+            ("lfit@v1.1.0", "lfit@v1.1.0", ""),
+            ("lfit@v1.1.0 # hello", "lfit@v1.1.0", "hello"),
+            ("lfit@v1.1.0  # two spaces", "lfit@v1.1.0", "two spaces"),
+            ("lfit@v1.1.0\t# tab", "lfit@v1.1.0", "tab"),
+            (
+                "lfit//f.txt@v1 # many words here",
+                "lfit//f.txt@v1",
+                "many words here",
+            ),
+        ],
+    )
+    def test_split_comment(
+        self, value: str, expected_spec: str, expected_comment: str
+    ) -> None:
+        """The separator is one or more spaces or tabs before ``#``."""
+        spec, comment = split_comment(value)
+        assert spec == expected_spec
+        assert comment == expected_comment
+
+
+# ---------------------------------------------------------------------
+# Upstream corpus: resolution + search candidates
+# ---------------------------------------------------------------------
+
+
+class TestResolution:
+    """Ported from the upstream resolution corpus."""
+
+    def test_org_only_default_branch(self) -> None:
+        """An org plus a branch takes every other default."""
+        resolved = _resolve("lfreleng-actions@main")
+        assert resolved.host_org == "lfreleng-actions"
+        assert resolved.repo == ".github"
+        assert resolved.ref == "main"
+        assert resolved.candidates == (
+            ".github/python-audit/onap/allow_list.txt",
+            ".github/python-audit/allow_list.txt",
+        )
+        assert resolved.path_explicit is False
+
+    def test_no_ref_defaults_to_head(self) -> None:
+        """An omitted ref means the host repo's default branch."""
+        resolved = _resolve("lfit")
+        assert resolved.ref == "HEAD"
+
+    def test_sha_ref_with_comment(self) -> None:
+        """An in-scalar comment is captured but ignored."""
+        resolved = _resolve(
+            "lfit@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v1.0.0"
+        )
+        assert resolved.host_org == "lfit"
+        assert resolved.ref == "ab7a9404c0f3da075243ca237b5fac12c98deaa5"
+        assert resolved.comment == "v1.0.0"
+
+    def test_filename_only_keeps_default_dir_search(self) -> None:
+        """A bare filename overrides the file, not the directories."""
+        resolved = _resolve("lfit//custom_list.txt@v1.1.0")
+        assert resolved.candidates == (
+            ".github/python-audit/onap/custom_list.txt",
+            ".github/python-audit/custom_list.txt",
+        )
+        assert resolved.path_explicit is False
+
+    def test_bare_double_slash_uses_defaults(self) -> None:
+        """A bare ``//`` resolves exactly as no ``//`` at all."""
+        resolved = _resolve(
+            "lfit//@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # note"
+        )
+        assert resolved.candidates == (
+            ".github/python-audit/onap/allow_list.txt",
+            ".github/python-audit/allow_list.txt",
+        )
+        assert resolved.ref == "ab7a9404c0f3da075243ca237b5fac12c98deaa5"
+
+    def test_explicit_directory_disables_search(self) -> None:
+        """A subpath containing ``/`` is used verbatim, with no search."""
+        resolved = _resolve("lfit//configs/onap/list.txt@main")
+        assert resolved.candidates == ("configs/onap/list.txt",)
+        assert resolved.path_explicit is True
+
+    def test_explicit_repo_override(self) -> None:
+        """``<org>/<repo>`` overrides the default ``.github`` repo."""
+        resolved = _resolve("lfit/special-repo//list.txt@main")
+        assert resolved.host_org == "lfit"
+        assert resolved.repo == "special-repo"
+
+    def test_empty_host_org_defaults_to_workflow_org(self) -> None:
+        """An omitted host org falls back to the workflow's own org."""
+        resolved = _resolve("//team_list.txt@main", org="onap")
+        assert resolved.host_org == "onap"
+        assert (
+            resolved.candidates[0] == ".github/python-audit/onap/team_list.txt"
+        )
+
+    def test_family_appears_in_default_path(self) -> None:
+        """The family names the directory under ``.github/``."""
+        resolved = _resolve("lfit@main", family="harden-runner")
+        assert resolved.candidates == (
+            ".github/harden-runner/onap/allow_list.txt",
+            ".github/harden-runner/allow_list.txt",
+        )
+
+
+# ---------------------------------------------------------------------
+# Upstream corpus: rejections
+# ---------------------------------------------------------------------
+
+
+class TestRejections:
+    """Ported from the upstream rejection corpus."""
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "",
+            "lfit@",
+            "lfit@a@b",
+            "lfit//a//b@main",
+            "lfit/repo/extra@main",
+            "bad org@main",
+            "lfit//../escape.txt@main",
+            "lfit///abs/path.txt@main",
+            "lfit//a\\b.txt@main",
+            "lfit@-badref",
+            "lfit@ref..with..dots",
+            "lfit@ref@{0}",
+            "lfit//evil;rm.txt@main",
+        ],
+    )
+    def test_invalid_specs_raise(self, spec: str) -> None:
+        """Every malformed shape is a hard error."""
+        with pytest.raises(SpecError):
+            _resolve(spec)
+
+    def test_newline_in_config_rejected(self) -> None:
+        """A newline anywhere in the spec is rejected."""
+        with pytest.raises(SpecError):
+            _resolve("lfit@main\nevil")
+
+    def test_newline_disguised_as_comment_rejected(self) -> None:
+        """A newline before ``#`` must not act as a separator.
+
+        Otherwise the trailing line would slip past the newline
+        rejection by masquerading as a comment.
+        """
+        with pytest.raises(SpecError):
+            _resolve("lfit@main\n# hidden")
+
+    def test_split_comment_ignores_newline_separator(self) -> None:
+        """``split_comment`` leaves a newline-separated ``#`` alone."""
+        spec, comment = split_comment("lfit@main\n# hidden")
+        assert spec == "lfit@main\n# hidden"
+        assert comment == ""
+
+
+# ---------------------------------------------------------------------
+# Local: the README `config` examples table
+# ---------------------------------------------------------------------
+
+_README_SHA = "ab7a9404c0f3da075243ca237b5fac12c98deaa5"
+_DEFAULT_CHAIN = (
+    ".github/harden-runner/onap/allow_list.txt",
+    ".github/harden-runner/allow_list.txt",
+)
+_CUSTOM_CHAIN = (
+    ".github/harden-runner/onap/custom_list.txt",
+    ".github/harden-runner/custom_list.txt",
+)
+_TEAM_CHAIN = (
+    ".github/harden-runner/onap/team_list.txt",
+    ".github/harden-runner/team_list.txt",
+)
+
+
+class TestReadmeExamples:
+    """Every row of the action README's ``config`` examples table.
+
+    The table assumes a workflow running in org ``onap``.
+    """
+
+    @pytest.mark.parametrize(
+        ("spec", "host_org", "repo", "ref", "candidates", "path_explicit"),
+        [
+            (
+                "lfreleng-actions@main",
+                "lfreleng-actions",
+                ".github",
+                "main",
+                _DEFAULT_CHAIN,
+                False,
+            ),
+            (
+                "lfit@v1.1.0",
+                "lfit",
+                ".github",
+                "v1.1.0",
+                _DEFAULT_CHAIN,
+                False,
+            ),
+            (
+                f"lfit@{_README_SHA} # v1.0.0",
+                "lfit",
+                ".github",
+                _README_SHA,
+                _DEFAULT_CHAIN,
+                False,
+            ),
+            (
+                "lfit//custom_list.txt@v1.1.0  # ONAP",
+                "lfit",
+                ".github",
+                "v1.1.0",
+                _CUSTOM_CHAIN,
+                False,
+            ),
+            (
+                f"lfit//@{_README_SHA}",
+                "lfit",
+                ".github",
+                _README_SHA,
+                _DEFAULT_CHAIN,
+                False,
+            ),
+            (
+                "lfit//configs/onap/list.txt@main",
+                "lfit",
+                ".github",
+                "main",
+                ("configs/onap/list.txt",),
+                True,
+            ),
+            (
+                "//team_list.txt@main",
+                "onap",
+                ".github",
+                "main",
+                _TEAM_CHAIN,
+                False,
+            ),
+        ],
+    )
+    def test_readme_row(
+        self,
+        spec: str,
+        host_org: str,
+        repo: str,
+        ref: str,
+        candidates: tuple[str, ...],
+        path_explicit: bool,
+    ) -> None:
+        """Each documented example resolves as documented."""
+        resolved = _resolve(spec, family="harden-runner")
+        assert resolved.host_org == host_org
+        assert resolved.repo == repo
+        assert resolved.ref == ref
+        assert resolved.candidates == candidates
+        assert resolved.path_explicit is path_explicit
+
+    def test_comment_is_ignored_for_resolution(self) -> None:
+        """The commented and uncommented forms resolve identically."""
+        with_comment = _resolve(
+            "lfit//custom_list.txt@v1.1.0  # ONAP", family="harden-runner"
+        )
+        without = _resolve(
+            "lfit//custom_list.txt@v1.1.0", family="harden-runner"
+        )
+        assert with_comment.comment == "ONAP"
+        assert without.comment == ""
+        assert with_comment.candidates == without.candidates
+        assert with_comment.ref == without.ref
+
+
+# ---------------------------------------------------------------------
+# Local: real values from the estate
+# ---------------------------------------------------------------------
+
+
+class TestEstateValues:
+    """Verified ``config`` values taken from live workflows."""
+
+    def test_shorthand_sha_pin(self) -> None:
+        """``@<sha>`` is the dominant form; it takes every default."""
+        resolved = resolve_spec(
+            ESTATE_SHORTHAND, workflow_org="lfreleng-actions"
+        )
+        assert resolved.host_org == "lfreleng-actions"
+        assert resolved.repo == ".github"
+        assert resolved.ref == "18d9c4446bea555d0783e850f6d295f844fe8f67"
+        assert resolved.candidates == (
+            ".github/harden-runner/lfreleng-actions/allow_list.txt",
+            ".github/harden-runner/allow_list.txt",
+        )
+        assert resolved.path_explicit is False
+        assert resolved.comment == ""
+
+    def test_shorthand_matches_fully_explicit_form(self) -> None:
+        """The explicit form names the shorthand's first candidate."""
+        shorthand = resolve_spec(
+            ESTATE_SHORTHAND, workflow_org="lfreleng-actions"
+        )
+        explicit = resolve_spec(
+            ESTATE_EXPLICIT, workflow_org="lfreleng-actions"
+        )
+        assert explicit.host_org == "lfreleng-actions"
+        assert explicit.repo == ".github"
+        assert explicit.ref == ESTATE_EXPLICIT_SHA
+        assert explicit.path_explicit is True
+        assert explicit.candidates == (shorthand.candidates[0],)
+
+    def test_yaml_quoted_value_with_surrounding_space(self) -> None:
+        """Surrounding whitespace is stripped before parsing."""
+        resolved = resolve_spec(
+            f"  {ESTATE_SHORTHAND}  ", workflow_org="lfreleng-actions"
+        )
+        assert resolved.ref == "18d9c4446bea555d0783e850f6d295f844fe8f67"
+
+    def test_branch_ref_resolves(self) -> None:
+        """A branch pin is valid grammar; currency is judged later."""
+        resolved = resolve_spec(
+            "lfreleng-actions@main", workflow_org="lfreleng-actions"
+        )
+        assert resolved.ref == "main"
+
+
+# ---------------------------------------------------------------------
+# Local: the family is always caller-supplied
+# ---------------------------------------------------------------------
+
+
+class TestFamilyIsCallerSupplied:
+    """The parser holds no per-action constants."""
+
+    def test_python_audit_family(self) -> None:
+        """``python-audit`` yields the sibling action's directories."""
+        resolved = resolve_spec(
+            ESTATE_SHORTHAND,
+            workflow_org="lfreleng-actions",
+            family="python-audit",
+        )
+        assert resolved.candidates == (
+            ".github/python-audit/lfreleng-actions/allow_list.txt",
+            ".github/python-audit/allow_list.txt",
+        )
+
+    def test_family_only_changes_the_directory(self) -> None:
+        """Everything but the directory is family-independent."""
+        harden = resolve_spec(
+            "lfit@main", workflow_org="onap", family="harden-runner"
+        )
+        audit = resolve_spec(
+            "lfit@main", workflow_org="onap", family="python-audit"
+        )
+        assert harden.host_org == audit.host_org
+        assert harden.repo == audit.repo
+        assert harden.ref == audit.ref
+        assert harden.candidates != audit.candidates
+
+    def test_explicit_path_ignores_the_family(self) -> None:
+        """An explicit path is not rewritten by the family."""
+        resolved = resolve_spec(
+            "lfit//configs/list.txt@main",
+            workflow_org="onap",
+            family="python-audit",
+        )
+        assert resolved.candidates == ("configs/list.txt",)
+
+    def test_default_family_is_harden_runner(self) -> None:
+        """Our own default serves the allow-list action."""
+        resolved = resolve_spec("lfit@main", workflow_org="onap")
+        assert resolved.candidates[0].startswith(".github/harden-runner/")
+
+
+# ---------------------------------------------------------------------
+# Local: raw component parsing
+# ---------------------------------------------------------------------
+
+
+class TestParseSpec:
+    """The raw component split, before defaults apply."""
+
+    def test_bare_double_slash_differs_from_no_subpath(self) -> None:
+        """Both resolve alike, but the raw parse keeps them distinct."""
+        bare = parse_spec("lfit//@main")
+        absent = parse_spec("lfit@main")
+        assert bare.has_subpath is True
+        assert bare.subpath == ""
+        assert absent.has_subpath is False
+        assert absent.subpath == ""
+
+    def test_omitted_ref_is_empty_not_head(self) -> None:
+        """``HEAD`` is a resolution default, not a parse result."""
+        assert parse_spec("lfit").ref == ""
+
+    def test_hash_without_leading_space_is_not_a_comment(self) -> None:
+        """``foo#bar`` is one token, so it reaches the validators."""
+        spec, comment = split_comment("lfit//a#b.txt@main")
+        assert spec == "lfit//a#b.txt@main"
+        assert comment == ""
+        with pytest.raises(SpecError):
+            _resolve("lfit//a#b.txt@main")
+
+
+# ---------------------------------------------------------------------
+# Local: render_spec
+# ---------------------------------------------------------------------
+
+_ROUND_TRIP_SPECS = [
+    "lfit",
+    "lfit@main",
+    "lfit@v1.1.0",
+    "lfit/special-repo//list.txt@main",
+    "lfit//custom_list.txt@v1.1.0",
+    "lfit//@main",
+    "lfit//",
+    "//team_list.txt@main",
+    "//",
+    "lfit//configs/onap/list.txt@main",
+    "lfit@HEAD",
+    ESTATE_SHORTHAND,
+    ESTATE_EXPLICIT,
+]
+
+
+class TestRenderSpecRoundTrip:
+    """Rendering a spec with its own ref reproduces its source form."""
+
+    @pytest.mark.parametrize("spec", _ROUND_TRIP_SPECS)
+    def test_round_trip_preserves_source_form(self, spec: str) -> None:
+        """Parse then render is the identity on the source form."""
+        resolved = _resolve(spec)
+        assert render_spec(resolved, ref=resolved.ref) == spec
+
+    @pytest.mark.parametrize("spec", _ROUND_TRIP_SPECS)
+    def test_round_trip_output_reparses_identically(self, spec: str) -> None:
+        """The rendered form resolves to the same coordinates."""
+        resolved = _resolve(spec)
+        reparsed = _resolve(render_spec(resolved, ref=resolved.ref))
+        assert reparsed == resolved
+
+    def test_round_trip_drops_the_trailing_comment(self) -> None:
+        """The source form excludes any in-scalar comment.
+
+        Comment rewriting belongs to the caller, which owns both the
+        in-scalar and the YAML comment positions.
+        """
+        resolved = _resolve("lfit@main  # v1.0.0")
+        assert resolved.comment == "v1.0.0"
+        assert render_spec(resolved, ref=resolved.ref) == "lfit@main"
+
+    def test_round_trip_normalises_surrounding_whitespace(self) -> None:
+        """Whitespace around the spec is not part of the source form."""
+        resolved = _resolve("  lfit@main  ")
+        assert render_spec(resolved, ref=resolved.ref) == "lfit@main"
+
+    def test_head_is_re_emitted_only_when_written(self) -> None:
+        """An omitted ref stays omitted; an explicit ``@HEAD`` stays.
+
+        Rendering ``HEAD`` onto a spec that named a different ref
+        therefore writes ``@HEAD`` rather than dropping the ref, which
+        would silently change the coordinate's meaning for a reader.
+        """
+        implicit = _resolve("lfit")
+        explicit = _resolve("lfit@HEAD")
+        assert render_spec(implicit, ref="HEAD") == "lfit"
+        assert render_spec(explicit, ref="HEAD") == "lfit@HEAD"
+        assert render_spec(_resolve("lfit@main"), ref="HEAD") == "lfit@HEAD"
+
+
+class TestRenderSpecRefBump:
+    """Rewriting the ref, which is what remediation needs."""
+
+    def test_bump_shorthand_sha(self) -> None:
+        """The dominant estate form bumps to a bare ``@<sha>``."""
+        resolved = resolve_spec(
+            ESTATE_SHORTHAND, workflow_org="lfreleng-actions"
+        )
+        assert (
+            render_spec(resolved, ref=ESTATE_EXPLICIT_SHA)
+            == f"@{ESTATE_EXPLICIT_SHA}"
+        )
+
+    def test_bump_explicit_path_keeps_the_path(self) -> None:
+        """Only the ref changes; the path survives untouched."""
+        resolved = resolve_spec(
+            ESTATE_EXPLICIT, workflow_org="lfreleng-actions"
+        )
+        rendered = render_spec(resolved, ref="18d9c4446bea555d0783e85")
+        assert rendered == (
+            "lfreleng-actions"
+            "//.github/harden-runner/lfreleng-actions/allow_list.txt"
+            "@18d9c4446bea555d0783e85"
+        )
+
+    def test_bump_adds_a_ref_the_author_omitted(self) -> None:
+        """Pinning an unpinned coordinate is a ref addition."""
+        assert render_spec(_resolve("lfit"), ref="v2.0.0") == "lfit@v2.0.0"
+
+    def test_bump_of_bare_double_slash(self) -> None:
+        """A bare ``//`` is preserved rather than normalised away."""
+        assert render_spec(_resolve("lfit//"), ref="v2") == "lfit//@v2"
+
+    def test_bump_preserves_an_omitted_org(self) -> None:
+        """The shorthand's empty source is not filled in on render."""
+        resolved = _resolve("//team_list.txt@main")
+        assert render_spec(resolved, ref="v2") == "//team_list.txt@v2"
+
+    @pytest.mark.parametrize(
+        "ref",
+        ["", "-badref", "/badref", "ref..dots", "ref@{0}", "bad ref"],
+    )
+    def test_invalid_target_ref_rejected(self, ref: str) -> None:
+        """A bad replacement ref never reaches a workflow file."""
+        resolved = _resolve("lfit@main")
+        with pytest.raises(SpecError):
+            render_spec(resolved, ref=ref)
+
+    def test_over_long_target_ref_rejected(self) -> None:
+        """The 255-character ceiling applies on render too."""
+        resolved = _resolve("lfit@main")
+        with pytest.raises(SpecError):
+            render_spec(resolved, ref="a" * 256)

--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -12,13 +12,20 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+    from typing import TypeAlias
 
     from rich.progress import Progress, TaskID
+
+    AutoFixResult: TypeAlias = tuple[
+        dict[Path, list[dict[str, str]]],
+        dict[str, int],
+        dict[str, list[dict[str, Any]]],
+    ]
 
 import pytest
 from typer.testing import CliRunner
@@ -127,6 +134,105 @@ def stub_validator_class(
             return validate(action_calls)
 
     return StubValidator
+
+
+def stub_auto_fixer_class(
+    fix: Callable[
+        [list[ValidationError], dict[Path, dict[int, ActionCall]], bool],
+        AutoFixResult,
+    ],
+) -> type[AutoFixer]:
+    """Build an auto-fixer class whose fixing step is replaced.
+
+    ``cli.py`` does ``from .auto_fix import AutoFixer`` at import time,
+    so patching ``gha_workflow_linter.auto_fix``'s attribute has no
+    effect on the CLI: the name has to be replaced where it is looked
+    up, ``gha_workflow_linter.cli.AutoFixer``. Left unpatched, the real
+    fixer runs, queries github.com and rewrites the workflow files the
+    test just wrote.
+
+    Subclassing the real fixer, rather than substituting a bare mock,
+    keeps construction and the async context manager genuine. Both are
+    inert -- they build an HTTP client and a Git client but issue no
+    request -- so the CLI's real setup and teardown path is exercised
+    while the one method that reaches the network is replaced.
+
+    The stub writes nothing to disk. The fixes it returns describe what
+    a real run would have rewritten, so callers must assert on what the
+    CLI does with them rather than on file contents; the rewriting
+    itself is covered by the tests that drive the real
+    :class:`AutoFixer` directly.
+
+    Args:
+        fix: Callable invoked with the validation errors, the scanner's
+            action calls and the ``check_for_updates`` flag, returning
+            the ``(fixes_by_file, redirect_stats,
+            stale_actions_summary)`` triple the CLI should see.
+
+    Returns:
+        A drop-in replacement for ``AutoFixer`` that performs no network
+        access and leaves the working tree untouched.
+    """
+
+    class StubAutoFixer(AutoFixer):
+        """Fixer reporting pre-computed changes, without network use."""
+
+        async def fix_validation_errors(
+            self,
+            errors: list[ValidationError],
+            all_action_calls: dict[Path, dict[int, ActionCall]],
+            check_for_updates: bool = False,
+        ) -> AutoFixResult:
+            """Return the fixes supplied by the enclosing factory."""
+            return fix(errors, all_action_calls, check_for_updates)
+
+    return StubAutoFixer
+
+
+class RecordedAutoFix:
+    """Auto-fix stub that records how the CLI invoked it.
+
+    A stubbed fixer writes nothing, and under ``--format json`` (which
+    forces quiet mode) the report of applied fixes is suppressed too, so
+    asserting on file contents or on the printed diff would only test
+    the stub. What remains genuinely observable is the exit code and the
+    arguments the CLI assembled for the fixer: which errors it
+    forwarded, which action calls it offered for update, and whether it
+    asked for latest versions. Recording those keeps the assertions on
+    production behaviour, and ``called`` fails loudly if the patch ever
+    stops taking effect.
+    """
+
+    def __init__(self, result: AutoFixResult) -> None:
+        """Store the triple to hand back when the CLI calls the fixer.
+
+        Args:
+            result: The ``(fixes_by_file, redirect_stats,
+                stale_actions_summary)`` triple to return.
+        """
+        self.result = result
+        self.called = False
+        self.errors: list[ValidationError] = []
+        self.action_calls: dict[Path, dict[int, ActionCall]] = {}
+        self.check_for_updates = False
+
+    @property
+    def action_call_count(self) -> int:
+        """Total number of action calls offered to the fixer."""
+        return sum(len(calls) for calls in self.action_calls.values())
+
+    def __call__(
+        self,
+        errors: list[ValidationError],
+        action_calls: dict[Path, dict[int, ActionCall]],
+        check_for_updates: bool,
+    ) -> AutoFixResult:
+        """Record the CLI's arguments and return the stored result."""
+        self.called = True
+        self.errors = errors
+        self.action_calls = action_calls
+        self.check_for_updates = check_for_updates
+        return self.result
 
 
 def iter_calls(
@@ -638,56 +744,59 @@ jobs:
             return errors
 
         # Mock git operations and the auto-fixer for this CLI test
+        # Report a fix for every flagged call, as a real --auto-latest
+        # run would. Line numbers match the ``uses:`` lines of the
+        # fixture, not the ``- name:`` lines above them.
+        expected_fixes: dict[Path, list[dict[str, str]]] = {
+            workflow_file: [
+                {
+                    "line_number": "10",
+                    "old_line": "uses: actions/checkout@invalid-branch",
+                    "new_line": "uses: actions/checkout@abc123",
+                },
+                {
+                    "line_number": "13",
+                    "old_line": "uses: actions/checkout@master",
+                    "new_line": "uses: actions/checkout@def456",
+                },
+                {
+                    "line_number": "16",
+                    "old_line": "uses: actions/setup-python@v4",
+                    "new_line": "uses: actions/setup-python@ghi789",
+                },
+                {
+                    "line_number": "19",
+                    "old_line": "uses: actions/setup-node@v3.8.1",
+                    "new_line": "uses: actions/setup-node@jkl012",
+                },
+                {
+                    "line_number": "22",
+                    "old_line": "uses: actions/upload-artifact@v2",
+                    "new_line": "uses: actions/upload-artifact@mno345",
+                },
+            ]
+        }
+        auto_fix = RecordedAutoFix(
+            (expected_fixes, {"actions_moved": 0, "calls_updated": 0}, {})
+        )
+
         with (
             patch(
                 "gha_workflow_linter.cli.ActionCallValidator",
                 stub_validator_class(mock_validate_calls),
             ),
             patch(
-                "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class,
+                "gha_workflow_linter.cli.AutoFixer",
+                stub_auto_fixer_class(auto_fix),
+            ),
         ):
-            mock_auto_fixer = AsyncMock()
-            mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                mock_auto_fixer
-            )
-
-            # Mock that it fixes all 5 issues
-            mock_auto_fixer.fix_validation_errors.return_value = (
-                {
-                    workflow_file: [
-                        {
-                            "line_number": "9",
-                            "old_line": "uses: actions/checkout@invalid-branch",
-                            "new_line": "uses: actions/checkout@abc123",
-                        },
-                        {
-                            "line_number": "12",
-                            "old_line": "uses: actions/checkout@master",
-                            "new_line": "uses: actions/checkout@def456",
-                        },
-                        {
-                            "line_number": "15",
-                            "old_line": "uses: actions/setup-python@v4",
-                            "new_line": "uses: actions/setup-python@ghi789",
-                        },
-                        {
-                            "line_number": "18",
-                            "old_line": "uses: actions/setup-node@v3.8.1",
-                            "new_line": "uses: actions/setup-node@jkl012",
-                        },
-                        {
-                            "line_number": "21",
-                            "old_line": "uses: actions/upload-artifact@v2",
-                            "new_line": "uses: actions/upload-artifact@mno345",
-                        },
-                    ]
-                },
-                {"actions_moved": 0, "calls_updated": 0},
-                {},
-            )
-
-            # Run CLI with require-pinned-sha (default is True)
+            # Run CLI with require-pinned-sha (default is True).
+            # --no-fail-on-error isolates the exit code to the fixer:
+            # the run can then only fail because the tree changed, so
+            # the exit code below tests that the CLI acted on the fixes
+            # it was handed. That validation errors alone also fail a
+            # run is covered by
+            # ``test_error_count_summary_with_pinned_sha_required``.
             result = runner.invoke(
                 app,
                 [
@@ -695,6 +804,7 @@ jobs:
                     str(temp_dir),
                     "--auto-fix",
                     "--auto-latest",
+                    "--no-fail-on-error",
                     "--validation-method",
                     "git",
                     "--format",
@@ -709,8 +819,19 @@ jobs:
             output_data = parse_json_output(result.stdout)
             assert output_data["validation_summary"]["total_errors"] == 5
 
-            # Verify the file was actually modified
-            assert workflow_file.read_text() != workflow_with_mixed_references
+            # With require_pinned_sha=True every non-SHA reference is an
+            # error, so all five reach the fixer, and --auto-latest asks
+            # it to move them to the latest versions.
+            assert auto_fix.called
+            assert len(auto_fix.errors) == 5
+            assert auto_fix.action_call_count == 5
+            assert auto_fix.check_for_updates is True
+
+            # The fixer is stubbed, so the workflow on disk is untouched:
+            # rewriting is covered by
+            # ``test_auto_fix_with_pinned_sha_required``, which drives
+            # the real AutoFixer.
+            assert workflow_file.read_text() == workflow_with_mixed_references
 
     def test_cli_auto_fix_with_pinned_sha_not_required(
         self,
@@ -750,55 +871,52 @@ validation_method: git
                 if call.reference == "invalid-branch"
             ]
 
+        # With auto_latest enabled a real run fixes the invalid
+        # reference and updates the other four calls to their latest
+        # versions, so the fixer reports five changes for one file.
+        expected_fixes: dict[Path, list[dict[str, str]]] = {
+            workflow_file: [
+                {
+                    "line_number": "10",
+                    "old_line": "uses: actions/checkout@invalid-branch",
+                    "new_line": "uses: actions/checkout@abc123",
+                },
+                {
+                    "line_number": "13",
+                    "old_line": "uses: actions/checkout@master",
+                    "new_line": "uses: actions/checkout@def456",
+                },
+                {
+                    "line_number": "16",
+                    "old_line": "uses: actions/setup-python@v4",
+                    "new_line": "uses: actions/setup-python@ghi789",
+                },
+                {
+                    "line_number": "19",
+                    "old_line": "uses: actions/setup-node@v3.8.1",
+                    "new_line": "uses: actions/setup-node@jkl012",
+                },
+                {
+                    "line_number": "22",
+                    "old_line": "uses: actions/upload-artifact@v2",
+                    "new_line": "uses: actions/upload-artifact@mno345",
+                },
+            ]
+        }
+        auto_fix = RecordedAutoFix(
+            (expected_fixes, {"actions_moved": 0, "calls_updated": 0}, {})
+        )
+
         with (
             patch(
                 "gha_workflow_linter.cli.ActionCallValidator",
                 stub_validator_class(mock_validate_calls),
             ),
             patch(
-                "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class,
+                "gha_workflow_linter.cli.AutoFixer",
+                stub_auto_fixer_class(auto_fix),
+            ),
         ):
-            mock_auto_fixer = AsyncMock()
-            mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                mock_auto_fixer
-            )
-
-            # Mock that it fixes all 5 issues (1 invalid ref + 4 version updates due to auto_latest)
-            mock_auto_fixer.fix_validation_errors.return_value = (
-                {
-                    workflow_file: [
-                        {
-                            "line_number": "9",
-                            "old_line": "uses: actions/checkout@invalid-branch",
-                            "new_line": "uses: actions/checkout@abc123",
-                        },
-                        {
-                            "line_number": "12",
-                            "old_line": "uses: actions/checkout@master",
-                            "new_line": "uses: actions/checkout@def456",
-                        },
-                        {
-                            "line_number": "15",
-                            "old_line": "uses: actions/setup-python@v4",
-                            "new_line": "uses: actions/setup-python@ghi789",
-                        },
-                        {
-                            "line_number": "18",
-                            "old_line": "uses: actions/setup-node@v3.8.1",
-                            "new_line": "uses: actions/setup-node@jkl012",
-                        },
-                        {
-                            "line_number": "21",
-                            "old_line": "uses: actions/upload-artifact@v2",
-                            "new_line": "uses: actions/upload-artifact@mno345",
-                        },
-                    ]
-                },
-                {"actions_moved": 0, "calls_updated": 0},
-                {},
-            )
-
             result = runner.invoke(
                 app,
                 [
@@ -806,23 +924,33 @@ validation_method: git
                     str(temp_dir),
                     "--config",
                     str(config_file),
+                    "--no-fail-on-error",
                     "--format",
                     "json",
                 ],
             )
 
-            # Should complete successfully
-            if result.exit_code in (0, 1):
-                # Parse JSON output for structured validation
-                output_data = parse_json_output(result.stdout)
-                # Only 1 validation error (require_pinned_sha=False, so tags/branches are valid)
-                # But auto_latest=True updates all actions to latest versions
-                assert output_data["validation_summary"]["total_errors"] >= 1
+            # --no-fail-on-error leaves the auto-fixer as the only
+            # source of a non-zero exit code, so this asserts that the
+            # CLI acted on the five fixes it was handed.
+            assert result.exit_code == 1
 
-                # Verify the file was modified
-                assert (
-                    workflow_file.read_text() != workflow_with_mixed_references
-                )
+            # Parse JSON output for structured validation
+            output_data = parse_json_output(result.stdout)
+            # Only 1 validation error (require_pinned_sha=False, so
+            # tags and branches are valid on their own).
+            assert output_data["validation_summary"]["total_errors"] == 1
+
+            # That single error is all the fixer is asked to repair, but
+            # auto_latest still offers it every action call in the tree
+            # so the remaining four can be moved to latest versions.
+            assert auto_fix.called
+            assert len(auto_fix.errors) == 1
+            assert auto_fix.action_call_count == 5
+            assert auto_fix.check_for_updates is True
+
+            # The fixer is stubbed, so nothing is rewritten on disk.
+            assert workflow_file.read_text() == workflow_with_mixed_references
 
     def test_error_count_summary_with_pinned_sha_required(
         self,
@@ -869,25 +997,22 @@ validation_method: git
                         )
             return errors
 
+        # Nothing is fixable in this scenario: the test is about the
+        # error counts the validation summary reports.
+        auto_fix = RecordedAutoFix(
+            ({}, {"actions_moved": 0, "calls_updated": 0}, {})
+        )
+
         with (
             patch(
                 "gha_workflow_linter.cli.ActionCallValidator",
                 stub_validator_class(mock_validate_calls),
             ),
             patch(
-                "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class,
+                "gha_workflow_linter.cli.AutoFixer",
+                stub_auto_fixer_class(auto_fix),
+            ),
         ):
-            mock_auto_fixer = AsyncMock()
-            mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                mock_auto_fixer
-            )
-            mock_auto_fixer.fix_validation_errors.return_value = (
-                {},
-                {"actions_moved": 0, "calls_updated": 0},
-                {},
-            )
-
             result = runner.invoke(
                 app,
                 [
@@ -901,16 +1026,24 @@ validation_method: git
                 ],
             )
 
-            if result.exit_code in (0, 1):
-                # Parse JSON output for structured validation
-                output_data = parse_json_output(result.stdout)
-                assert output_data["validation_summary"]["total_errors"] == 5
-                assert (
-                    output_data["validation_summary"]["invalid_references"] == 1
-                )
-                assert (
-                    output_data["validation_summary"]["not_pinned_to_sha"] == 4
-                )
+            # No fixes were applied, so the exit code comes from the
+            # five outstanding validation errors alone.
+            assert result.exit_code == 1
+
+            # Parse JSON output for structured validation
+            output_data = parse_json_output(result.stdout)
+            assert output_data["validation_summary"]["total_errors"] == 5
+            assert output_data["validation_summary"]["invalid_references"] == 1
+            assert output_data["validation_summary"]["not_pinned_to_sha"] == 4
+
+            # All five errors reach the fixer, but without --auto-latest
+            # it is not asked to chase newer versions.
+            assert auto_fix.called
+            assert len(auto_fix.errors) == 5
+            assert auto_fix.check_for_updates is False
+
+            # The fixer reported no changes, so the workflow is intact.
+            assert workflow_file.read_text() == workflow_with_mixed_references
 
     def test_error_count_summary_with_pinned_sha_not_required(
         self,
@@ -1335,25 +1468,21 @@ jobs:
                 and call.reference in ["v3", "v4"]
             ]
 
+        # The scenario is about what gets flagged, not about fixing.
+        auto_fix = RecordedAutoFix(
+            ({}, {"actions_moved": 0, "calls_updated": 0}, {})
+        )
+
         with (
             patch(
                 "gha_workflow_linter.cli.ActionCallValidator",
                 stub_validator_class(mock_validate_calls),
             ),
             patch(
-                "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class,
+                "gha_workflow_linter.cli.AutoFixer",
+                stub_auto_fixer_class(auto_fix),
+            ),
         ):
-            mock_auto_fixer = AsyncMock()
-            mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                mock_auto_fixer
-            )
-            mock_auto_fixer.fix_validation_errors.return_value = (
-                {},
-                {"actions_moved": 0, "calls_updated": 0},
-                {},
-            )
-
             result = runner.invoke(
                 app,
                 [
@@ -1372,6 +1501,15 @@ jobs:
                 and "validation errors" in result.stdout
             )
             assert "2 actions not pinned to SHA" in result.stdout
+            # Only the two action calls are errors; the fixer is still
+            # offered the remote reusable workflow call so --auto-latest
+            # could update it, but never the local ``./`` call.
+            assert auto_fix.called
+            assert len(auto_fix.errors) == 2
+            assert auto_fix.action_call_count == 3
+            # The fixer reported no changes, so the workflow is intact,
+            # reusable and local calls included.
+            assert workflow_file.read_text() == workflow_content
 
     def test_auto_fix_with_large_workflow_file(self, temp_dir: Path) -> None:
         """Test auto-fix performance with large workflow files."""
@@ -1411,25 +1549,21 @@ jobs:
                 for file_path, call in iter_calls(action_calls)
             ]
 
+        # The scenario is about scale, not about fixing.
+        auto_fix = RecordedAutoFix(
+            ({}, {"actions_moved": 0, "calls_updated": 0}, {})
+        )
+
         with (
             patch(
                 "gha_workflow_linter.cli.ActionCallValidator",
                 stub_validator_class(mock_validate_calls),
             ),
             patch(
-                "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class,
+                "gha_workflow_linter.cli.AutoFixer",
+                stub_auto_fixer_class(auto_fix),
+            ),
         ):
-            mock_auto_fixer = AsyncMock()
-            mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                mock_auto_fixer
-            )
-            mock_auto_fixer.fix_validation_errors.return_value = (
-                {},
-                {"actions_moved": 0, "calls_updated": 0},
-                {},
-            )
-
             result = runner.invoke(
                 app,
                 [
@@ -1448,6 +1582,13 @@ jobs:
                 and "validation errors" in result.stdout
             )
             assert "50 actions not pinned to SHA" in result.stdout
+            # Every one of the 50 calls is carried through to the fixer
+            # in a single batch.
+            assert auto_fix.called
+            assert len(auto_fix.errors) == 50
+            assert auto_fix.action_call_count == 50
+            # The fixer reported no changes, so the workflow is intact.
+            assert workflow_file.read_text() == workflow_content
 
     def test_auto_fix_with_syntax_errors(self, temp_dir: Path) -> None:
         """Test auto-fix behavior with workflows that have YAML syntax errors."""
@@ -1629,38 +1770,31 @@ jobs:
                 for file_path, call in iter_calls(action_calls)
             ]
 
+        # Mock fixes for all files
+        expected_fixes: dict[Path, list[dict[str, str]]] = {
+            workflow_dir / "test.yaml": [
+                {
+                    "line_number": "7",
+                    "old_line": "uses: actions/checkout@v3",
+                    "new_line": "uses: actions/checkout@sha123",
+                }
+            ]
+            for workflow_dir in dirs
+        }
+        auto_fix = RecordedAutoFix(
+            (expected_fixes, {"actions_moved": 0, "calls_updated": 0}, {})
+        )
+
         with (
             patch(
                 "gha_workflow_linter.cli.ActionCallValidator",
                 stub_validator_class(mock_validate_calls),
             ),
             patch(
-                "gha_workflow_linter.auto_fix.AutoFixer"
-            ) as mock_auto_fixer_class,
+                "gha_workflow_linter.cli.AutoFixer",
+                stub_auto_fixer_class(auto_fix),
+            ),
         ):
-            mock_auto_fixer = AsyncMock()
-            mock_auto_fixer_class.return_value.__aenter__.return_value = (
-                mock_auto_fixer
-            )
-
-            # Mock fixes for all files
-            fixed_files = {}
-            for workflow_dir in dirs:
-                workflow_file = workflow_dir / "test.yaml"
-                fixed_files[workflow_file] = [
-                    {
-                        "line_number": "7",
-                        "old_line": "uses: actions/checkout@v3",
-                        "new_line": "uses: actions/checkout@sha123",
-                    }
-                ]
-
-            mock_auto_fixer.fix_validation_errors.return_value = (
-                fixed_files,
-                {"actions_moved": 0, "calls_updated": 0},
-                {},
-            )
-
             result = runner.invoke(
                 app,
                 [
@@ -1681,6 +1815,17 @@ jobs:
             )
             assert "Updated 3 workflow call(s) in 3 file(s)" in result.stdout
             assert result.exit_code == 1
+            # One call per directory reaches the fixer, so the count
+            # above cannot come from one file being scanned three times.
+            assert auto_fix.called
+            assert len(auto_fix.errors) == 3
+            assert set(auto_fix.action_calls) == set(expected_fixes)
+            # Every workflow directory is named in the report.
+            for workflow_path in expected_fixes:
+                assert str(workflow_path.relative_to(temp_dir)) in result.stdout
+                # The fixer is stubbed and writes nothing, so the
+                # original references survive on disk.
+                assert "actions/checkout@v3" in workflow_path.read_text()
 
 
 class TestYAMLStructurePreservation:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from gha_workflow_linter.cli import (
 from gha_workflow_linter.models import (
     ActionCall,
     ActionCallType,
+    Config,
     LogLevel,
     ReferenceType,
     ValidationError,
@@ -191,7 +192,7 @@ class TestCLICommands:
     ) -> None:
         """Test basic lint command execution."""
         # Setup mocks
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -273,7 +274,7 @@ class TestCLICommands:
         self, mock_scanner: Mock, mock_config_manager: Mock
     ) -> None:
         """Test lint command with scanner error."""
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.side_effect = OSError(
             "Permission denied"
         )
@@ -294,7 +295,7 @@ class TestCLICommands:
         mock_config_manager: Mock,
     ) -> None:
         """Test lint command with GitHub token from environment."""
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -331,7 +332,7 @@ class TestCLICommands:
         mock_config_manager: Mock,
     ) -> None:
         """Test lint command with GitHub token from CLI flag."""
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -367,7 +368,7 @@ class TestCLICommands:
         mock_config_manager: Mock,
     ) -> None:
         """Test lint command with JSON output format."""
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {
             Path("workflow.yml"): {1: Mock()}
         }
@@ -555,7 +556,7 @@ class TestCLICommands:
         mock_config_manager: Mock,
     ) -> None:
         """Test lint command with cache TTL option."""
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -616,7 +617,7 @@ class TestCLICommands:
         mock_config_manager: Mock,
     ) -> None:
         """Test lint command with --no-require-pinned-sha flag."""
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -653,7 +654,7 @@ class TestCLICommands:
     ) -> None:
         """Test lint command with --no-fail-on-error flag."""
         # Setup mocks to return validation errors
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {
             Path("workflow.yml"): {1: Mock()}
         }

--- a/tests/test_cli_default_lint.py
+++ b/tests/test_cli_default_lint.py
@@ -14,7 +14,7 @@ from unittest.mock import Mock, patch
 from typer.testing import CliRunner
 
 from gha_workflow_linter.cli import _preprocess_args_for_default_command, app
-from gha_workflow_linter.models import ValidationMethod
+from gha_workflow_linter.models import Config, ValidationMethod
 
 
 class TestCLIDefaultLint:
@@ -42,7 +42,7 @@ class TestCLIDefaultLint:
     ) -> None:
         """Test that running without subcommand invokes lint."""
         # Setup mocks
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -86,7 +86,7 @@ class TestCLIDefaultLint:
     ) -> None:
         """Test that flags work without explicit 'lint' subcommand."""
         # Setup mocks
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -353,7 +353,7 @@ class TestCLIDefaultLint:
     ) -> None:
         """Test that --format json works without explicit 'lint' subcommand."""
         # Setup mocks
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -390,7 +390,7 @@ class TestCLIDefaultLint:
         self, mock_config_manager: Mock
     ) -> None:
         """Test that --config flag works without explicit 'lint' subcommand."""
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create a config file
@@ -433,7 +433,7 @@ class TestCLIDefaultLint:
     ) -> None:
         """Test that --files flag works without explicit 'lint' subcommand."""
         # Setup mocks
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -483,7 +483,7 @@ class TestCLIDefaultLint:
     ) -> None:
         """Test that default path (current directory) works without explicit 'lint' subcommand."""
         # Setup mocks
-        mock_config_manager.return_value.load_config.return_value = Mock()
+        mock_config_manager.return_value.load_config.return_value = Config()
         mock_scanner.return_value.scan_directory.return_value = {}
         mock_scanner.return_value.get_scan_summary.return_value = {
             "total_files": 0,
@@ -522,7 +522,7 @@ class TestCLIDefaultLint:
             ) as mock_validator,
             patch("gha_workflow_linter.cli.ValidationCache") as mock_cache,
         ):
-            mock_config.return_value.load_config.return_value = Mock()
+            mock_config.return_value.load_config.return_value = Config()
             mock_scanner.return_value.scan_directory.return_value = {}
             mock_scanner.return_value.get_scan_summary.return_value = {
                 "total_files": 0,

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -14,11 +14,13 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest import mock
 
 import pytest
 
 from gha_workflow_linter import exit_codes
 from gha_workflow_linter.allow_list_scanner import CommentPosition, QuoteStyle
+from gha_workflow_linter.cache import ValidationCache
 from gha_workflow_linter.cli import (
     _AutoFixOutcome,
     _determine_exit_code,
@@ -28,6 +30,7 @@ from gha_workflow_linter.cli import (
 from gha_workflow_linter.models import (
     ActionCall,
     ActionCallType,
+    AllowListConfig,
     Category,
     CLIOptions,
     Config,
@@ -562,3 +565,92 @@ class TestAllowListExitCodes:
             config,
         )
         assert code == exit_codes.ALLOW_LIST_STALE
+
+
+class TestAllowListStageFailure:
+    """A broken check must not silently pass under --verify-allow-list.
+
+    Regression tests for the review finding that _run_allow_list_stage
+    swallowed every exception and returned None, which made
+    _determine_exit_code skip the allow-list branch entirely -- so
+    enforcement degraded to "pass" precisely when the check could not
+    run, contradicting the documented guarantee.
+    """
+
+    @staticmethod
+    def _stage(
+        *, verify: bool, quiet: bool = True
+    ) -> tuple[AllowListOutcome | None, Config]:
+        from gha_workflow_linter.cli import _run_allow_list_stage
+
+        config = Config()
+        config.allow_list.verify = verify
+        cache = ValidationCache(config.cache)
+        options = _options(quiet=quiet, path=Path("/nonexistent-path-xyz"))
+
+        with mock.patch(
+            "gha_workflow_linter.cli.AllowListChecker",
+            side_effect=RuntimeError("boom"),
+        ):
+            return _run_allow_list_stage(config, options, cache), config
+
+    def test_advisory_mode_skips_on_failure(self) -> None:
+        outcome, _ = self._stage(verify=False)
+        assert outcome is None
+
+    def test_verify_mode_reports_failure(self) -> None:
+        outcome, _ = self._stage(verify=True)
+        assert outcome is not None
+        assert outcome.unresolved
+
+    def test_verify_mode_exits_unresolved_on_failure(self) -> None:
+        """The whole point: a broken check fails, it does not pass."""
+        outcome, config = self._stage(verify=True)
+        code = _exit_code(
+            _options(), _validation(), _autofix(), outcome, config
+        )
+        assert code == exit_codes.ALLOW_LIST_UNRESOLVED
+
+    def test_advisory_mode_exits_success_on_failure(self) -> None:
+        outcome, config = self._stage(verify=False)
+        code = _exit_code(
+            _options(), _validation(), _autofix(), outcome, config
+        )
+        assert code == exit_codes.SUCCESS
+
+
+class TestShowSuppressedIsConfigDriven:
+    """--show-suppressed must be settable from a config file.
+
+    Rendering previously read options.show_suppressed, so a config-file
+    setting had no effect unless the CLI flag was also passed.
+    """
+
+    def test_cli_flag_reaches_config(self) -> None:
+        from gha_workflow_linter.cli import _apply_cli_overrides
+
+        config = Config()
+        _apply_cli_overrides(config, _options(show_suppressed=True), None)
+        assert config.allow_list.show_suppressed is True
+
+    def test_config_value_survives_absent_flag(self) -> None:
+        from gha_workflow_linter.cli import _apply_cli_overrides
+
+        config = Config()
+        config.allow_list.show_suppressed = True
+        _apply_cli_overrides(config, _options(), None)
+        assert config.allow_list.show_suppressed is True
+
+
+class TestNoDeadConfigKnobs:
+    """Config must not advertise behaviour that does nothing.
+
+    Remediation lands in a later phase; until something implements it,
+    an 'update' knob would mislead users and downstream tooling.
+    """
+
+    def test_allow_list_config_has_no_update_knob(self) -> None:
+        assert "update" not in AllowListConfig.model_fields
+
+    def test_cli_options_have_no_update_knob(self) -> None:
+        assert "update_allow_list" not in CLIOptions.model_fields

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -12,6 +12,7 @@ about the same repository state.
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest import mock
@@ -442,7 +443,9 @@ def _allow_list_outcome(
     """Build an outcome with the given failure shape."""
     from gha_workflow_linter.allow_list_check import AllowListOutcome as _O
 
-    findings = [_stale_finding() for _ in range(unsuppressed)]
+    # Distinct line numbers: findings are keyed by (file, line), so
+    # identical pins would collapse into one for fix tracking.
+    findings = [_stale_finding(line=n + 1) for n in range(unsuppressed)]
     return _O(
         findings=findings,
         hosts={},
@@ -454,8 +457,8 @@ def _allow_list_outcome(
     )
 
 
-def _stale_finding() -> Any:
-    """A minimal unsuppressed STALE finding."""
+def _stale_finding(*, line: int = 1) -> Any:
+    """A minimal unsuppressed STALE finding at the given line."""
     from gha_workflow_linter.allow_list_check import AllowListFinding
     from gha_workflow_linter.allow_list_scanner import AllowListPin
     from gha_workflow_linter.allow_list_spec import resolve_spec
@@ -463,7 +466,7 @@ def _stale_finding() -> Any:
 
     pin = AllowListPin(
         file_path=Path(".github/workflows/ci.yaml"),
-        line_number=1,
+        line_number=line,
         column=0,
         key_path=("jobs", "b", "steps", "0", "with", "config"),
         raw_line="        config: '@18d9c444'  # v0.1.1",
@@ -642,15 +645,74 @@ class TestShowSuppressedIsConfigDriven:
         assert config.allow_list.show_suppressed is True
 
 
-class TestNoDeadConfigKnobs:
-    """Config must not advertise behaviour that does nothing.
+class TestAllowListRemediationExitCodes:
+    """--update-allow-list changes files, so the caller must notice."""
 
-    Remediation lands in a later phase; until something implements it,
-    an 'update' knob would mislead users and downstream tooling.
-    """
+    @staticmethod
+    def _fixed(outcome: AllowListOutcome) -> AllowListOutcome:
+        """Mark every finding in the outcome as rewritten."""
+        return dataclasses.replace(
+            outcome,
+            fixed_lines=frozenset(
+                (str(f.pin.file_path), f.pin.line_number)
+                for f in outcome.findings
+            ),
+        )
 
-    def test_allow_list_config_has_no_update_knob(self) -> None:
-        assert "update" not in AllowListConfig.model_fields
+    def test_files_changed_fails_like_the_action_fixer(self) -> None:
+        outcome = self._fixed(_allow_list_outcome(unsuppressed=2))
+        code = _exit_code(
+            _options(), _validation(), _autofix(), outcome, Config()
+        )
+        assert code == exit_codes.DEFECTS_FOUND
 
-    def test_cli_options_have_no_update_knob(self) -> None:
-        assert "update_allow_list" not in CLIOptions.model_fields
+    def test_fixed_findings_do_not_also_fail_verification(self) -> None:
+        """Everything repaired means nothing left to enforce against."""
+        config = Config()
+        config.allow_list.verify = True
+        outcome = self._fixed(_allow_list_outcome(unsuppressed=2))
+
+        code = _exit_code(
+            _options(), _validation(), _autofix(), outcome, config
+        )
+
+        assert code == exit_codes.DEFECTS_FOUND
+        assert not outcome.outstanding
+
+    def test_unfixable_findings_still_fail_verification(self) -> None:
+        config = Config()
+        config.allow_list.verify = True
+        # Two findings, only the first rewritten.
+        outcome = _allow_list_outcome(unsuppressed=2)
+        outcome = dataclasses.replace(
+            outcome,
+            fixed_lines=frozenset(
+                {
+                    (
+                        str(outcome.findings[0].pin.file_path),
+                        outcome.findings[0].pin.line_number,
+                    )
+                }
+            ),
+        )
+
+        code = _exit_code(
+            _options(), _validation(), _autofix(), outcome, config
+        )
+
+        assert code == exit_codes.ALLOW_LIST_STALE
+
+    def test_nothing_fixed_is_success(self) -> None:
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(),
+            _allow_list_outcome(),
+            Config(),
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_update_knob_exists_now_that_it_works(self) -> None:
+        """The inverse of the earlier no-dead-knobs guard."""
+        assert "update" in AllowListConfig.model_fields
+        assert "update_allow_list" in CLIOptions.model_fields

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -13,11 +13,12 @@ about the same repository state.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from gha_workflow_linter import exit_codes
+from gha_workflow_linter.allow_list_scanner import CommentPosition, QuoteStyle
 from gha_workflow_linter.cli import (
     _AutoFixOutcome,
     _determine_exit_code,
@@ -37,6 +38,9 @@ from gha_workflow_linter.models import (
     result_category,
 )
 from gha_workflow_linter.validator import ActionCallValidator
+
+if TYPE_CHECKING:
+    from gha_workflow_linter.allow_list_check import AllowListOutcome
 
 
 class TestExitCodeConstants:
@@ -247,13 +251,26 @@ def _autofix(
     )
 
 
+def _exit_code(
+    options: CLIOptions,
+    validation: _ValidationOutcome,
+    autofix: _AutoFixOutcome,
+    allow_list: AllowListOutcome | None = None,
+    config: Config | None = None,
+) -> int:
+    """Call _determine_exit_code with a default configuration."""
+    return _determine_exit_code(
+        options, validation, autofix, config or Config(), allow_list
+    )
+
+
 class TestDetermineExitCode:
     def test_clean_run(self) -> None:
-        code = _determine_exit_code(_options(), _validation(), _autofix())
+        code = _exit_code(_options(), _validation(), _autofix())
         assert code == exit_codes.SUCCESS
 
     def test_validation_errors_fail(self) -> None:
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(),
             _validation([_validation_error()]),
             _autofix(),
@@ -261,7 +278,7 @@ class TestDetermineExitCode:
         assert code == exit_codes.DEFECTS_FOUND
 
     def test_no_fail_on_error_suppresses_defects(self) -> None:
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(fail_on_error=False),
             _validation([_validation_error()]),
             _autofix(),
@@ -269,7 +286,7 @@ class TestDetermineExitCode:
         assert code == exit_codes.SUCCESS
 
     def test_test_references_do_not_fail(self) -> None:
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(),
             _validation([_validation_error(comment="# v4 testing")]),
             _autofix(),
@@ -282,7 +299,7 @@ class TestDetermineExitCode:
                 {"line_number": "1", "old_line": "x", "new_line": "y"}
             ]
         }
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(),
             _validation(),
             _autofix(fixed_files=fixed),
@@ -291,7 +308,7 @@ class TestDetermineExitCode:
 
     def test_skipped_only_fixes_do_not_fail(self) -> None:
         fixed = {Path("a.yaml"): [{"line_number": "1", "skipped": "true"}]}
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(),
             _validation(),
             _autofix(fixed_files=fixed),
@@ -305,7 +322,7 @@ class TestOutdatedActions:
     STALE = {"build.yaml": [{"line": 3, "action": "actions/checkout"}]}
 
     def test_outdated_advisory_by_default(self) -> None:
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(),
             _validation(),
             _autofix(stale=self.STALE),
@@ -313,7 +330,7 @@ class TestOutdatedActions:
         assert code == exit_codes.SUCCESS
 
     def test_outdated_fails_under_verify_actions(self) -> None:
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(verify_actions=True),
             _validation(),
             _autofix(stale=self.STALE),
@@ -321,7 +338,7 @@ class TestOutdatedActions:
         assert code == exit_codes.ACTIONS_OUTDATED
 
     def test_verify_actions_clean(self) -> None:
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(verify_actions=True),
             _validation(),
             _autofix(),
@@ -333,7 +350,7 @@ class TestOutdatedActions:
 
     def test_outdated_outranks_defects(self) -> None:
         """A specifically-requested condition is not masked by code 1."""
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(verify_actions=True),
             _validation([_validation_error()]),
             _autofix(stale=self.STALE),
@@ -355,7 +372,7 @@ class TestPresentationDoesNotAffectExitCode:
 
     def test_defect_not_masked_by_outdated_actions(self) -> None:
         """The core bug: a real error alongside an outdated action."""
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(),
             _validation([_validation_error()]),
             _autofix(stale=self.STALE),
@@ -368,7 +385,7 @@ class TestPresentationDoesNotAffectExitCode:
                 {"line_number": "1", "old_line": "x", "new_line": "y"}
             ]
         }
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(),
             _validation(),
             _autofix(fixed_files=fixed, stale=self.STALE),
@@ -389,7 +406,7 @@ class TestPresentationDoesNotAffectExitCode:
         self, presentation: dict[str, object]
     ) -> None:
         """lint, --quiet and --format json must agree on the code."""
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(**presentation),
             _validation([_validation_error()]),
             _autofix(stale=self.STALE),
@@ -408,9 +425,140 @@ class TestPresentationDoesNotAffectExitCode:
     def test_clean_run_agrees_across_presentation(
         self, presentation: dict[str, object]
     ) -> None:
-        code = _determine_exit_code(
+        code = _exit_code(
             _options(**presentation),
             _validation(),
             _autofix(stale=self.STALE),
         )
         assert code == exit_codes.SUCCESS
+
+
+def _allow_list_outcome(
+    *, unsuppressed: int = 0, unresolved: bool = False
+) -> AllowListOutcome:
+    """Build an outcome with the given failure shape."""
+    from gha_workflow_linter.allow_list_check import AllowListOutcome as _O
+
+    findings = [_stale_finding() for _ in range(unsuppressed)]
+    return _O(
+        findings=findings,
+        hosts={},
+        unresolved={"lfreleng-actions/.github": "no releases"}
+        if unresolved
+        else {},
+        suppressed_count=0,
+        checked=True,
+    )
+
+
+def _stale_finding() -> Any:
+    """A minimal unsuppressed STALE finding."""
+    from gha_workflow_linter.allow_list_check import AllowListFinding
+    from gha_workflow_linter.allow_list_scanner import AllowListPin
+    from gha_workflow_linter.allow_list_spec import resolve_spec
+    from gha_workflow_linter.models import AllowListFindingKind
+
+    pin = AllowListPin(
+        file_path=Path(".github/workflows/ci.yaml"),
+        line_number=1,
+        column=0,
+        key_path=("jobs", "b", "steps", "0", "with", "config"),
+        raw_line="        config: '@18d9c444'  # v0.1.1",
+        raw_value="@18d9c4446bea555d0783e850f6d295f844fe8f67",
+        quote_style=QuoteStyle.SINGLE,
+        comment_position=CommentPosition.YAML,
+        version_comment="v0.1.1",
+        directives=frozenset(),
+        suppressed_by=None,
+        suppression_reason=None,
+        spec=resolve_spec(
+            "@18d9c4446bea555d0783e850f6d295f844fe8f67",
+            workflow_org="lfreleng-actions",
+        ),
+        auto_fixable=True,
+    )
+    return AllowListFinding(
+        pin=pin,
+        kind=AllowListFindingKind.STALE,
+        severity=Severity.WARNING,
+        message="stale",
+        current_sha="18d9c4446bea555d0783e850f6d295f844fe8f67",
+        target_sha="bf6642f68d58c1b81bbe993e676d6cc339ac3654",
+        target_version="v0.12.2",
+        suppressed=False,
+    )
+
+
+class TestAllowListExitCodes:
+    """Allow-list findings are advisory unless --verify-allow-list."""
+
+    def test_stale_pins_advisory_by_default(self) -> None:
+        config = Config()
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(),
+            _allow_list_outcome(unsuppressed=3),
+            config,
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_stale_pins_fail_under_verify(self) -> None:
+        config = Config()
+        config.allow_list.verify = True
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(),
+            _allow_list_outcome(unsuppressed=3),
+            config,
+        )
+        assert code == exit_codes.ALLOW_LIST_STALE
+
+    def test_clean_run_under_verify(self) -> None:
+        config = Config()
+        config.allow_list.verify = True
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(),
+            _allow_list_outcome(),
+            config,
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_unresolved_outranks_stale(self) -> None:
+        """An unresolved check must never look like a clean-or-stale result."""
+        config = Config()
+        config.allow_list.verify = True
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(),
+            _allow_list_outcome(unsuppressed=3, unresolved=True),
+            config,
+        )
+        assert code == exit_codes.ALLOW_LIST_UNRESOLVED
+
+    def test_unresolved_advisory_without_verify(self) -> None:
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(),
+            _allow_list_outcome(unresolved=True),
+            Config(),
+        )
+        assert code == exit_codes.SUCCESS
+
+    def test_stale_outranks_generic_defects(self) -> None:
+        """A specifically requested condition is not masked by code 1."""
+        config = Config()
+        config.allow_list.verify = True
+        code = _exit_code(
+            _options(),
+            _validation([_validation_error()]),
+            _autofix(),
+            _allow_list_outcome(unsuppressed=1),
+            config,
+        )
+        assert code == exit_codes.ALLOW_LIST_STALE

--- a/tests/test_scanner_repository_boundaries.py
+++ b/tests/test_scanner_repository_boundaries.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests that scanning stops at nested repository boundaries.
+
+Git worktrees, submodules and vendored clones each place a ``.git`` entry
+at their own root. Anything beneath one belongs to a different
+repository, or to a second checkout of this one, so its workflows are not
+the scanned repository's concern.
+
+Without this, a repository keeping worktrees under ``.worktrees/``
+reported every finding several times over -- once per checked-out branch,
+against files the working tree does not contain. Verified against the
+real ``lfreleng-actions/.github`` repository: 24 lines of duplicate
+findings before the fix, none after.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime by fixtures
+
+import pytest
+
+from gha_workflow_linter.models import Config
+from gha_workflow_linter.scanner import WorkflowScanner
+
+WORKFLOW = """---
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+"""
+
+ACTION = """---
+name: Test action
+description: Fixture
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      shell: bash
+"""
+
+
+def _workflow(root: Path, *parts: str) -> Path:
+    """Write a workflow file at ``root/<parts>/.github/workflows/ci.yaml``."""
+    directory = root.joinpath(*parts, ".github", "workflows")
+    directory.mkdir(parents=True, exist_ok=True)
+    target = directory / "ci.yaml"
+    target.write_text(WORKFLOW)
+    return target
+
+
+def _mark_repository(path: Path, *, as_file: bool) -> None:
+    """Make ``path`` look like a repository root.
+
+    Args:
+        path: Directory to mark.
+        as_file: True writes a gitdir pointer file, as a worktree or
+            submodule has; False creates a directory, as a clone has.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    git = path / ".git"
+    if as_file:
+        git.write_text("gitdir: /elsewhere/.git/worktrees/branch\n")
+    else:
+        git.mkdir()
+
+
+def _scan(root: Path) -> set[Path]:
+    """Return every file the scanner discovers under ``root``."""
+    return set(WorkflowScanner(Config()).find_workflow_files(root))
+
+
+class TestNestedRepositoriesAreSkipped:
+    @pytest.mark.parametrize(
+        ("kind", "as_file"),
+        [("worktree", True), ("submodule", True), ("clone", False)],
+    )
+    def test_nested_repository_excluded(
+        self, tmp_path: Path, kind: str, as_file: bool
+    ) -> None:
+        _mark_repository(tmp_path, as_file=False)
+        own = _workflow(tmp_path)
+        _mark_repository(tmp_path / "nested", as_file=as_file)
+        nested = _workflow(tmp_path, "nested")
+
+        found = _scan(tmp_path)
+
+        assert own in found, f"the repository's own workflow was lost ({kind})"
+        assert nested not in found, f"{kind} workflow was scanned"
+
+    def test_worktrees_directory_pattern(self, tmp_path: Path) -> None:
+        """The exact shape that produced 24 duplicate findings."""
+        _mark_repository(tmp_path, as_file=False)
+        own = _workflow(tmp_path)
+        for branch in ("fix-one", "fix-two"):
+            _mark_repository(tmp_path / ".worktrees" / branch, as_file=True)
+            _workflow(tmp_path, ".worktrees", branch)
+
+        found = _scan(tmp_path)
+
+        assert found == {own}
+
+    def test_deeply_nested_content_excluded(self, tmp_path: Path) -> None:
+        """Everything below the boundary goes, not just its top level."""
+        _mark_repository(tmp_path, as_file=False)
+        own = _workflow(tmp_path)
+        _mark_repository(tmp_path / "vendor" / "dep", as_file=False)
+        _workflow(tmp_path, "vendor", "dep", "deep", "deeper")
+
+        assert _scan(tmp_path) == {own}
+
+    def test_action_files_also_excluded(self, tmp_path: Path) -> None:
+        _mark_repository(tmp_path, as_file=False)
+        own_action = tmp_path / "action.yaml"
+        own_action.write_text(ACTION)
+        _mark_repository(tmp_path / "nested", as_file=True)
+        nested_action = tmp_path / "nested" / "action.yaml"
+        nested_action.write_text(ACTION)
+
+        found = _scan(tmp_path)
+
+        assert own_action in found
+        assert nested_action not in found
+
+    def test_scan_root_is_never_a_boundary(self, tmp_path: Path) -> None:
+        """The repository being scanned is not excluded by its own .git."""
+        _mark_repository(tmp_path, as_file=False)
+        own = _workflow(tmp_path)
+
+        assert _scan(tmp_path) == {own}
+
+    def test_worktree_root_scanned_directly(self, tmp_path: Path) -> None:
+        """Pointing at a worktree scans it: it is then the root."""
+        worktree = tmp_path / "wt"
+        _mark_repository(worktree, as_file=True)
+        target = _workflow(worktree)
+
+        assert _scan(worktree) == {target}
+
+    def test_plain_directories_unaffected(self, tmp_path: Path) -> None:
+        """Only a .git entry marks a boundary, not depth or naming."""
+        _mark_repository(tmp_path, as_file=False)
+        own = _workflow(tmp_path)
+        buried = _workflow(tmp_path, "packages", "sub")
+
+        assert _scan(tmp_path) == {own, buried}
+
+    def test_non_repository_root_scans_children(self, tmp_path: Path) -> None:
+        """A container directory that is not itself a repository.
+
+        Each child is a separate repository, so each is a boundary and
+        nothing is scanned. Multi-repository scanning is a distinct mode
+        that visits each repository as its own root; this documents the
+        behaviour rather than endorsing it as a way to scan many repos.
+        """
+        _mark_repository(tmp_path / "repo-a", as_file=False)
+        _workflow(tmp_path, "repo-a")
+        _mark_repository(tmp_path / "repo-b", as_file=False)
+        _workflow(tmp_path, "repo-b")
+
+        assert _scan(tmp_path) == set()
+
+
+class TestRepositoryRootDetectionIsCached:
+    def test_repeated_queries_stat_once(self, tmp_path: Path) -> None:
+        _mark_repository(tmp_path, as_file=False)
+        scanner = WorkflowScanner(Config())
+        target = tmp_path / "a" / "b"
+        target.mkdir(parents=True)
+
+        scanner._crosses_repository_boundary(target, tmp_path)
+        cached = dict(scanner._repository_roots)
+        scanner._crosses_repository_boundary(target, tmp_path)
+
+        assert scanner._repository_roots == cached
+
+    def test_unreadable_directory_is_not_a_boundary(
+        self, tmp_path: Path
+    ) -> None:
+        """An OSError must not silently exclude a whole subtree."""
+        scanner = WorkflowScanner(Config())
+
+        assert scanner._is_repository_root(tmp_path / "missing") is False


### PR DESCRIPTION
## Summary

Phases 1 and 2 of the work tracked in #296 and lfreleng-actions/.github#146:
**detection and remediation** of stale `harden-runner` allow-list pins.

Design: `docs/ALLOW_LIST_FEATURE.md` (added in #297).

## The problem

The workflow-repo family pins the harden-runner egress allow-list with a
custom `uses:`-style coordinate consumed by
[`harden-runner-block-action`](https://github.com/lfreleng-actions/harden-runner-block-action):

<!-- markdownlint-disable MD013 -->

```yaml
# Internal workflow, shorthand form
- uses: lfreleng-actions/harden-runner-block-action@6db537b3...  # v0.2.1
  with:
    config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1

# Reusable-workflow input default, explicit path form
harden_runner_allowlist:
  default: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@bf6642f6...'  # v0.12.2
```

<!-- markdownlint-enable MD013 -->

These are values of `config:` and `default:` keys, **not** `uses:`
references, so Dependabot cannot see them and they drift. A stale pin
means a block-mode job lacks newly allow-listed endpoints, producing
confusing `ECONNREFUSED` failures long after someone corrected the
allow-list.

## Behaviour

| Invocation | Stale pins | Result | Exit |
| --- | --- | --- | --- |
| `lint` (default) | yes | warning | unchanged |
| `lint --verify-allow-list` | yes | error | `3` |
| `lint --verify-allow-list` (cannot resolve) | unknown | error | `4` |
| `lint --verify-allow-list` (all suppressed) | suppressed | — | `0` |
| `lint --update-allow-list` | yes | rewritten | `1` |
| `lint --update-allow-list --verify-allow-list` | all fixed | rewritten | `1` |
| `lint --update-allow-list --verify-allow-list` | some unfixable | partial | `3` |
| `lint --update-allow-list` (all suppressed) | suppressed | **no write** | `0` |
| `lint --no-allow-list` | not checked | — | unchanged |

**Advisory by default.** This is an `lfreleng-actions` convention rather
than GitHub-native validation, and the linter runs as a pre-commit hook,
so findings are warnings that leave the exit code alone. Exit `3` and `4`
are distinct on purpose: enforcement that silently degrades to "pass"
when the check cannot run is worse than useless.

## Remediation

`--update-allow-list` rewrites the reference and its version comment, and
nothing else. The edit is a **surgical substring replacement** rather
than a rebuild of the line, so quoting style, the spacing before `#`, the
comment's position (inside or outside the quotes) and any suppression
directive with its reason all survive. That matters because these edits
become review-ready PRs, and a reformatted neighbouring comment is noise
a reviewer has to read past.

Writes go through `file_edit.replace_lines` (added in #297): one atomic
write per file, preserving each line's own terminator, so a CRLF file
stays CRLF and a file without a trailing newline does not gain one. Two
findings claiming the same line raise during planning, before any file is
opened, rather than silently losing an edit.

Findings that remediation repaired no longer count as outstanding, so
`--update-allow-list --verify-allow-list` does not fix everything and
then report failure anyway.

## Suppression is a first-class feature

A repository holding a pin deliberately is a legitimate and expected
state, so this is built in rather than bolted on:

<!-- markdownlint-disable MD013 -->

```yaml
    # gha-workflow-linter: allow-list-pin-ok -- waiting on ONAP rollout
    config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1

    config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1 allow-list-pin-ok
```

<!-- markdownlint-enable MD013 -->

A suppressed pin is excluded from reporting, enforcement **and
remediation** — the file's mtime never moves. Suppression covers
**currency** findings only: a comment that disagrees with its SHA is a
defect regardless of intent, and a lying comment is how the estate lost
track of the internal workflows in the first place.

Suppressed pins still appear in `--format json` with
`"suppressed": true`, and every run prints a one-line count so they do
not become invisible.

## Consumers are not special-cased

The central repository hosts one allow-list directory per consumer family
side by side (`harden-runner/`, `python-audit/`, …). The families are
therefore **data, not code**: staleness never depends on the family, so a
new consumer is covered the day it appears with no code change, no
registry entry and no release.

## A design bug found by running the tool on the estate

Pointing the linter at `java-workflows` produced a **downgrade**,
recommended as a staleness fix, against pins that were already correct:

```text
line 58   config: '@bf6642f6…'  # v0.12.2
          → '@d46590dd…'  # v0.7.0   (lfreleng-actions/.github)
```

The resolver was right: `java-workflows` sets a 7-day Dependabot
cooldown, v0.12.2 was 6 days old and therefore ineligible. The defect was
in classification, which treated "SHA differs" as "stale" with no notion
of direction. Classification now resolves the pinned commit to its
release and reports staleness only when the target is genuinely newer.

Only a live run finds this — worth noting for review.

## New modules

| Module | Responsibility |
| --- | --- |
| `allow_list_spec` | Grammar parser. A port of the file mirrored between `harden-runner-block-action` and `python-audit-action`, with **its upstream test corpus ported as the conformance suite** |
| `allow_list_scanner` | YAML node-tree walk producing pins with line/column anchors |
| `allow_list_resolver`, `latest_release` | Release resolution across both backends, with peeling, cooldown and caching |
| `allow_list_check` | Classification, severity, suppression, org resolution |
| `allow_list_fix` | Surgical in-place rewriting |
| `allow_list_report` | Text and JSON rendering |

`action.yaml` gains `allow-list`, `verify-allow-list`,
`update-allow-list` and `allow-list-org` inputs, plus
`allow-list-stale` and `allow-list-fixed` outputs.

## Validation

- **1281 tests** passing (from 934), coverage 83.6% (gate 70%)
- `ruff`, `ruff format`, `mypy --strict`, `basedpyright --strict`,
  `markdownlint`, `write-good`, `reuse`, `codespell`, `aislop`,
  `yamllint`, `actionlint`, `shellcheck` — all pass
- Every row of the behaviour matrix above exercised against the real CLI
- Remediation verified against a copy of the `lfreleng-actions/.github`
  repository: two distinct stale pins rewritten, exit `1`, and a second
  run reports clean under `--verify-allow-list`

## Review notes

Three Copilot findings were addressed in `8217801`, all correct:

1. **Enforcement silently degraded to pass** — `_run_allow_list_stage`
   swallowed every exception and returned `None`, so under
   `--verify-allow-list` a broken check reported success. Chasing this
   exposed a **second instance of the same class**: an unresolvable
   workflow org made every pin invisible, so the run reported "clean"
   without having checked anything. Both now exit `4`.
2. **A no-op `update` config knob** — removed at the time, and
   reintroduced in this commit now that remediation implements it. The
   guard test was inverted rather than deleted, so the intent stays
   recorded.
3. **`show_suppressed` was dead from a config file** — rendering read
   `options.` while the override wrote to `config.`.

Fixing (1) also surfaced a latent test bug: two CLI test modules set
`load_config.return_value = Mock()`, which makes **every** boolean config
field truthy, silently enabling flags the test never asked for. All 15
occurrences replaced with a real `Config()`.

`.aislop/history.jsonl` is now gitignored — generated per run and picked
up accidentally.
