### PR TITLE
Feat: rename auto-latest and make writes atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ gha-workflow-linter lint --auto-fix
 gha-workflow-linter lint --auto-fix --fix-test-calls
 
 # Auto-fix without using latest versions (keeps current version)
-gha-workflow-linter lint --auto-fix --no-auto-latest
+gha-workflow-linter lint --auto-fix --no-update-actions
 
 # Run without any authentication (limited to 60 requests/hour)
 # This happens when GitHub CLI is not installed/authenticated AND no token exists
@@ -195,10 +195,10 @@ gha-workflow-linter lint --auto-fix
 gha-workflow-linter lint --no-auto-fix
 
 # Auto-fix with latest versions (default: disabled unless overridden in config)
-gha-workflow-linter lint --auto-fix --auto-latest
+gha-workflow-linter lint --auto-fix --update-actions
 
 # Auto-fix without using latest versions (keeps current version)
-gha-workflow-linter lint --auto-fix --no-auto-latest
+gha-workflow-linter lint --auto-fix --no-update-actions
 ```
 
 **Skip Testing Actions**: By default, auto-fix skips actions with 'test' in
@@ -230,6 +230,47 @@ Example output (default behavior, test actions skipped):
   + - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
 ```
 
+### Exit Codes
+
+<!-- markdownlint-disable MD013 -->
+
+| Code | Meaning                                                               |
+| ---- | --------------------------------------------------------------------- |
+| `0`  | No failing findings                                                   |
+| `1`  | Defects found, or a fixer modified files, or the run itself failed    |
+| `2`  | Command-line usage error (reserved by the argument parser)            |
+| `3`  | `--verify-allow-list` and stale allow-list pins remain                |
+| `4`  | `--verify-allow-list` and the tool could not reach the latest release |
+| `5`  | `--verify-actions` and outdated action calls remain                   |
+
+<!-- markdownlint-enable MD013 -->
+
+When more than one applies, the most significant wins: `4`, then `3`,
+then `5`, then `1`. A check that could not run outranks a stale result,
+because enforcement reporting success when it never looked is worse than
+useless. A condition you asked about by name outranks the generic `1`,
+and nothing masks it.
+
+Codes `3`, `4` and `5` require the matching `--verify-*` flag. Without
+it, the linter reports those findings and leaves the exit code alone.
+
+### Verifying Action Currency
+
+`--verify-actions` treats outdated action calls as errors, mirroring
+`--verify-allow-list`:
+
+```bash
+# Report outdated actions but do not fail (the default)
+gha-workflow-linter lint
+
+# Fail when any action call has a newer release available
+gha-workflow-linter lint --verify-actions
+```
+
+This is useful in a scheduled compliance run, where you want to know
+that something has fallen behind, without blocking a developer's commit
+over it.
+
 ### Update Cooldown
 
 To guard against supply-chain attacks and retracted releases, the linter
@@ -240,10 +281,10 @@ policy.
 
 ```bash
 # Update to releases at least 7 days old
-gha-workflow-linter lint --auto-fix --auto-latest --cooldown 7
+gha-workflow-linter lint --auto-fix --update-actions --cooldown 7
 
 # Disable the cooldown (the default behaviour)
-gha-workflow-linter lint --auto-fix --auto-latest --cooldown 0
+gha-workflow-linter lint --auto-fix --update-actions --cooldown 0
 ```
 
 When `--cooldown` is not supplied, the linter walks up from the scanned
@@ -479,13 +520,13 @@ require_pinned_sha: true
 auto_fix: true
 
 # Use latest versions when auto-fixing (default: false)
-auto_latest: false
+update_actions: false
 
 # Allow prerelease versions when finding latest versions (default: false)
 allow_prerelease: false
 
 # Use two spaces before inline comments when fixing (default: false)
-two_space_comments: false
+two_space_comments: true
 
 # Skip scanning action.yaml/action.yml files (default: false)
 skip_actions: false
@@ -809,7 +850,7 @@ gha-workflow-linter lint --format json
 | `exclude`            | Comma-separated exclude patterns             | No       |         |
 | `require-pinned-sha` | Require actions pinned to commit SHAs        | No       | `true`  |
 | `auto-fix`           | Auto-fix broken/invalid references           | No       | `true`  |
-| `auto-latest`        | Use latest versions when auto-fixing         | No       | `false` |
+| `update-actions`     | Update action calls to the latest release    | No       | `false` |
 | `allow-prerelease`   | Allow prerelease versions for latest         | No       | `false` |
 | `two-space-comments` | Use two spaces before inline comments        | No       | `false` |
 | `skip-actions`       | Skip scanning action.yaml/action.yml files   | No       | `false` |
@@ -856,8 +897,8 @@ Options:
   --no-require-pinned-sha    Allow actions with tags/branches
   --auto-fix                 Auto-fix broken/invalid references
   --no-auto-fix              Disable auto-fixing
-  --auto-latest              Use latest versions when auto-fixing
-  --no-auto-latest           Don't use latest versions when auto-fixing
+  --update-actions           Update action calls to the latest release
+  --no-update-actions        Keep the current action versions
   --allow-prerelease         Allow prerelease versions for latest
   --no-allow-prerelease      Disallow prerelease versions
   --two-space-comments       Use two spaces before inline comments

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ update_actions: false
 # Allow prerelease versions when finding latest versions (default: false)
 allow_prerelease: false
 
-# Use two spaces before inline comments when fixing (default: false)
+# Use two spaces before inline comments when fixing (default: true)
 two_space_comments: true
 
 # Skip scanning action.yaml/action.yml files (default: false)
@@ -841,7 +841,7 @@ gha-workflow-linter lint --format json
 | -------------------- | -------------------------------------------- | -------- | ------- |
 | `path`               | Path to scan for workflows                   | No       | `.`     |
 | `config-file`        | Path to configuration file                   | No       |         |
-| `github-token`       | GitHub API token                             | No       |         |
+| `validation-method`  | Validation method (github-api or git)        | No       | auto    |
 | `log-level`          | Logging level                                | No       | `INFO`  |
 | `output-format`      | Output format (text, json)                   | No       | `text`  |
 | `fail-on-error`      | Exit with error on failures                  | No       | `true`  |
@@ -855,6 +855,11 @@ gha-workflow-linter lint --format json
 | `two-space-comments` | Use two spaces before inline comments        | No       | `false` |
 | `skip-actions`       | Skip scanning action.yaml/action.yml files   | No       | `false` |
 | `fix-test-calls`     | Fix actions with 'test' in comments          | No       | `false` |
+| `cooldown`           | Days a release must have been public         | No       |         |
+| `allow-list`         | Detect stale harden-runner allow-list pins   | No       | `true`  |
+| `verify-allow-list`  | Fail when stale allow-list pins remain       | No       | `false` |
+| `update-allow-list`  | Rewrite stale allow-list pins in place       | No       | `false` |
+| `allow-list-org`     | Org for the allow-list `@` shorthand         | No       |         |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,33 @@ inputs:
     description: "Skip scanning action.yaml/action.yml files"
     required: false
     default: "false"
+  auto-fix:
+    description: "Automatically fix broken/invalid references"
+    required: false
+    default: "true"
+  update-actions:
+    description: >
+      When auto-fixing, update action calls to the latest release.
+      Replaces the former 'auto-latest' name.
+    required: false
+    default: "false"
+  allow-prerelease:
+    description: "Allow prerelease versions when finding latest versions"
+    required: false
+    default: "false"
+  two-space-comments:
+    description: "Use two spaces before inline comments when fixing"
+    required: false
+    default: "true"
+  fix-test-calls:
+    description: "Fix action calls whose comment mentions testing"
+    required: false
+    default: "false"
+  cooldown:
+    description: >
+      Minimum days a release must have been available before updating to
+      it. Read from .github/dependabot.yml when unset.
+    required: false
   validation-method:
     description: "Validation method (github-api, git, or auto-detect)"
     required: false
@@ -138,6 +165,12 @@ runs:
         INPUT_EXCLUDE: ${{ inputs.exclude }}
         INPUT_REQUIRE_PINNED_SHA: ${{ inputs.require-pinned-sha }}
         INPUT_SKIP_ACTIONS: ${{ inputs.skip-actions }}
+        INPUT_AUTO_FIX: ${{ inputs.auto-fix }}
+        INPUT_UPDATE_ACTIONS: ${{ inputs.update-actions }}
+        INPUT_ALLOW_PRERELEASE: ${{ inputs.allow-prerelease }}
+        INPUT_TWO_SPACE_COMMENTS: ${{ inputs.two-space-comments }}
+        INPUT_FIX_TEST_CALLS: ${{ inputs.fix-test-calls }}
+        INPUT_COOLDOWN: ${{ inputs.cooldown }}
         INPUT_VALIDATION_METHOD: ${{ inputs.validation-method }}
         INPUT_ALLOW_LIST: ${{ inputs.allow-list }}
         INPUT_VERIFY_ALLOW_LIST: ${{ inputs.verify-allow-list }}
@@ -191,6 +224,30 @@ runs:
 
         if [[ "$INPUT_SKIP_ACTIONS" == "true" ]]; then
           args+=(--skip-actions)
+        fi
+
+        if [[ "$INPUT_AUTO_FIX" == "false" ]]; then
+          args+=(--no-auto-fix)
+        fi
+
+        if [[ "$INPUT_UPDATE_ACTIONS" == "true" ]]; then
+          args+=(--update-actions)
+        fi
+
+        if [[ "$INPUT_ALLOW_PRERELEASE" == "true" ]]; then
+          args+=(--allow-prerelease)
+        fi
+
+        if [[ "$INPUT_TWO_SPACE_COMMENTS" == "false" ]]; then
+          args+=(--no-two-space-comments)
+        fi
+
+        if [[ "$INPUT_FIX_TEST_CALLS" == "true" ]]; then
+          args+=(--fix-test-calls)
+        fi
+
+        if [[ -n "$INPUT_COOLDOWN" ]]; then
+          args+=(--cooldown "$INPUT_COOLDOWN")
         fi
 
         if [[ -n "$INPUT_VALIDATION_METHOD" ]]; then

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -20,6 +20,7 @@ from rich.text import Text
 from .auto_fix_versions import _VersionResolutionMixin
 from .cache import ValidationCache
 from .console import console as _shared_console
