### PR TITLE
Fix: Bump PyPI publish action to v0.2.0

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: development
           tag: ${{ needs.release.outputs.tag }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: production
           tag: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
Bumps the PyPI publish action **v0.1.9 → v0.2.0** at both call sites, so a tag push can publish.

## Why

This project builds with **Hatchling**, which since 1.30 defaults to `Metadata-Version: 2.5`. Confirmed against a local build of the current tree:

```console
$ uv build && unzip -p dist/*.whl '*/METADATA' | head -1
Metadata-Version: 2.5
```

The publish action pinned here carried a twine that rejects that version:

```
ERROR    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
         valid metadata version
```

The rejection comes from twine **inside the publish container**, not from PyPI. twine replaces `packaging`'s list of valid metadata versions with its own hard-coded copy, which stopped at `2.4`, so nothing in this repository can work around it. v0.2.0 carries a backend with twine 7.0, whose copy includes `2.5`.

## Why by hand rather than via Dependabot

The seven-day cooldown would hold this until then, and the allow-list work merged in #300 and #303 cannot reach PyPI until this lands. The same bump is already open elsewhere in the organisation for the same reason:

- lfreleng-actions/lftools-uv#631
- lfreleng-actions/dependamerge#415

## Note on the pin

The SHA is the **peeled commit** for `v0.2.0`, not the annotated tag object:

```console
8798fe4e79f0c221b92f2c94a9ac3455d9ac178e  refs/tags/v0.2.0      # tag object
276603f5d72b11427755ef139c6fb80489cec5d9  refs/tags/v0.2.0^{}   # commit  <- pinned
```

GitHub Actions cannot check out a tag object, so pinning the former produces a reference that fails at run time. This linter now detects that case (`ANNOTATED_TAG_SHA`, added in #297) and reports the peeled commit to use instead; running it against this change confirms the pin is valid.

## Validation

- `actionlint`, `yamllint`, `reuse`, `codespell`, `aislop` — clean
- `gha-workflow-linter` against its own workflows — all action calls valid
- Local build confirms the metadata version that triggers the failure
