### PR TITLE
Fix: check a fixed tree in the mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,29 @@ repos:
     rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0
     hooks:
       - id: mypy
+        # Analyse a fixed tree rather than whatever happens to be staged.
+        # This hook runs in an isolated virtualenv built from
+        # additional_dependencies below, which cannot include
+        # gha_workflow_linter itself. Handed only test files, mypy could
+        # not resolve `from gha_workflow_linter...`, the imported names
+        # degraded to Any, and `strict = true` turned every use of one
+        # into an error -- so committing a change to tests/ alone failed
+        # while `--all-files` passed. Naming the directories puts src/ in
+        # front of mypy every time, so the imports resolve from source.
+        #
+        # args replaces the hook's defaults rather than adding to them,
+        # so --ignore-missing-imports and --scripts-are-modules are
+        # repeated here; dropping them would change what is checked.
+        # Keep the directory list in step with [tool.basedpyright]
+        # include in pyproject.toml.
+        pass_filenames: false
+        args:
+          - --ignore-missing-imports
+          - --scripts-are-modules
+          - src
+          - tests
+          - scripts
+          - examples
         additional_dependencies:
           - pydantic>=2.10.3
           - pydantic-settings>=2.7.0


### PR DESCRIPTION
Fixes #316.

The `mypy` hook failed whenever it ran on a subset of files — which is what happens on every `git commit` — while passing on the full set:

```console
$ prek run mypy --all-files
mypy.....................................................................Passed

$ prek run mypy --files tests/test_auto_fix.py
mypy.....................................................................Failed
  tests/test_auto_fix.py:125: error: Class cannot subclass "ActionCallValidator" (has type "Any")  [misc]
  tests/test_auto_fix.py:178: error: Class cannot subclass "AutoFixer" (has type "Any")  [misc]
  tests/test_auto_fix.py:1356: error: Returning Any from function declared to return "str"  [no-any-return]
```

The hook runs in an isolated virtualenv built from its `additional_dependencies`, and that list cannot carry `gha_workflow_linter` itself. Handed only test files, mypy could not resolve `from gha_workflow_linter…`, the imported names degraded to `Any`, and `strict = true` turned every use of one into an error. The errors were an artefact of the file set, not of the code — `uv run mypy tests/test_auto_fix.py`, with the project installed, reports `Success`.

## Change

Name the directories and stop passing filenames, so `src/` is in front of mypy every time and the imports resolve from source. No strictness setting is relaxed and no error is suppressed; checking gets *stronger*, because test files are no longer analysed in isolation against an absent package.

Two details that were easy to get wrong, and which the issue's suggested snippet would have got wrong:

- **`args` replaces the hook's defaults rather than adding to them.** `mirrors-mypy` at the pinned rev defines `args: ["--ignore-missing-imports", "--scripts-are-modules"]`. Both are repeated explicitly; omitting them would have quietly changed what is checked.
- **`scripts/` and `examples/` are named too**, not just `src` and `tests` as #316 proposed. Those directories contain Python (`scripts/trace_async_execution.py`, `examples/cache_demo.py`, and two more) and are reached today only by way of being staged, so pinning the list to two directories would have stopped them being checked at all. The list now matches `[tool.basedpyright] include`, and a comment asks that they be kept in step.

## Verification

Liveness — a bad return type appended to `scripts/simple_profile.py`, with the hook invoked against an *unrelated* file in `src/`:

```console
$ prek run mypy --files src/gha_workflow_linter/cli.py
  scripts/simple_profile.py:85: error: Incompatible return value type (got "str", expected "int")  [return-value]
  Found 1 error in 1 file (checked 92 source files)
```

So the whole tree is analysed whatever is staged, and `scripts/` is genuinely covered.

| Check | Before | After |
| --- | --- | --- |
| `prek run mypy --files tests/test_auto_fix.py` | 3 errors | **Passed** |
| `prek run mypy --all-files` | Passed | **Passed** |
| Commit touching only `tests/` | needed `SKIP=mypy` | **no skip needed** |
| Files analysed on a partial run | 1 | **92** |

Runtime is ~3s cold, ~0.3s warm, so the whole-tree analysis costs little per commit. This commit itself was made without `SKIP=mypy`, unlike all three on #315.