+from .file_edit import replace_lines
 from .git_validator import GitValidationClient
 from .github_api import GitHubGraphQLClient
 from .models import (
@@ -1084,12 +1085,12 @@ class AutoFixer(_VersionResolutionMixin):
     ) -> str:
         """Choose the reference to fix an action call to.
 
-        Uses the latest release/tag when ``auto_latest`` is set, otherwise
+        Uses the latest release/tag when ``update_actions`` is set, otherwise
         repairs an invalid reference (with a fallback), and finally falls
         back to the default branch. Non-fixable cases keep the current
         reference (e.g. NOT_PINNED_TO_SHA).
         """
-        if self.config.auto_latest:
+        if self.config.update_actions:
             # Use latest release/tag if available - use base repo
             target_ref = await self._get_latest_release_or_tag(base_repo_key)
             if not target_ref:
@@ -1227,30 +1228,55 @@ class AutoFixer(_VersionResolutionMixin):
     async def _apply_fixes_to_file(
         self, file_path: Path, line_fixes: dict[int, tuple[str, str]]
     ) -> list[dict[str, str]]:
-        """Apply fixes to a workflow file."""
+        """Rewrite a workflow file with the supplied line fixes.
+
+        The rewrite is delegated to
+        :func:`~gha_workflow_linter.file_edit.replace_lines`, which
+        publishes a sibling temporary file with a single
+        :func:`os.replace`, so the workflow file is either fully updated
+        or left byte-for-byte unchanged. Each rewritten line keeps the
+        terminator it already had, so a CRLF file stays CRLF and a file
+        without a trailing newline does not gain one.
+
+        Args:
+            file_path: Workflow file to rewrite.
+            line_fixes: Mapping of 1-based line number to an
+                ``(old_line, new_line)`` pair. Only ``new_line`` is
+                written; the caller's ``old_line`` is not used. An empty
+                mapping is a no-op that does not open or touch the file.
+
+        Returns:
+            One dict per fixed line, ordered by line number, with the
+            keys ``line_number`` (stringified), ``old_line``, and
+            ``new_line``. ``old_line`` is the content actually read from
+            disk rather than the caller-supplied value, so a rendered
+            diff cannot disagree with the file it describes.
+
+        Raises:
+            ValueError: If a line number is out of range for the file, or
+                a replacement spans more than one line. Previously an
+                out-of-range line was silently skipped; the whole file is
+                now left untouched instead of partially rewritten.
+            OSError: If the file cannot be read, or the replacement
+                cannot be written or moved into place.
+        """
         try:
-            with open(file_path, encoding="utf-8") as f:
-                lines = f.readlines()
-
-            # Apply fixes (line numbers are 1-based)
-            changes = []
-            for i, _line in enumerate(lines, 1):
-                if i in line_fixes:
-                    old_line, new_line = line_fixes[i]
-                    lines[i - 1] = new_line + "\n"
-                    changes.append(
-                        {
-                            "line_number": str(i),
-                            "old_line": old_line,
-                            "new_line": new_line,
-                        }
-                    )
-
-            with open(file_path, "w", encoding="utf-8") as f:
-                f.writelines(lines)
-
-            return changes
-
+            changes = replace_lines(
+                file_path,
+                {
+                    line_number: new_line
+                    for line_number, (_old, new_line) in line_fixes.items()
+                },
+            )
         except Exception as e:
             self.logger.error(f"Failed to apply fixes to {file_path}: {e}")
             raise
