### PR TITLE
Test: cover the per-file auto-fix write failure

### DIFF
--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -11,15 +11,19 @@ from breaking when output formatting changes.
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
     from pathlib import Path
     from typing import TypeAlias
 
+    from rich.live import Live
     from rich.progress import Progress, TaskID
+
+    from gha_workflow_linter.file_edit import LineChange
 
     AutoFixResult: TypeAlias = tuple[
         dict[Path, list[dict[str, str]]],
@@ -32,6 +36,7 @@ from typer.testing import CliRunner
 
 from gha_workflow_linter.auto_fix import AutoFixer
 from gha_workflow_linter.cli import app
+from gha_workflow_linter.file_edit import replace_lines
 from gha_workflow_linter.models import (
     ActionCall,
     ActionCallType,
@@ -294,6 +299,52 @@ def not_pinned_to_sha_errors(
         )
         for file_path, call in iter_calls(action_calls)
     ]
+
+
+def stub_resolved_fixes_class(
+    version_fixes: dict[Path, dict[int, tuple[str, str]]],
+) -> type[AutoFixer]:
+    """Build a fixer whose reference-resolution step is replaced.
+
+    ``fix_validation_errors`` decides what to rewrite in two stages: it
+    resolves every call to its replacement, over the network, and then
+    writes the results out file by file. Only the second stage is under
+    test here, so the first is replaced with a prepared answer.
+
+    Unlike :func:`stub_auto_fixer_class`, this leaves
+    ``fix_validation_errors`` itself genuine, so the real writing loop
+    runs and the real files are rewritten.
+
+    Args:
+        version_fixes: Mapping of file path to a mapping of 1-based line
+            number to an ``(old_line, new_line)`` pair, as the batch
+            resolution step would have returned.
+
+    Returns:
+        A drop-in replacement for ``AutoFixer`` that resolves nothing
+        over the network but still writes.
+    """
+
+    class StubResolutionAutoFixer(AutoFixer):
+        """Fixer with pre-resolved replacements, without network use."""
+
+        async def _process_action_calls_batch(
+            self,
+            all_action_calls: dict[Path, dict[int, ActionCall]],
+            live: Live | None,
+            check_for_updates: bool = False,
+            validation_error_calls: set[tuple[Path, int]] | None = None,
+            validation_errors: list[ValidationError] | None = None,
+            show_live_updates: bool = True,
+        ) -> tuple[
+            dict[Path, dict[int, tuple[str, str]]],
+            dict[Path, dict[int, str]],
+            dict[str, list[dict[str, Any]]],
+        ]:
+            """Return the replacements supplied by the enclosing factory."""
+            return version_fixes, {}, {}
+
+    return StubResolutionAutoFixer
 
 
 class TestAutoFixBehaviorWithPinnedSHA:
@@ -2013,6 +2064,131 @@ jobs:
 
 class TestAutoFixErrorHandling:
     """Test auto-fix error handling and edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_write_failure_on_one_file_spares_the_rest(
+        self,
+        temp_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test that one file failing to rewrite does not affect others."""
+        workflow_content = """name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+"""
+        original_line = "      - uses: actions/checkout@v3"
+        pinned_line = (
+            "      - uses: actions/checkout@"
+            "11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2"
+        )
+
+        workflows = temp_dir / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        writable = workflows / "writable.yaml"
+        doomed = workflows / "doomed.yaml"
+        for path in (writable, doomed):
+            path.write_text(workflow_content)
+
+        # The same call appears in both files, at the same line.
+        action_call = ActionCall(
+            raw_line=original_line,
+            line_number=7,
+            organization="actions",
+            repository="checkout",
+            reference="v3",
+            reference_type=ReferenceType.TAG,
+            call_type=ActionCallType.ACTION,
+        )
+
+        errors = [
+            ValidationError(
+                file_path=file_path,
+                action_call=action_call,
+                result=ValidationResult.NOT_PINNED_TO_SHA,
+                error_message="Action not pinned to SHA",
+            )
+            for file_path in (writable, doomed)
+        ]
+        all_action_calls = {
+            file_path: {7: action_call} for file_path in (writable, doomed)
+        }
+
+        # Both files need the same line replaced. Working that out is the
+        # step that reaches the network, so it is answered in advance;
+        # the writing loop under test is left genuine.
+        #
+        # The doomed file is listed first deliberately. The loop writes
+        # files in this order, so an unhandled failure here would abandon
+        # the run before the healthy file was ever reached, and the
+        # assertions below would not be able to tell that apart from a
+        # failure that was handled.
+        version_fixes = {
+            file_path: {7: (original_line, pinned_line)}
+            for file_path in (doomed, writable)
+        }
+
+        def failing_replace_lines(
+            path: Path, replacements: Mapping[int, str]
+        ) -> list[LineChange]:
+            """Fail for one file; rewrite the other for real."""
+            if path == doomed:
+                raise OSError("Read-only file system")
+            return replace_lines(path, replacements)
+
+        config = Config(
+            require_pinned_sha=True,
+            auto_fix=True,
+            cache=CacheConfig(enabled=False),
+        )
+        fixer_class = stub_resolved_fixes_class(version_fixes)
+
+        with (
+            patch(
+                "gha_workflow_linter.auto_fix.replace_lines",
+                failing_replace_lines,
+            ),
+            caplog.at_level(
+                logging.ERROR, logger="gha_workflow_linter.auto_fix"
+            ),
+        ):
+            async with fixer_class(config, base_path=temp_dir) as fixer:
+                (
+                    applied_fixes,
+                    _redirects,
+                    _stale,
+                ) = await fixer.fix_validation_errors(
+                    errors,
+                    all_action_calls,
+                    check_for_updates=False,
+                )
+
+        # The healthy file went through the real writing path and is
+        # reported, so its fix is counted and rendered as usual.
+        assert writable.read_text().splitlines()[6] == pinned_line
+        assert applied_fixes[writable] == [
+            {
+                "line_number": "7",
+                "old_line": original_line,
+                "new_line": pinned_line,
+            }
+        ]
+
+        # The failing one keeps its contents and drops out of the
+        # report. That is what makes the logging below matter: absent
+        # from applied_fixes, it reaches neither the fix count, nor the
+        # rendered diff, nor the exit code.
+        assert doomed.read_text() == workflow_content
+        assert doomed not in applied_fixes
+
+        # So the only trace of it is the log, which must name the file
+        # and say what went wrong. Both _apply_fixes_to_file and its
+        # caller log this, so the message appears more than once.
+        assert f"Failed to apply fixes to {doomed}" in caplog.text
+        assert "Read-only file system" in caplog.text
 
     def test_auto_fix_with_network_errors(self, temp_dir: Path) -> None:
         """Test that auto-fix handles network errors gracefully."""


### PR DESCRIPTION
Fixes #317.

`AutoFixer.fix_validation_errors` writes its results file by file and catches failures per file (`auto_fix.py:280-285`), so one workflow that cannot be rewritten does not cost the others their fixes. Nothing exercised that handler.

The gap mattered because a file that fails **drops out of `applied_fixes` and so leaves no trace anywhere else**: it is counted in no fix total, appears in no rendered diff, and cannot reach the exit code, which `_determine_exit_code` derives from that same mapping. Only the log records it.

The neighbouring paths were already covered, and neither reaches this one — `tests/test_file_edit.py` covers the rewrite itself, and `test_auto_fix_failure_is_reported_not_raised` (added in #315) covers a failure of the fixing step as a whole, at CLI level. This sits between them.

## Approach

Reaching the handler needs fixes to write, which normally means resolving every call over the network first. A new factory, `stub_resolved_fixes_class`, replaces only the batch resolution step with a prepared answer. Unlike `stub_auto_fixer_class` it leaves `fix_validation_errors` itself genuine, so **the real writing loop runs and the healthy file is really rewritten on disk** — the test asserts its contents changed, not just that a dict says so. `replace_lines` is patched where `auto_fix.py` looks it up, to fail for one of the two files and delegate to the real implementation for the other.

The failing file is listed **first** on purpose. The loop writes in that order, so an unhandled failure abandons the run before the healthy file is reached — without that ordering, "the others are spared" would have held incidentally rather than being tested.

## Verification by sabotage

| Sabotage | Result |
| --- | --- |
| Delete the `try`/`except` entirely | `OSError` propagates out of `fix_validation_errors` — test fails |
| Keep the handler but `break` out of the loop | Healthy file left unwritten — test fails on its contents |
| Unmodified | Passes, 0.18s |

The second is the one that pins the actual property in the issue title.

The file remains hermetic: **26 tests, 0.99s** with `~/.cache/gha-workflow-linter` moved aside and egress blocked, no test above 0.07s. Full suite 1376 passed, 22 skipped.

## Two things to flag

**1. The failure is logged twice.** `_apply_fixes_to_file` logs `Failed to apply fixes to {path}: {e}` and then re-raises (`auto_fix.py:1271-1273`); the caller catches it and logs the identical message again (`auto_fix.py:284`). So every write failure is reported twice. The test asserts the message is present rather than counting occurrences, so it neither depends on nor endorses the duplication. Removing the inner `try`/`except` looks like the right fix — the `Raises:` section of that docstring already documents propagation as the contract — but that is a source change and outside what #317 asks for. Happy to open a follow-up.

**2. This branch needs `SKIP=mypy` to commit**, which is #316 exactly. Branched from `main`, so it does not carry that fix:

```console
$ prek run mypy --files tests/test_auto_fix.py     # isolated venv
  ...5 errors, all "has type Any" / "Returning Any"

$ uv run mypy tests/test_auto_fix.py               # project installed
Success: no issues found in 1 source file
```

Three of the five pre-date this PR; the new subclass and the `replace_lines` delegation add two more of the same kind. All disappear once #318 lands — the two PRs are independent and can merge in either order, but this is a live demonstration of why #318 is worth having.