+
+        return [
+            {
+                "line_number": str(change.line_number),
+                "old_line": change.old_line,
+                "new_line": change.new_line,
+            }
+            for change in changes
+        ]

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -845,7 +845,7 @@ def lint(
         gha-workflow-linter lint --no-require-pinned-sha
 
         # Auto-fix issues without using latest versions
-        gha-workflow-linter lint --auto-fix --no-auto-latest
+        gha-workflow-linter lint --auto-fix --no-update-actions
 
         # Auto-fix with two-space comment formatting
         gha-workflow-linter lint --auto-fix --two-space-comments
@@ -854,7 +854,7 @@ def lint(
         gha-workflow-linter lint --auto-fix --fix-test-calls
 
         # Only update to releases at least 7 days old (supply-chain cooldown)
-        gha-workflow-linter lint --auto-fix --auto-latest --cooldown 7
+        gha-workflow-linter lint --auto-fix --update-actions --cooldown 7
 
         # Scan only specific files
         gha-workflow-linter lint --files .github/workflows/ci.yml
@@ -2001,7 +2001,8 @@ def _display_stale_actions_from_summary(
         console.print()
 
     console.print(
-        "[cyan]Run with [bold]--auto-fix --auto-latest[/bold] to update these actions 💡[/cyan]\n"
+        "[cyan]Run with [bold]--auto-fix --update-actions[/bold] to update "
+        "these actions 💡[/cyan]\n"
     )
 
 

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -49,7 +49,7 @@ from .allow_list_report import (
 from .auto_fix import AutoFixer
 from .cache import CachePrimeReport, ValidationCache
 from .config import ConfigManager
-from .console import console
+from .console import console, err_console
 from .dependabot import resolve_cooldown
 from .exceptions import (
     AuthenticationError,
@@ -426,8 +426,8 @@ def _apply_cli_overrides(
     # Apply auto-fix overrides (only if explicitly provided)
     if options.auto_fix is not None:
         config.auto_fix = options.auto_fix
-    if options.auto_latest is not None:
-        config.auto_latest = options.auto_latest
+    if options.update_actions is not None:
+        config.update_actions = options.update_actions
     if options.allow_prerelease is not None:
         config.allow_prerelease = options.allow_prerelease
     if options.two_space_comments is not None:
@@ -536,6 +536,44 @@ def _configure_validation_backend(
             raise
 
 
+def _resolve_update_actions(
+    update_actions: bool | None,
+    auto_latest: bool | None,
+    *,
+    quiet: bool,
+) -> bool | None:
+    """Combine the canonical flag with its deprecated predecessor.
+
+    ``--auto-latest`` was renamed to ``--update-actions`` once a second
+    updatable thing (the allow-list) existed and the old name stopped
+    saying which. The old spelling keeps working so scripts and CI
+    configurations do not break.
+
+    Args:
+        update_actions: Value of ``--update-actions``, or None.
+        auto_latest: Value of the deprecated ``--auto-latest``, or None.
+        quiet: Suppress the deprecation notice.
+
+    Returns:
+        The effective value, or None when neither flag was given.
+    """
+    if auto_latest is None:
+        return update_actions
+
+    if not quiet:
+        # stderr, never stdout: --format json must stay machine-readable.
+        err_console.print(
+            "[yellow]--auto-latest is deprecated; use --update-actions "
+            "⚠️[/yellow]"
+        )
+
+    if update_actions is not None:
+        # Both given: the canonical flag wins, so a script adding the new
+        # name to an existing invocation gets what it asked for.
+        return update_actions
+    return auto_latest
+
+
 @app.command()
 def lint(
     path: Path | None = typer.Argument(
@@ -636,10 +674,21 @@ def lint(
         "--auto-fix/--no-auto-fix",
         help="Automatically fix broken/invalid SHA pins, versions, and branches (default: enabled unless overridden in config)",
     ),
+    update_actions: bool | None = typer.Option(
+        None,
+        "--update-actions/--no-update-actions",
+        help=(
+            "When auto-fixing, update action calls to the latest release "
+            "(default: disabled unless overridden in config)"
+        ),
+    ),
     auto_latest: bool | None = typer.Option(
         None,
         "--auto-latest/--no-auto-latest",
-        help="When auto-fixing, use the latest version of actions (default: disabled unless overridden in config)",
+        help=(
+            "(deprecated) Former name for --update-actions. Still "
+            "honoured; will be removed in a future major release"
+        ),
     ),
     allow_prerelease: bool | None = typer.Option(
         None,
@@ -862,7 +911,9 @@ def lint(
             cache_ttl=cache_ttl,
             validation_method=validation_method,
             auto_fix=auto_fix,
-            auto_latest=auto_latest,
+            update_actions=_resolve_update_actions(
+                update_actions, auto_latest, quiet=quiet
+            ),
             allow_prerelease=allow_prerelease,
             two_space_comments=two_space_comments,
             skip_actions=skip_actions,
@@ -1198,7 +1249,7 @@ def _run_auto_fix_stage(
     # Determine if we should run auto-fix:
     # - If auto_fix is enabled, fix validation errors and check for outdated
     #   versions.
-    # - If auto_latest is also enabled, update to latest versions.
+    # - If update_actions is also enabled, update to latest versions.
     should_run_auto_fix = (config.auto_fix or not config.fix_test_calls) and (
         validation.validation_errors or config.auto_fix
     )
@@ -1220,11 +1271,11 @@ def _run_auto_fix_stage(
                 cache=shared_cache,
             ) as auto_fixer:
                 # When auto_fix is enabled, always pass all action calls to
-                # check. check_for_updates=True only when auto_latest is
+                # check. check_for_updates=True only when update_actions is
                 # enabled (update to latest versions); False means: fix
                 # validation errors, report outdated versions.
                 all_calls = validation.workflow_calls if config.auto_fix else {}
-                check_for_updates = config.auto_latest
+                check_for_updates = config.update_actions
                 return await auto_fixer.fix_validation_errors(
                     validation.validation_errors,
                     all_calls,
@@ -1674,7 +1725,7 @@ def run_linter(config: Config, options: CLIOptions) -> int:
     # depend on --quiet, which also gates this block).
     if (
         autofix.stale_actions_summary
-        and not config.auto_latest
+        and not config.update_actions
         and not options.quiet
     ):
         _display_stale_actions_from_summary(

--- a/src/gha_workflow_linter/config.py
+++ b/src/gha_workflow_linter/config.py
@@ -8,12 +8,158 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+import textwrap
 from typing import Any
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 import yaml
 
 from .models import Config
+
+#: Header prepended to generated configuration files. Everything below
+#: the header comes from the configuration model, so the template cannot
+#: drift as fields are added.
+_CONFIG_HEADER = """\
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# gha-workflow-linter configuration file
+#
+# Generated from the configuration model: every setting the tool
+# understands appears below, commented with its purpose and set to its
+# default value. Delete an entry to keep the built-in default.
+#
+# Full documentation:
+# https://github.com/lfit/gha-workflow-linter#configuration
+---
+"""
+
+#: Width used for wrapped comment text and emitted YAML scalars. One
+#: below the yamllint default line-length limit of 80.
+_LINE_WIDTH = 79
+
+#: Dotted paths of fields that must never carry a value in a generated
+#: template, however the running configuration was populated.
+_REDACTED_PATHS = frozenset({"github_api.token"})
+
+#: Explanation emitted alongside every redacted field.
+_REDACTED_NOTES = {
+    "github_api.token": (
+        "Deliberately left empty: the token normally comes from the "
+        "GITHUB_TOKEN environment variable or the GitHub CLI, and a token "
+        "held in memory is never written to this file."
+    )
+}
+
+
+class _BlockDumper(yaml.SafeDumper):
+    """YAML dumper that indents sequences beneath their parent key.
+
+    PyYAML emits block sequences at the same indentation as the mapping
+    key that owns them, which yamllint rejects under its default
+    ``indent-sequences: true`` setting.
+    """
+
+    def increase_indent(
+        self, flow: bool = False, indentless: bool = False
+    ) -> None:
+        """Increase emitter indentation, never indentless.
+
+        Args:
+            flow: Whether the collection is being emitted in flow style.
+            indentless: Ignored; sequences are always indented.
+
+        Returns:
+            None.
+        """
+        del indentless
+        super().increase_indent(flow, False)
+
+
+def _comment_lines(text: str, indent: int) -> list[str]:
+    """Render descriptive text as wrapped, indented YAML comments.
+
+    Args:
+        text: Description text to render.
+        indent: Number of leading spaces for the comment block.
+
+    Returns:
+        Comment lines, each already indented and prefixed with ``# ``.
+    """
+    prefix = f"{' ' * indent}# "
+    return textwrap.wrap(
+        " ".join(text.split()),
+        width=_LINE_WIDTH,
+        initial_indent=prefix,
+        subsequent_indent=prefix,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+
+
+def _value_lines(name: str, value: Any, indent: int) -> list[str]:
+    """Render a single ``key: value`` entry as indented YAML lines.
+
+    Args:
+        name: Field name to emit as the mapping key.
+        value: JSON-compatible value produced by ``model_dump``.
+        indent: Number of leading spaces for the entry.
+
+    Returns:
+        Indented YAML lines for the entry, without a trailing newline.
+    """
+    dumped = yaml.dump(
+        {name: value},
+        Dumper=_BlockDumper,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+        width=_LINE_WIDTH,
+    )
+    pad = " " * indent
+    return [f"{pad}{line}" if line else "" for line in dumped.splitlines()]
+
+
+def _model_lines(
+    model: BaseModel, indent: int = 0, path: str = ""
+) -> list[str]:
+    """Render a pydantic model as commented YAML in declaration order.
+
+    Each field is preceded by its ``Field(description=...)`` text, so the
+    generated file documents itself straight from the model.
+
+    Args:
+        model: Model instance to render.
+        indent: Number of leading spaces for this block.
+        path: Dotted path of the parent block, empty at the top level.
+
+    Returns:
+        YAML lines for the model, without trailing newlines.
+    """
+    lines: list[str] = []
+
+    dumped = model.model_dump(mode="json")
+    for name, field in type(model).model_fields.items():
+        field_path = f"{path}.{name}" if path else name
+        value = getattr(model, name)
+
+        if lines:
+            lines.append("")
+        if field.description:
+            lines.extend(_comment_lines(field.description, indent))
+
+        if isinstance(value, BaseModel):
+            lines.append(f"{' ' * indent}{name}:")
+            lines.extend(_model_lines(value, indent + 2, field_path))
+        elif field_path in _REDACTED_PATHS:
+            note = _REDACTED_NOTES.get(field_path)
+            if note:
+                lines.extend(_comment_lines(note, indent))
+            lines.append(f"{' ' * indent}{name}:")
+        else:
+            lines.extend(_value_lines(name, dumped[name], indent))
+
+    return lines
 
 
 class ConfigManager:
@@ -50,6 +196,17 @@ class ConfigManager:
             self.logger.debug("No config file found, using defaults")
 
         # Create Config object (will load from environment variables)
+        if "auto_latest" in config_data:
+            self.logger.warning(
+                "Configuration key 'auto_latest' is deprecated; rename it "
+                "to 'update_actions'. The old name still loads and will be "
+                "removed in a future major release"
+            )
+            if "update_actions" in config_data:
+                # Both present: the canonical key wins, matching how the
+                # CLI resolves --update-actions against --auto-latest.
+                del config_data["auto_latest"]
+
         try:
             config = Config(**config_data)
             self.logger.debug("Configuration loaded successfully")
@@ -138,11 +295,19 @@ class ConfigManager:
         """
         Save default configuration to file.
 
+        The template is generated from :class:`~.models.Config` rather
+        than hand-written, so every field the model gains appears here
+        automatically. The generated file round-trips: loading it back
+        yields a ``Config`` equal to the defaults.
+
         Args:
             output_path: Optional path to save config file
 
         Returns:
             Path where config was saved
+
+        Raises:
+            ValueError: If the file cannot be written
         """
         if output_path is None:
             config_dir = self._get_config_directory()
@@ -152,118 +317,9 @@ class ConfigManager:
                 config_dir.mkdir(parents=True, exist_ok=True)
                 output_path = config_dir / "config.yaml"
 
-        default_config = Config()
-
-        # Convert to dictionary for YAML serialization
-        config_dict: dict[str, object] = {
-            "log_level": default_config.log_level.value,
-            "parallel_workers": default_config.parallel_workers,
-            "scan_extensions": default_config.scan_extensions,
-            "exclude_patterns": default_config.exclude_patterns,
-            "require_pinned_sha": default_config.require_pinned_sha,
-            "auto_fix": default_config.auto_fix,
-            "auto_latest": default_config.auto_latest,
-            "two_space_comments": default_config.two_space_comments,
-            "skip_actions": default_config.skip_actions,
-            "network": {
-                "timeout_seconds": default_config.network.timeout_seconds,
-                "max_retries": default_config.network.max_retries,
-                "retry_delay_seconds": default_config.network.retry_delay_seconds,
-                "rate_limit_delay_seconds": default_config.network.rate_limit_delay_seconds,
-            },
-            "github_api": {
-                "base_url": default_config.github_api.base_url,
-                "graphql_url": default_config.github_api.graphql_url,
-                "max_repositories_per_query": default_config.github_api.max_repositories_per_query,
-                "max_references_per_query": default_config.github_api.max_references_per_query,
-                "rate_limit_threshold": default_config.github_api.rate_limit_threshold,
-                "rate_limit_reset_buffer": default_config.github_api.rate_limit_reset_buffer,
-            },
-        }
-
-        # Add comments for clarity
-        yaml_content = f"""# gha-workflow-linter configuration file
-# SPDX-License-Identifier: Apache-2.0
-
-# Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-log_level: {config_dict["log_level"]}
-
-# Number of parallel workers for validation (1-32)
-parallel_workers: {config_dict["parallel_workers"]}
-
-# File extensions to scan for workflows
-scan_extensions:
-{chr(10).join(f'  - "{ext}"' for ext in (config_dict["scan_extensions"] if isinstance(config_dict["scan_extensions"], list) else []))}
-
-# Patterns to exclude from scanning (can be empty)
-exclude_patterns: []
-
-# Require action calls to be pinned to commit SHAs
-require_pinned_sha: {config_dict["require_pinned_sha"]}
-
-# Auto-fix broken/invalid references
-auto_fix: {config_dict["auto_fix"]}
-
-# Use latest versions when auto-fixing
-auto_latest: {config_dict["auto_latest"]}
-
-# Use two spaces before inline comments when fixing
-two_space_comments: {config_dict["two_space_comments"]}
-
-# Skip scanning action.yaml/action.yml files
-skip_actions: {config_dict["skip_actions"]}
-
-# Harden-runner allow-list pin checking. These pins are an
-# lfreleng-actions convention rather than GitHub-native syntax, so the
-# check is advisory by default: it reports stale pins but never changes
-# the exit code. Set verify to true to enforce (exit status 3, or 4 when
-# the latest release cannot be resolved).
-allow_list:
-  enabled: true
-  verify: false
-  show_suppressed: false
-  # Organisation used to resolve the '@<sha>' shorthand. When empty the
-  # tool infers it from GITHUB_REPOSITORY_OWNER, then the 'upstream' git
-  # remote, then 'origin'. Forks should set this explicitly.
-  org: ""
-
-# Network configuration
-network:
-  # Timeout for network requests (seconds)
-  timeout_seconds: {config_dict["network"]["timeout_seconds"] if isinstance(config_dict["network"], dict) else 30}
-
-  # Maximum retry attempts for failed requests
-  max_retries: {config_dict["network"]["max_retries"] if isinstance(config_dict["network"], dict) else 3}
-
-  # Delay between retry attempts (seconds)
-  retry_delay_seconds: {config_dict["network"]["retry_delay_seconds"] if isinstance(config_dict["network"], dict) else 1.0}
-
-  # Delay between requests for rate limiting (seconds)
-  rate_limit_delay_seconds: {config_dict["network"]["rate_limit_delay_seconds"] if isinstance(config_dict["network"], dict) else 0.1}
-
-# GitHub API configuration
-github_api:
-  # GitHub API base URL
-  base_url: {config_dict["github_api"]["base_url"] if isinstance(config_dict["github_api"], dict) else "https://api.github.com"}
-
-  # GitHub GraphQL API URL
-  graphql_url: {config_dict["github_api"]["graphql_url"] if isinstance(config_dict["github_api"], dict) else "https://api.github.com/graphql"}
-
-  # Maximum repositories per GraphQL query
-  max_repositories_per_query: {config_dict["github_api"]["max_repositories_per_query"] if isinstance(config_dict["github_api"], dict) else 100}
-
-  # Maximum references per GraphQL query
-  max_references_per_query: {config_dict["github_api"]["max_references_per_query"] if isinstance(config_dict["github_api"], dict) else 100}
-
-  # Rate limit threshold for delays
-  rate_limit_threshold: {config_dict["github_api"]["rate_limit_threshold"] if isinstance(config_dict["github_api"], dict) else 1000}
-
-  # Buffer seconds before rate limit reset
-  rate_limit_reset_buffer: {config_dict["github_api"]["rate_limit_reset_buffer"] if isinstance(config_dict["github_api"], dict) else 60}
-
-  # GitHub API token (can also be set via GITHUB_TOKEN environment variable)
-  # token: your_github_token_here
-"""
+        lines = [_CONFIG_HEADER.rstrip("\n"), ""]
+        lines.extend(_model_lines(Config()))
+        yaml_content = "\n".join(lines) + "\n"
 
         try:
             with open(output_path, "w", encoding="utf-8") as f:

--- a/src/gha_workflow_linter/console.py
+++ b/src/gha_workflow_linter/console.py
@@ -23,4 +23,9 @@ from rich.console import Console
 
 console: Console = Console()
 
-__all__ = ["console"]
+#: Companion writing to standard error. Deprecation notices and similar
+#: out-of-band messages use this so ``--format json`` keeps standard
+#: output machine-readable.
+err_console: Console = Console(stderr=True)
+
+__all__ = ["console", "err_console"]

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -9,7 +9,13 @@ from enum import Enum
 from pathlib import Path
 import re
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+)
 
 from .system_utils import get_default_workers
 
@@ -561,7 +567,9 @@ class AllowListConfig(BaseModel):
 class Config(BaseModel):
     """Main configuration model."""
 
-    model_config = ConfigDict()
+    # populate_by_name lets update_actions be set by its own name as well
+    # as through the deprecated auto_latest alias.
+    model_config = ConfigDict(populate_by_name=True)
 
     log_level: LogLevel = Field(
         default=LogLevel.INFO, description="Logging level"
@@ -587,8 +595,13 @@ class Config(BaseModel):
     auto_fix: bool = Field(
         default=True, description="Automatically fix broken/invalid references"
     )
-    auto_latest: bool = Field(
-        default=False, description="Use latest versions when auto-fixing"
+    update_actions: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("update_actions", "auto_latest"),
+        description=(
+            "Update action calls to the latest release when auto-fixing. "
+            "The former name 'auto_latest' still loads and is deprecated"
+        ),
     )
     allow_prerelease: bool = Field(
         default=False,
@@ -689,8 +702,9 @@ class CLIOptions(BaseModel):
     auto_fix: bool | None = Field(
         default=None, description="Automatically fix broken/invalid references"
     )
-    auto_latest: bool | None = Field(
-        default=None, description="Use latest versions when auto-fixing"
+    update_actions: bool | None = Field(
+        default=None,
+        description="Update action calls to the latest release",
     )
     allow_prerelease: bool | None = Field(
         default=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@
 
 from collections.abc import Generator
 from pathlib import Path
+import re
 import tempfile
 
 import pytest
@@ -15,6 +16,30 @@ from gha_workflow_linter.models import (
     LogLevel,
     NetworkConfig,
 )
+
+_ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from console output.
+
+    Rich colours its output when it believes it is writing to a terminal,
+    and its highlighter puts the escape sequences *inside* values rather
+    than around them: ``1.3.0`` is emitted as
+    ``\\x1b[1;36m1.3\\x1b[0m.\\x1b[1;36m0\\x1b[0m``, and a number in a
+    sentence is styled the same way. An assertion against raw output
+    therefore tests the styling as much as the text, and passes or fails
+    depending on whether the run happens to have a terminal -- green
+    locally, red on CI, or the reverse once a version string changes
+    shape. Strip the sequences first so the assertion tests the text.
+
+    Args:
+        text: Console output, possibly containing escape sequences.
+
+    Returns:
+        The same text with escape sequences removed.
+    """
+    return _ANSI_ESCAPE_PATTERN.sub("", text)
 
 
 @pytest.fixture

--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -45,6 +45,7 @@ from gha_workflow_linter.models import (
     ValidationResult,
 )
 from gha_workflow_linter.validator import ActionCallValidator
+from tests.conftest import strip_ansi
 
 
 def parse_json_output(stdout: str) -> dict[str, Any]:
@@ -744,7 +745,7 @@ jobs:
             return errors
 
         # Mock git operations and the auto-fixer for this CLI test
-        # Report a fix for every flagged call, as a real --auto-latest
+        # Report a fix for every flagged call, as a real --update-actions
         # run would. Line numbers match the ``uses:`` lines of the
         # fixture, not the ``- name:`` lines above them.
         expected_fixes: dict[Path, list[dict[str, str]]] = {
@@ -820,7 +821,7 @@ jobs:
             assert output_data["validation_summary"]["total_errors"] == 5
 
             # With require_pinned_sha=True every non-SHA reference is an
-            # error, so all five reach the fixer, and --auto-latest asks
+            # error, so all five reach the fixer, and --update-actions asks
             # it to move them to the latest versions.
             assert auto_fix.called
             assert len(auto_fix.errors) == 5
@@ -1036,7 +1037,7 @@ validation_method: git
             assert output_data["validation_summary"]["invalid_references"] == 1
             assert output_data["validation_summary"]["not_pinned_to_sha"] == 4
 
-            # All five errors reach the fixer, but without --auto-latest
+            # All five errors reach the fixer, but without --update-actions
             # it is not asked to chase newer versions.
             assert auto_fix.called
             assert len(auto_fix.errors) == 5
@@ -1152,7 +1153,7 @@ validation_method: git
         assert "validation errors" in result.stdout
         assert "Auto-fixed" not in result.stdout
 
-    def test_auto_latest_disabled(self, temp_dir: Path) -> None:
+    def test_update_actions_disabled(self, temp_dir: Path) -> None:
         """Test auto-fix with update_actions=False uses existing versions not latest."""
         workflow_file = temp_dir / ".github" / "workflows" / "test.yaml"
         workflow_file.parent.mkdir(parents=True)
@@ -1279,7 +1280,7 @@ jobs:
             ],
         )
 
-        # With --no-auto-latest and a valid SHA, there should be no validation errors
+        # With --no-update-actions and a valid SHA, there should be no validation errors
         assert result.exit_code == 0
 
         # Parse JSON output for structured validation
@@ -1361,7 +1362,7 @@ jobs:
         # Test that CLI flags are accepted (actual behavior is tested elsewhere)
         test_cases = [
             (["--no-auto-fix"], "Auto-fix disabled via CLI"),
-            (["--no-update-actions"], "Auto-latest disabled via CLI"),
+            (["--no-update-actions"], "update_actions disabled via CLI"),
         ]
 
         for flags, description in test_cases:
@@ -1500,9 +1501,9 @@ jobs:
                 and "2" in result.stdout
                 and "validation errors" in result.stdout
             )
-            assert "2 actions not pinned to SHA" in result.stdout
+            assert "2 actions not pinned to SHA" in strip_ansi(result.stdout)
             # Only the two action calls are errors; the fixer is still
-            # offered the remote reusable workflow call so --auto-latest
+            # offered the remote reusable workflow call so --update-actions
             # could update it, but never the local ``./`` call.
             assert auto_fix.called
             assert len(auto_fix.errors) == 2
@@ -1581,7 +1582,7 @@ jobs:
                 and "50" in result.stdout
                 and "validation errors" in result.stdout
             )
-            assert "50 actions not pinned to SHA" in result.stdout
+            assert "50 actions not pinned to SHA" in strip_ansi(result.stdout)
             # Every one of the 50 calls is carried through to the fixer
             # in a single batch.
             assert auto_fix.called
@@ -1813,7 +1814,9 @@ jobs:
                 and "3" in result.stdout
                 and "validation errors" in result.stdout
             )
-            assert "Updated 3 workflow call(s) in 3 file(s)" in result.stdout
+            assert "Updated 3 workflow call(s) in 3 file(s)" in strip_ansi(
+                result.stdout
+            )
             assert result.exit_code == 1
             # One call per directory reaches the fixer, so the count
             # above cannot come from one file being scanned three times.

--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -269,7 +269,7 @@ class TestAutoFixBehaviorWithPinnedSHA:
             parallel_workers=2,
             require_pinned_sha=True,
             auto_fix=True,
-            auto_latest=True,
+            update_actions=True,
             two_space_comments=False,
             skip_actions=False,
             fix_test_calls=False,
@@ -291,7 +291,7 @@ class TestAutoFixBehaviorWithPinnedSHA:
             parallel_workers=2,
             require_pinned_sha=False,
             auto_fix=True,
-            auto_latest=False,
+            update_actions=False,
             two_space_comments=False,
             skip_actions=False,
             fix_test_calls=False,
@@ -803,7 +803,7 @@ jobs:
                     "lint",
                     str(temp_dir),
                     "--auto-fix",
-                    "--auto-latest",
+                    "--update-actions",
                     "--no-fail-on-error",
                     "--validation-method",
                     "git",
@@ -848,7 +848,7 @@ jobs:
         config_content = """
 require_pinned_sha: false
 auto_fix: true
-auto_latest: true
+update_actions: true
 validation_method: git
 """
         config_file = temp_dir / "gha-workflow-linter.yaml"
@@ -1082,7 +1082,7 @@ validation_method: git
                 str(temp_dir),
                 "--config",
                 str(config_file),
-                "--auto-latest",
+                "--update-actions",
             ],
         )
 
@@ -1153,7 +1153,7 @@ validation_method: git
         assert "Auto-fixed" not in result.stdout
 
     def test_auto_latest_disabled(self, temp_dir: Path) -> None:
-        """Test auto-fix with auto_latest=False uses existing versions not latest."""
+        """Test auto-fix with update_actions=False uses existing versions not latest."""
         workflow_file = temp_dir / ".github" / "workflows" / "test.yaml"
         workflow_file.parent.mkdir(parents=True)
         workflow_file.write_text("""name: Test
@@ -1168,7 +1168,7 @@ jobs:
         config_content = """
 require_pinned_sha: true
 auto_fix: true
-auto_latest: false  # Don't use latest versions
+update_actions: false  # Don't use latest versions
 validation_method: git
 """
         config_file = temp_dir / "gha-workflow-linter.yaml"
@@ -1182,14 +1182,14 @@ validation_method: git
                 "lint",
                 str(temp_dir),
                 "--auto-fix",
-                "--no-auto-latest",
+                "--no-update-actions",
                 "--format",
                 "json",
             ],
         )
 
         # Should auto-fix without upgrading to latest version
-        # When auto_latest=False, it should pin to the SHA of v4, not upgrade to v5
+        # When update_actions=False, it should pin to the SHA of v4, not upgrade to v5
         output_data = parse_json_output(result.stdout)
 
         # If there were errors, file should be modified to pin to SHA
@@ -1271,7 +1271,7 @@ jobs:
                 "lint",
                 str(temp_dir),
                 "--auto-fix",
-                "--no-auto-latest",
+                "--no-update-actions",
                 "--validation-method",
                 "git",
                 "--format",
@@ -1361,7 +1361,7 @@ jobs:
         # Test that CLI flags are accepted (actual behavior is tested elsewhere)
         test_cases = [
             (["--no-auto-fix"], "Auto-fix disabled via CLI"),
-            (["--no-auto-latest"], "Auto-latest disabled via CLI"),
+            (["--no-update-actions"], "Auto-latest disabled via CLI"),
         ]
 
         for flags, description in test_cases:
@@ -1674,7 +1674,7 @@ jobs:
                 "lint",
                 str(temp_dir),
                 "--auto-fix",
-                "--auto-latest",
+                "--update-actions",
             ],
         )
 
@@ -1801,7 +1801,7 @@ jobs:
                     "lint",
                     str(temp_dir),
                     "--auto-fix",
-                    "--auto-latest",
+                    "--update-actions",
                     "--validation-method",
                     "git",
                 ],
@@ -1839,7 +1839,7 @@ class TestYAMLStructurePreservation:
             parallel_workers=2,
             require_pinned_sha=True,
             auto_fix=True,
-            auto_latest=True,
+            update_actions=True,
             two_space_comments=True,
             skip_actions=False,
             fix_test_calls=False,

--- a/tests/test_auto_fix_atomic_writes.py
+++ b/tests/test_auto_fix_atomic_writes.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Byte-level regression tests for auto-fix file rewriting.
+
+``AutoFixer._apply_fixes_to_file`` used to read a workflow file with
+``readlines()``, mutate a few entries, and write the result back over the
+same path. That approach truncated the original before the replacement
+was durable, discarded CRLF line endings via universal newlines, and
+appended an unconditional ``"\\n"`` to every rewritten line.
+
+These tests drive the method against real files under ``tmp_path`` and
+assert on ``read_bytes()``, so they pin the byte-for-byte behaviour the
+migration onto :func:`~gha_workflow_linter.file_edit.replace_lines`
+guarantees rather than the text the linter happens to render.
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+import stat
+from typing import TYPE_CHECKING, Any, Literal
+
+import pytest
+
+from gha_workflow_linter.auto_fix import AutoFixer
+from gha_workflow_linter.models import Config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+UTF8_BOM = b"\xef\xbb\xbf"
+
+CHECKOUT_OLD = (
+    "      - uses: actions/checkout@v4"  # unpinned, the thing being fixed
+)
+CHECKOUT_NEW = (
+    "      - uses: actions/checkout@"
+    "08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v4.0.0"
+)
+
+
+@pytest.fixture
+def fixer() -> AutoFixer:
+    """An auto-fixer built for direct, offline use of the file rewriter."""
+    return AutoFixer(Config())
+
+
+def write_bytes(path: Path, name: str, content: bytes) -> Path:
+    """Create ``name`` under ``path`` containing exactly ``content``.
+
+    Args:
+        path: Directory to create the file in.
+        name: File name.
+        content: Exact bytes to write.
+
+    Returns:
+        Path to the newly created file.
+    """
+    target = path / name
+    target.write_bytes(content)
+    return target
+
+
+def directory_entries(path: Path) -> list[str]:
+    """Return the sorted names of every entry in ``path``.
+
+    Args:
+        path: Directory to list.
+
+    Returns:
+        Sorted entry names, including any temporary-file debris.
+    """
+    return sorted(entry.name for entry in path.iterdir())
+
+
+class PartialWriter:
+    """Handle wrapper that fails midway through ``writelines``."""
+
+    def __init__(self, handle: Any) -> None:
+        """Wrap ``handle`` so writes stop after the first line.
+
+        Args:
+            handle: Real file object to delegate to.
+        """
+        self._handle = handle
+
+    def __enter__(self) -> PartialWriter:
+        """Return self so the wrapper works as a context manager.
+
+        Returns:
+            This wrapper.
+        """
+        return self
+
+    def __exit__(self, *exc_info: object) -> Literal[False]:
+        """Close the wrapped handle and let the exception propagate.
+
+        Args:
+            *exc_info: Standard exception triple, unused.
+
+        Returns:
+            ``False``, so any in-flight exception is not suppressed.
+        """
+        self._handle.close()
+        return False
+
+    def writelines(self, lines: list[str]) -> None:
+        """Write the first line only, then fail as a full disk would.
+
+        Args:
+            lines: Complete file content to write.
+
+        Raises:
+            OSError: Always, after a deliberately partial write.
+        """
+        for line in lines[:1]:
+            self._handle.write(line)
+        raise OSError("simulated disk full")
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate every other attribute to the wrapped handle.
+
+        Args:
+            name: Attribute being looked up.
+
+        Returns:
+            The corresponding attribute of the wrapped handle.
+        """
+        return getattr(self._handle, name)
+
+
+def _is_write_mode(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+    """Report whether an ``open``-style call requests write access.
+
+    Args:
+        args: Positional arguments the call was made with.
+        kwargs: Keyword arguments the call was made with.
+
+    Returns:
+        ``True`` if the mode grants write access, ``False`` otherwise.
+    """
+    mode = kwargs.get("mode", args[1] if len(args) > 1 else "r")
+    return any(flag in str(mode) for flag in ("w", "a", "+", "x"))
+
+
+def install_failing_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every writable file handle fail after one line.
+
+    A rewrite obtains its writable handle either from ``open(path, "w")``
+    -- as the historical in-place implementation did -- or from
+    :func:`os.fdopen` on a temporary file, as the atomic implementation
+    does. Wrapping both means the injected failure does not presuppose
+    which strategy is in use, so this test genuinely distinguishes a
+    truncating write from an atomic one. Read-mode handles are left
+    alone.
+
+    Args:
+        monkeypatch: Fixture used to install and later undo the patches.
+    """
+    real_open = builtins.open
+    real_fdopen = os.fdopen
+
+    def failing_open(*args: Any, **kwargs: Any) -> Any:
+        handle = real_open(*args, **kwargs)
+        if _is_write_mode(args, kwargs):
+            return PartialWriter(handle)
+        return handle
+
+    def failing_fdopen(*args: Any, **kwargs: Any) -> Any:
+        handle = real_fdopen(*args, **kwargs)
+        if _is_write_mode(args, kwargs):
+            return PartialWriter(handle)
+        return handle
+
+    monkeypatch.setattr(builtins, "open", failing_open)
+    monkeypatch.setattr(os, "fdopen", failing_fdopen)
+
+
+class TestLineEndings:
+    """Rewrites keep each line's original terminator."""
+
+    @pytest.mark.asyncio
+    async def test_crlf_file_stays_crlf(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """Fixing one line does not convert a CRLF file to LF."""
+        target = write_bytes(
+            tmp_path,
+            "workflow.yaml",
+            b"steps:\r\n" + CHECKOUT_OLD.encode() + b"\r\n" + b"  end\r\n",
+        )
+
+        await fixer._apply_fixes_to_file(
+            target, {2: (CHECKOUT_OLD, CHECKOUT_NEW)}
+        )
+
+        assert target.read_bytes() == (
+            b"steps:\r\n" + CHECKOUT_NEW.encode() + b"\r\n" + b"  end\r\n"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mixed_line_endings_survive(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """Each line keeps whichever terminator it already had."""
+        target = write_bytes(
+            tmp_path,
+            "workflow.yaml",
+            b"lf\ncrlf\r\ncr\rlast\n",
+        )
+
+        await fixer._apply_fixes_to_file(target, {2: ("crlf", "CRLF")})
+
+        assert target.read_bytes() == b"lf\nCRLF\r\ncr\rlast\n"
+
+    @pytest.mark.asyncio
+    async def test_cr_only_line_keeps_its_terminator(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """A classic-Mac terminator is not rewritten to LF."""
+        target = write_bytes(tmp_path, "workflow.yaml", b"one\rtwo\r")
+
+        await fixer._apply_fixes_to_file(target, {1: ("one", "ONE")})
+
+        assert target.read_bytes() == b"ONE\rtwo\r"
+
+
+class TestTrailingNewline:
+    """A missing final newline is never invented."""
+
+    @pytest.mark.asyncio
+    async def test_missing_final_newline_is_not_added(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """Fixing the last line of a file without one adds nothing."""
+        target = write_bytes(
+            tmp_path,
+            "workflow.yaml",
+            b"steps:\n" + CHECKOUT_OLD.encode(),
+        )
+
+        await fixer._apply_fixes_to_file(
+            target, {2: (CHECKOUT_OLD, CHECKOUT_NEW)}
+        )
+
+        assert target.read_bytes() == b"steps:\n" + CHECKOUT_NEW.encode()
+
+    @pytest.mark.asyncio
+    async def test_existing_final_newline_is_kept(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """A file that ends with a newline still does afterwards."""
+        target = write_bytes(
+            tmp_path,
+            "workflow.yaml",
+            b"steps:\n" + CHECKOUT_OLD.encode() + b"\n",
+        )
+
+        await fixer._apply_fixes_to_file(
+            target, {2: (CHECKOUT_OLD, CHECKOUT_NEW)}
+        )
+
+        assert target.read_bytes() == (
+            b"steps:\n" + CHECKOUT_NEW.encode() + b"\n"
+        )
+
+
+class TestAtomicity:
+    """A failed rewrite leaves the original file untouched."""
+
+    @pytest.mark.asyncio
+    async def test_failed_write_leaves_file_byte_identical(
+        self,
+        fixer: AutoFixer,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A full disk mid-write must not corrupt the workflow."""
+        original = b"steps:\n" + CHECKOUT_OLD.encode() + b"\n  end\n"
+        target = write_bytes(tmp_path, "workflow.yaml", original)
+        install_failing_writes(monkeypatch)
+
+        with pytest.raises(OSError, match="simulated disk full"):
+            await fixer._apply_fixes_to_file(
+                target, {2: (CHECKOUT_OLD, CHECKOUT_NEW)}
+            )
+
+        assert target.read_bytes() == original
+        assert directory_entries(tmp_path) == ["workflow.yaml"]
+
+    @pytest.mark.asyncio
+    async def test_failed_rename_leaves_file_byte_identical(
+        self,
+        fixer: AutoFixer,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failure to publish is cleaned up completely."""
+        original = b"steps:\n" + CHECKOUT_OLD.encode() + b"\n"
+        target = write_bytes(tmp_path, "workflow.yaml", original)
+
+        def failing_replace(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(os, "replace", failing_replace)
+
+        with pytest.raises(OSError, match="simulated rename failure"):
+            await fixer._apply_fixes_to_file(
+                target, {2: (CHECKOUT_OLD, CHECKOUT_NEW)}
+            )
+
+        assert target.read_bytes() == original
+        assert directory_entries(tmp_path) == ["workflow.yaml"]
+
+
+class TestFileProperties:
+    """Encoding markers and permissions round-trip unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_utf8_bom_survives(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """A byte order mark is neither stripped nor duplicated."""
+        target = write_bytes(
+            tmp_path,
+            "workflow.yaml",
+            UTF8_BOM + b"steps:\n" + CHECKOUT_OLD.encode() + b"\n",
+        )
+
+        changes = await fixer._apply_fixes_to_file(
+            target, {2: (CHECKOUT_OLD, CHECKOUT_NEW)}
+        )
+
+        assert target.read_bytes() == (
+            UTF8_BOM + b"steps:\n" + CHECKOUT_NEW.encode() + b"\n"
+        )
+        assert changes[0]["old_line"] == CHECKOUT_OLD
+
+    @pytest.mark.asyncio
+    async def test_file_permissions_survive(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """The rewritten file keeps the original's mode bits."""
+        target = write_bytes(tmp_path, "workflow.yaml", b"one\ntwo\n")
+        target.chmod(0o600)
+
+        await fixer._apply_fixes_to_file(target, {1: ("one", "ONE")})
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        assert target.read_bytes() == b"ONE\ntwo\n"
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_content_round_trips(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """UTF-8 content elsewhere in the file is not mangled."""
+        original = "# naïve\nold\n".encode()
+        target = write_bytes(tmp_path, "workflow.yaml", original)
+
+        await fixer._apply_fixes_to_file(target, {2: ("old", "néw")})
+
+        assert target.read_bytes() == "# naïve\nnéw\n".encode()
+
+
+class TestReturnedChanges:
+    """The reported changes match what landed on disk."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_lines_in_one_call(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """Every requested line is rewritten and reported once."""
+        target = write_bytes(tmp_path, "workflow.yaml", b"a\nb\nc\nd\n")
+
+        changes = await fixer._apply_fixes_to_file(
+            target, {3: ("c", "C"), 1: ("a", "A")}
+        )
+
+        assert target.read_bytes() == b"A\nb\nC\nd\n"
+        assert changes == [
+            {"line_number": "1", "old_line": "a", "new_line": "A"},
+            {"line_number": "3", "old_line": "c", "new_line": "C"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_old_line_reflects_disk_content(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """A stale caller-supplied ``old_line`` cannot skew the diff."""
+        target = write_bytes(tmp_path, "workflow.yaml", b"actual\nsecond\n")
+
+        changes = await fixer._apply_fixes_to_file(
+            target, {1: ("stale expectation", "fixed")}
+        )
+
+        assert changes == [
+            {"line_number": "1", "old_line": "actual", "new_line": "fixed"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_old_line_excludes_the_terminator(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """Reported content never carries a stray ``\\r`` or ``\\n``."""
+        target = write_bytes(tmp_path, "workflow.yaml", b"one\r\ntwo\r\n")
+
+        changes = await fixer._apply_fixes_to_file(target, {1: ("one", "ONE")})
+
+        assert changes[0]["old_line"] == "one"
+        assert changes[0]["new_line"] == "ONE"
+
+    @pytest.mark.asyncio
+    async def test_untouched_lines_are_byte_identical(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """Only the targeted line differs from the original bytes."""
+        original = (
+            b"---\n"
+            # REUSE-IgnoreStart
+            b"# SPDX-License-Identifier: Apache-2.0\r\n"
+            # REUSE-IgnoreEnd
+            b"jobs:\n"
+            + CHECKOUT_OLD.encode()
+            + b"\r\n"
+            + b"  trailing\twhitespace   \n"
+        )
+        target = write_bytes(tmp_path, "workflow.yaml", original)
+
+        await fixer._apply_fixes_to_file(
+            target, {4: (CHECKOUT_OLD, CHECKOUT_NEW)}
+        )
+
+        rewritten = target.read_bytes()
+        assert rewritten.split(b"\n")[0] == original.split(b"\n")[0]
+        # REUSE-IgnoreStart
+        assert b"# SPDX-License-Identifier: Apache-2.0\r\n" in rewritten
+        # REUSE-IgnoreEnd
+        assert rewritten.endswith(b"  trailing\twhitespace   \n")
+        assert CHECKOUT_NEW.encode() + b"\r\n" in rewritten
+
+
+class TestNoOpAndErrors:
+    """Edge cases around empty and invalid fix mappings."""
+
+    @pytest.mark.asyncio
+    async def test_empty_fixes_do_not_touch_the_file(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """No fixes means no write, and no modification-time change."""
+        original = b"steps:\n" + CHECKOUT_OLD.encode() + b"\n"
+        target = write_bytes(tmp_path, "workflow.yaml", original)
+        os.utime(target, (1_000_000, 1_000_000))
+        before = target.stat().st_mtime_ns
+
+        changes = await fixer._apply_fixes_to_file(target, {})
+
+        assert changes == []
+        assert target.read_bytes() == original
+        assert target.stat().st_mtime_ns == before
+        assert directory_entries(tmp_path) == ["workflow.yaml"]
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_line_leaves_file_unchanged(
+        self, fixer: AutoFixer, tmp_path: Path
+    ) -> None:
+        """An impossible line number aborts the whole rewrite."""
+        original = b"one\ntwo\n"
+        target = write_bytes(tmp_path, "workflow.yaml", original)
+
+        with pytest.raises(ValueError, match="out of range"):
+            await fixer._apply_fixes_to_file(
+                target, {1: ("one", "ONE"), 9: ("nine", "NINE")}
+            )
+
+        assert target.read_bytes() == original
+        assert directory_entries(tmp_path) == ["workflow.yaml"]

--- a/tests/test_auto_fix_cli_flags.py
+++ b/tests/test_auto_fix_cli_flags.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from gha_workflow_linter.cli import app
+from tests.conftest import strip_ansi
 
 
 class TestAutoFixCLIFlags:
@@ -228,7 +229,9 @@ class TestAutoFixHelp:
 
         result = runner.invoke(app, ["lint", "--help"])
 
-        help_text = result.stdout.lower()
+        # Rich inserts colour codes inside option names when it
+        # believes it is writing to a terminal, which CI does.
+        help_text = strip_ansi(result.stdout).lower()
 
         # Check for auto-fix related options in help
         # Use partial matching to handle formatting differences

--- a/tests/test_auto_fix_cli_flags.py
+++ b/tests/test_auto_fix_cli_flags.py
@@ -73,8 +73,8 @@ jobs:
         flag_combinations = [
             ["--auto-fix"],
             ["--no-auto-fix"],
-            ["--auto-latest"],
-            ["--no-auto-latest"],
+            ["--update-actions"],
+            ["--no-update-actions"],
             ["--two-space-comments"],
             ["--no-two-space-comments"],
             ["--require-pinned-sha"],
@@ -155,7 +155,7 @@ jobs:
         config_content = """
 require_pinned_sha: "invalid_boolean"
 auto_fix: 123
-auto_latest: "true_but_string"
+update_actions: "true_but_string"
 two_space_comments: null
 """
         config_file = temp_dir / "gha-workflow-linter.yaml"
@@ -215,7 +215,7 @@ jobs:
 
             assert "require_pinned_sha:" in generated_config
             assert "auto_fix:" in generated_config
-            assert "auto_latest:" in generated_config
+            assert "update_actions:" in generated_config
             assert "two_space_comments:" in generated_config
 
 
@@ -233,6 +233,8 @@ class TestAutoFixHelp:
         # Check for auto-fix related options in help
         # Use partial matching to handle formatting differences
         assert "auto-fix" in help_text
+        assert "update-actions" in help_text
+        # The deprecated spelling stays discoverable until removal.
         assert "auto-latest" in help_text
         assert "two-space" in help_text or "two space" in help_text
         assert "require-pinned-sha" in help_text or "pinned-sha" in help_text

--- a/tests/test_auto_fix_mismatched_sha.py
+++ b/tests/test_auto_fix_mismatched_sha.py
@@ -38,7 +38,7 @@ class TestMismatchedShaFix:
             parallel_workers=2,
             require_pinned_sha=True,
             auto_fix=True,
-            auto_latest=False,  # Should not upgrade to latest
+            update_actions=False,  # Should not upgrade to latest
             two_space_comments=True,
             skip_actions=False,
             fix_test_calls=False,
@@ -236,7 +236,7 @@ jobs:
         self, config: Config, tmp_path: Path
     ) -> None:
         """Test that mismatched SHA respects comment version even when check_for_updates=True."""
-        config.auto_latest = True
+        config.update_actions = True
 
         # Create a workflow file with a valid but mismatched SHA
         workflow_content = """
@@ -327,7 +327,7 @@ jobs:
         self, config: Config, tmp_path: Path
     ) -> None:
         """Test that INVALID_REFERENCE with comment uses comment version even with check_for_updates."""
-        config.auto_latest = True
+        config.update_actions = True
 
         workflow_content = """
 name: Test
@@ -425,7 +425,7 @@ class TestInvalidReferenceWithCommentVersion:
             parallel_workers=2,
             require_pinned_sha=True,
             auto_fix=True,
-            auto_latest=False,
+            update_actions=False,
             two_space_comments=True,
             skip_actions=False,
             fix_test_calls=False,

--- a/tests/test_cache_integration.py
+++ b/tests/test_cache_integration.py
@@ -15,6 +15,7 @@ from typer.testing import CliRunner
 from gha_workflow_linter.cache import CacheConfig, ValidationCache
 from gha_workflow_linter.cli import app
 from gha_workflow_linter.models import ValidationResult
+from tests.conftest import strip_ansi
 
 
 class TestCacheIntegration:
@@ -120,7 +121,7 @@ cache:
                 app, ["cache", "--purge", "--config", config_file]
             )
             assert result.exit_code == 0
-            assert "Purged 2 cache entries" in result.stdout
+            assert "Purged 2 cache entries" in strip_ansi(result.stdout)
 
             # Verify cache is empty
             new_cache = ValidationCache(cache_config)
@@ -171,7 +172,9 @@ cache:
                 app, ["cache", "--cleanup", "--config", config_file]
             )
             assert result.exit_code == 0
-            assert "Removed 1 expired cache entries" in result.stdout
+            assert "Removed 1 expired cache entries" in strip_ansi(
+                result.stdout
+            )
         finally:
             Path(config_file).unlink()
 
@@ -198,7 +201,7 @@ cache:
                 app, ["cache", "--info", "--config", config_file]
             )
             assert result.exit_code == 0
-            assert "Enabled        │ False" in result.stdout
+            assert "Enabled        │ False" in strip_ansi(result.stdout)
 
         finally:
             Path(config_file).unlink()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ from gha_workflow_linter.models import (
     ValidationError,
     ValidationResult,
 )
+from tests.conftest import strip_ansi
 
 
 class TestCLICallbacks:
@@ -163,20 +164,20 @@ class TestCLICommands:
         """Test main app help."""
         result = self.runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert __version__ in result.stdout
+        assert __version__ in strip_ansi(result.stdout)
         assert "GitHub Actions workflow linter" in result.stdout
 
     def test_version_flag(self) -> None:
         """Test --version flag."""
         result = self.runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert __version__ in result.stdout
+        assert __version__ in strip_ansi(result.stdout)
 
     def test_lint_help(self) -> None:
         """Test lint command help."""
         result = self.runner.invoke(app, ["lint", "--help"])
         assert result.exit_code == 0
-        assert __version__ in result.stdout
+        assert __version__ in strip_ansi(result.stdout)
         assert "Scan GitHub Actions workflows" in result.stdout
 
     @patch("gha_workflow_linter.cli.ConfigManager")

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the generated default configuration template.
+
+The template is generated from :class:`~gha_workflow_linter.models.Config`
+rather than hand-written. These tests exist to keep it that way: the
+round-trip assertion is what makes drift impossible, and the
+``model_fields``-driven coverage assertions fail the moment a new field
+is added to the model without appearing in the template.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from gha_workflow_linter.config import ConfigManager, _model_lines
+from gha_workflow_linter.models import (
+    AllowListConfig,
+    CacheConfig,
+    Config,
+    GitConfig,
+    GitHubAPIConfig,
+    LogLevel,
+    NetworkConfig,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+NESTED_BLOCKS: list[tuple[str, type[BaseModel]]] = [
+    ("network", NetworkConfig),
+    ("git", GitConfig),
+    ("github_api", GitHubAPIConfig),
+    ("cache", CacheConfig),
+    ("allow_list", AllowListConfig),
+]
+
+
+@pytest.fixture
+def generated_path(tmp_path: Path) -> Path:
+    """Write the default configuration template to a temporary file.
+
+    Args:
+        tmp_path: pytest-provided temporary directory.
+
+    Returns:
+        Path to the generated configuration file.
+    """
+    return ConfigManager().save_default_config(tmp_path / "config.yaml")
+
+
+@pytest.fixture
+def generated_text(generated_path: Path) -> str:
+    """Read the generated configuration template.
+
+    Args:
+        generated_path: Path to the generated configuration file.
+
+    Returns:
+        Raw text of the generated file.
+    """
+    return generated_path.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def generated_data(generated_text: str) -> dict[str, Any]:
+    """Parse the generated configuration template.
+
+    Args:
+        generated_text: Raw text of the generated file.
+
+    Returns:
+        Parsed mapping from the generated file.
+    """
+    data: Any = yaml.safe_load(generated_text)
+    assert isinstance(data, dict)
+    return data
+
+
+class TestGeneratedTemplateRoundTrip:
+    """The generated template must reproduce the default configuration."""
+
+    def test_round_trip_equals_default_config(
+        self, generated_path: Path
+    ) -> None:
+        """Loading the generated file yields the default Config."""
+        loaded = ConfigManager().load_config(generated_path)
+
+        assert loaded == Config()
+
+    def test_round_trip_is_stable(self, generated_path: Path) -> None:
+        """Regenerating from the loaded config produces identical text."""
+        first = generated_path.read_text(encoding="utf-8")
+        second_path = generated_path.parent / "again.yaml"
+        ConfigManager().save_default_config(second_path)
+
+        assert second_path.read_text(encoding="utf-8") == first
+
+    def test_template_is_parsable_yaml(
+        self, generated_data: dict[str, Any]
+    ) -> None:
+        """The generated file parses as a YAML mapping."""
+        assert generated_data
+
+
+class TestGeneratedTemplateCoverage:
+    """Every model field must appear in the generated template."""
+
+    def test_all_top_level_fields_present(
+        self, generated_data: dict[str, Any]
+    ) -> None:
+        """Each Config field appears as a top-level key."""
+        missing = set(Config.model_fields) - set(generated_data)
+
+        assert not missing, f"template omits Config fields: {sorted(missing)}"
+
+    def test_no_unexpected_top_level_keys(
+        self, generated_data: dict[str, Any]
+    ) -> None:
+        """The template does not invent keys the model cannot accept."""
+        unexpected = set(generated_data) - set(Config.model_fields)
+
+        assert not unexpected
+
+    @pytest.mark.parametrize(("block", "model"), NESTED_BLOCKS)
+    def test_nested_block_present_with_all_fields(
+        self,
+        generated_data: dict[str, Any],
+        block: str,
+        model: type[BaseModel],
+    ) -> None:
+        """Each nested block appears with every field of its model."""
+        nested: Any = generated_data[block]
+
+        assert isinstance(nested, dict)
+        missing = set(model.model_fields) - set(nested)
+        assert not missing, f"{block} omits: {sorted(missing)}"
+
+    def test_field_order_follows_model_declaration(
+        self, generated_data: dict[str, Any]
+    ) -> None:
+        """Keys are not alphabetised; they follow the model's order."""
+        assert list(generated_data) == list(Config.model_fields)
+
+    def test_previously_omitted_fields_present(
+        self, generated_data: dict[str, Any]
+    ) -> None:
+        """Fields the hand-written template silently dropped are back."""
+        for key in (
+            "validation_method",
+            "allow_prerelease",
+            "fix_test_calls",
+            "cooldown_days",
+            "git",
+            "cache",
+        ):
+            assert key in generated_data
+
+    def test_field_descriptions_emitted_as_comments(
+        self, generated_text: str
+    ) -> None:
+        """Comments come from the model, so they cannot drift either."""
+        for name, field in Config.model_fields.items():
+            if field.description:
+                first_word = field.description.split()[0]
+                assert f"# {first_word}" in generated_text, name
+
+
+class TestGeneratedTemplateSerialisation:
+    """Values must serialise as portable YAML scalars."""
+
+    def test_cache_dir_is_a_string(
+        self, generated_data: dict[str, Any]
+    ) -> None:
+        """Path values serialise as strings, not Python objects."""
+        cache: Any = generated_data["cache"]
+        cache_dir: Any = cache["cache_dir"]
+
+        assert isinstance(cache_dir, str)
+        assert Path(cache_dir) == CacheConfig().cache_dir
+
+    def test_no_python_object_tags(self, generated_text: str) -> None:
+        """No value relies on PyYAML's Python-specific tags."""
+        assert "!!python" not in generated_text
+
+    def test_enum_values_are_strings(
+        self, generated_data: dict[str, Any], generated_text: str
+    ) -> None:
+        """Enums serialise as their string values."""
+        assert generated_data["log_level"] == LogLevel.INFO.value
+        assert isinstance(generated_data["log_level"], str)
+        assert "log_level: INFO" in generated_text
+
+    def test_optional_enum_serialises_as_null(
+        self, generated_data: dict[str, Any], generated_text: str
+    ) -> None:
+        """An unset ValidationMethod round-trips as null, not a tag."""
+        assert generated_data["validation_method"] is None
+        assert "validation_method: null" in generated_text
+
+    def test_booleans_use_yaml_literals(self, generated_text: str) -> None:
+        """Booleans are lowercase YAML, not Python repr."""
+        assert "require_pinned_sha: true" in generated_text
+        assert "update_actions: false" in generated_text
+        offenders = re.findall(
+            r"^\s*\w+: (?:True|False)$", generated_text, re.M
+        )
+        assert not offenders
+
+    def test_lists_render_as_indented_sequences(
+        self, generated_data: dict[str, Any], generated_text: str
+    ) -> None:
+        """Sequences are indented under their key, as yamllint expects."""
+        assert generated_data["scan_extensions"] == [".yml", ".yaml"]
+        assert "scan_extensions:\n  - .yml\n  - .yaml\n" in generated_text
+
+
+class TestGeneratedTemplateToken:
+    """The template must never carry a GitHub token."""
+
+    def test_token_is_empty(self, generated_data: dict[str, Any]) -> None:
+        """No token value is written to the template."""
+        github_api: Any = generated_data["github_api"]
+
+        assert not github_api["token"]
+
+    def test_token_line_carries_no_value(self, generated_text: str) -> None:
+        """The token key is emitted with an empty value."""
+        assert re.search(r"^  token:[ \t]*$", generated_text, re.MULTILINE)
+
+    def test_token_not_written_when_present(self) -> None:
+        """A token held in the running config is never serialised."""
+        secret = "ghp_notarealtokenbutitlookslikeone"
+        rendered = "\n".join(
+            _model_lines(
+                GitHubAPIConfig(token=secret),
+                indent=2,
+                path="github_api",
+            )
+        )
+
+        assert secret not in rendered
+        assert re.search(r"^  token:[ \t]*$", rendered, re.MULTILINE)
+
+    def test_token_documented(self, generated_text: str) -> None:
+        """The template explains where the token comes from."""
+        assert "GITHUB_TOKEN" in generated_text
+        assert "GitHub CLI" in generated_text
+
+
+class TestGeneratedTemplateHeader:
+    """The static header must survive generation."""
+
+    def test_starts_with_spdx_lines(self, generated_text: str) -> None:
+        """The file opens with the project's SPDX convention."""
+        lines = generated_text.splitlines()
+
+        # REUSE-IgnoreStart
+        assert lines[0] == "# SPDX-License-Identifier: Apache-2.0"
+        # REUSE-IgnoreEnd
+        assert lines[1] == (
+            "# SPDX-FileCopyrightText: 2026 The Linux Foundation"
+        )
+
+    def test_header_notes_generation_and_docs(
+        self, generated_text: str
+    ) -> None:
+        """The header says the file is generated and points at the docs."""
+        assert "gha-workflow-linter configuration file" in generated_text
+        assert "Generated from the configuration model" in generated_text
+        assert (
+            "https://github.com/lfit/gha-workflow-linter#configuration"
+            in generated_text
+        )
+
+    def test_document_start_marker_present(self, generated_text: str) -> None:
+        """A document start marker follows the header comment."""
+        assert "\n---\n" in generated_text
+
+
+class TestGeneratedTemplateFormatting:
+    """Output should satisfy the repository's YAML lint conventions."""
+
+    def test_no_trailing_whitespace(self, generated_text: str) -> None:
+        """No line carries trailing whitespace."""
+        offenders = [
+            line
+            for line in generated_text.splitlines()
+            if line.rstrip() != line
+        ]
+
+        assert not offenders
+
+    def test_lines_within_line_length(self, generated_text: str) -> None:
+        """Every line fits the 80 column limit."""
+        offenders = [
+            line for line in generated_text.splitlines() if len(line) > 80
+        ]
+
+        assert not offenders
+
+    def test_ends_with_single_newline(self, generated_text: str) -> None:
+        """The file ends with exactly one newline."""
+        assert generated_text.endswith("\n")
+        assert not generated_text.endswith("\n\n")
+
+    def test_indentation_is_two_spaces(self, generated_text: str) -> None:
+        """Nested keys are indented by two spaces."""
+        assert "\ngithub_api:\n" in generated_text
+        assert "\n  base_url: https://api.github.com\n" in generated_text

--- a/tests/test_files_option.py
+++ b/tests/test_files_option.py
@@ -272,7 +272,7 @@ runs:
                     "--files",
                     ".github/workflows/ci.yml",
                     "--auto-fix",
-                    "--no-auto-latest",
+                    "--no-update-actions",
                 ],
             )
 

--- a/tests/test_update_actions_migration.py
+++ b/tests/test_update_actions_migration.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the --auto-latest to --update-actions migration.
+
+``--auto-latest`` was renamed once a second updatable thing existed: with
+both action pins and allow-list pins in play, "latest" no longer said
+which. The old spelling keeps working so scripts and CI configurations do
+not break, and these tests pin that promise from both directions -- the
+old name still works, and the new one wins when both are given.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime by fixtures
+
+import pytest
+from typer.testing import CliRunner
+
+from gha_workflow_linter.cli import _resolve_update_actions
+from gha_workflow_linter.config import ConfigManager
+from gha_workflow_linter.models import Config
+
+
+class TestFlagResolution:
+    """--update-actions and the deprecated --auto-latest."""
+
+    @pytest.mark.parametrize(
+        ("update_actions", "auto_latest", "expected"),
+        [
+            (None, None, None),
+            (True, None, True),
+            (False, None, False),
+            (None, True, True),
+            (None, False, False),
+            # Both given: the canonical flag wins, so adding the new name
+            # to an existing invocation gets what it asked for.
+            (True, False, True),
+            (False, True, False),
+        ],
+    )
+    def test_resolution(
+        self,
+        update_actions: bool | None,
+        auto_latest: bool | None,
+        expected: bool | None,
+    ) -> None:
+        assert (
+            _resolve_update_actions(update_actions, auto_latest, quiet=True)
+            is expected
+        )
+
+    def test_deprecated_flag_warns(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _resolve_update_actions(None, True, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "deprecated" in captured.err
+        assert "--update-actions" in captured.err
+
+    def test_warning_goes_to_stderr_not_stdout(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--format json must stay machine-readable."""
+        _resolve_update_actions(None, True, quiet=False)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_canonical_flag_is_silent(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _resolve_update_actions(True, None, quiet=False)
+
+        assert capsys.readouterr().err == ""
+
+    def test_quiet_suppresses_the_notice(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _resolve_update_actions(None, True, quiet=True)
+
+        assert capsys.readouterr().err == ""
+
+
+class TestBothFlagsAreAccepted:
+    """Neither spelling may be rejected by the argument parser."""
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--update-actions",
+            "--no-update-actions",
+            "--auto-latest",
+            "--no-auto-latest",
+        ],
+    )
+    def test_flag_parses(self, flag: str, tmp_path: Path) -> None:
+        from gha_workflow_linter.cli import app
+
+        result = CliRunner().invoke(
+            app, ["lint", str(tmp_path), flag, "--no-allow-list"]
+        )
+
+        assert "No such option" not in result.output
+
+    def test_help_lists_both(self) -> None:
+        from gha_workflow_linter.cli import app
+
+        text = CliRunner().invoke(app, ["lint", "--help"]).stdout.lower()
+
+        assert "update-actions" in text
+        assert "auto-latest" in text
+        assert "deprecated" in text
+
+
+class TestConfigKeyMigration:
+    """The config file key follows the same rules as the flag."""
+
+    def test_new_key_loads(self, tmp_path: Path) -> None:
+        target = tmp_path / "cfg.yaml"
+        target.write_text("update_actions: true\n")
+
+        assert ConfigManager().load_config(target).update_actions is True
+
+    def test_deprecated_key_still_loads(self, tmp_path: Path) -> None:
+        target = tmp_path / "cfg.yaml"
+        target.write_text("auto_latest: true\n")
+
+        assert ConfigManager().load_config(target).update_actions is True
+
+    def test_deprecated_key_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        target = tmp_path / "cfg.yaml"
+        target.write_text("auto_latest: true\n")
+
+        with caplog.at_level("WARNING"):
+            ConfigManager().load_config(target)
+
+        assert "auto_latest" in caplog.text
+        assert "update_actions" in caplog.text
+
+    def test_new_key_wins_when_both_present(self, tmp_path: Path) -> None:
+        target = tmp_path / "cfg.yaml"
+        target.write_text("auto_latest: true\nupdate_actions: false\n")
+
+        assert ConfigManager().load_config(target).update_actions is False
+
+    def test_new_key_does_not_warn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        target = tmp_path / "cfg.yaml"
+        target.write_text("update_actions: true\n")
+
+        with caplog.at_level("WARNING"):
+            ConfigManager().load_config(target)
+
+        assert "deprecated" not in caplog.text
+
+    def test_default_is_off(self) -> None:
+        assert Config().update_actions is False
+
+    def test_generated_template_uses_the_new_name(self, tmp_path: Path) -> None:
+        """A freshly generated config must not teach the old spelling."""
+        written = ConfigManager().save_default_config(tmp_path / "cfg.yaml")
+        text = written.read_text()
+
+        assert "update_actions:" in text
+        assert "auto_latest:" not in text

--- a/tests/test_update_actions_migration.py
+++ b/tests/test_update_actions_migration.py
@@ -20,6 +20,7 @@ from typer.testing import CliRunner
 from gha_workflow_linter.cli import _resolve_update_actions
 from gha_workflow_linter.config import ConfigManager
 from gha_workflow_linter.models import Config
+from tests.conftest import strip_ansi
 
 
 class TestFlagResolution:
@@ -107,7 +108,8 @@ class TestBothFlagsAreAccepted:
     def test_help_lists_both(self) -> None:
         from gha_workflow_linter.cli import app
 
-        text = CliRunner().invoke(app, ["lint", "--help"]).stdout.lower()
+        raw = CliRunner().invoke(app, ["lint", "--help"]).stdout
+        text = strip_ansi(raw).lower()
 
         assert "update-actions" in text
         assert "auto-latest" in text


### PR DESCRIPTION
## Summary

Phase 3 of the work tracked in #296: consolidation. **No allow-list
behaviour changes** — this is the flag migration, the atomic-write fix,
and the configuration template, all of which the earlier phases deferred.

Design: `docs/ALLOW_LIST_FEATURE.md` §18.

## `--auto-latest` becomes `--update-actions`

The old name said "latest" without saying latest *what*. That was fine
while action pins were the only updatable thing; with allow-list pins now
in play it is ambiguous, and the two switches should read alike:

```console
gha-workflow-linter lint --auto-fix --update-actions
gha-workflow-linter lint --update-allow-list
```

The old spelling keeps working, **on the flag and as a configuration
key**, so scripts and CI configurations do not break. Both emit a
deprecation notice, and both stay until no earlier than the next major
release.

| given | result |
| --- | --- |
| `--update-actions` | used, silently |
| `--auto-latest` | used, with a deprecation notice |
| both | the canonical one wins |
| `auto_latest:` in a config file | loads, with a notice |
| both keys in a config file | `update_actions` wins |

The canonical flag winning matters: adding the new name to an existing
invocation gets what it asks for, rather than silently keeping the old
value.

The notice goes to **standard error, never standard output**, so
`--format json` stays machine-readable. Verified end to end.

## The auto-fixer no longer risks corrupting workflow files

`AutoFixer._apply_fixes_to_file` truncated the original with
`open(path, "w")` and rebuilt it from `readlines()`. Three defects
followed:

1. **Non-atomic** — a crash, full disk or interrupt mid-write destroyed
   the user's workflow file, with no backup.
2. **Line endings destroyed** — universal newlines plus a hard-coded
   `"\n"` converted any CRLF file to LF wholesale.
3. **Trailing newline invented** — appending `"\n"` unconditionally added
   one to files that had none.

It now uses `file_edit.replace_lines`, added in #297 and already used by
the allow-list fixer: one atomic write per file, preserving each line's
own terminator.

Sixteen regression tests cover this, and the three headline defects were
**confirmed to fail against the old implementation** before the change
landed. Worth noting: the first version of the atomicity test
monkeypatched `os.fdopen`, which the old code never calls — so it
"failed" only with `DID NOT RAISE`, proving nothing. The test now wraps
both `builtins.open` and `os.fdopen`, and against the old code the
fixture file is genuinely left truncated to `b'steps:\n'`.

Two smaller behaviour changes fall out, both documented:

- `old_line` in the returned changes now comes from disk rather than the
  caller's tuple, so a rendered diff cannot claim a line said something
  it did not.
- An out-of-range line number now raises instead of being silently
  dropped, making a caller bug all-or-nothing for that file rather than
  partially applied.

## The generated config file is generated from the model

`save_default_config` built its output from a hand-written f-string that
had drifted badly. Confirmed missing: `validation_method`,
`allow_prerelease`, `fix_test_calls`, `cooldown_days`, the **entire**
`git:` and `cache:` blocks, and most of `allow_list:`. Every field added
since the template was written had silently failed to appear, and nothing
caught it.

It now renders `Config()` through `yaml.dump`, with each field commented
using its own model `description`, so neither the values nor the prose
can drift again:

```yaml
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: 2026 The Linux Foundation

# gha-workflow-linter configuration file
#
# Generated from the configuration model: every setting the tool
# understands appears below, commented with its purpose and set to its
# default value.
---

# Logging level
log_level: INFO
```

The load-bearing test asserts the generated file **round-trips to a
`Config` equal to the default**, and coverage tests are driven by
`model_fields` so a new field fails until it appears. Booleans are now
YAML `true`/`false` rather than Python `True`/`False`, and
`github_api.token` is emitted empty with an explanation.

## Documentation

- New **exit-code table** covering `0`/`1`/`2`/`3`/`4`/`5` with the
  precedence rule.
- New **`--verify-actions`** section (the flag shipped in #297 but was
  never documented).
- The renamed flag throughout.
- Fixed a defect in the configuration example: it claimed
  `two_space_comments` defaults to `false`; the model says `true`.

## Validation

- **1375 tests** passing (from 1306), coverage 83.6% (gate 70%)
- `ruff`, `ruff format`, `mypy --strict`, `basedpyright --strict`,
  `markdownlint`, `write-good`, `reuse`, `codespell`, `aislop`,
  `yamllint`, `actionlint` — all pass
- Migration verified against the real CLI: deprecated flag warns on
  stderr and not stdout, canonical flag is silent, `--format json` still
  parses, and the deprecated config key loads with a notice

## Note

Two REUSE false positives were suppressed with `REUSE-IgnoreStart` /
`REUSE-IgnoreEnd`: the new tests contain `SPDX-License-Identifier`
strings inside fixtures and assertions, which REUSE otherwise reads as
real (and invalid) license declarations.
