### PR TITLE
Fix: strengthen mypy checking and write-failure cover

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,29 +68,32 @@ repos:
     rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0
     hooks:
       - id: mypy
-        # Analyse a fixed tree rather than whatever happens to be staged.
-        # This hook runs in an isolated virtualenv built from
-        # additional_dependencies below, which cannot include
-        # gha_workflow_linter itself. Handed only test files, mypy could
-        # not resolve `from gha_workflow_linter...`, the imported names
-        # degraded to Any, and `strict = true` turned every use of one
-        # into an error -- so committing a change to tests/ alone failed
-        # while `--all-files` passed. Naming the directories puts src/ in
-        # front of mypy every time, so the imports resolve from source.
+        # Analyse a fixed set rather than whatever happens to be staged.
+        # The hook runs in an isolated virtualenv built from
+        # additional_dependencies, which carries the third-party packages
+        # but not gha_workflow_linter itself. Passed only test files, the
+        # imports from the package cannot resolve and every imported name
+        # degrades to Any, which under strict = true turns each use into
+        # an error (disallow_subclassing_any, warn_return_any). Passing
+        # src/ alongside the rest lets the imports resolve from source,
+        # so the checking gets stronger rather than weaker: no
+        # strictness setting is relaxed here, and what may go
+        # unresolved is stated per module in [tool.mypy] rather than
+        # waved through wholesale. One such exemption exists, for the
+        # generated _version module; see the note beside it.
+        # The set matches [tool.basedpyright] include in pyproject.toml,
+        # which lists every tracked Python location; keep them in step.
         #
         # args replaces the hook's defaults rather than adding to them,
-        # so --ignore-missing-imports and --scripts-are-modules are
-        # repeated here; dropping them would change what is checked.
-        # Keep the directory list in step with [tool.basedpyright]
-        # include in pyproject.toml.
+        # and its --ignore-missing-imports is deliberately not repeated
+        # here. That flag overrode ignore_missing_imports = false in
+        # pyproject.toml, so anything absent from the virtualenv below
+        # became Any and every use of it went unchecked in silence --
+        # pytest among them, which is why it now appears there. Dropping
+        # the flag is what makes the per-module overrides in
+        # [tool.mypy] the single account of what may go unresolved.
         pass_filenames: false
-        args:
-          - --ignore-missing-imports
-          - --scripts-are-modules
-          - src
-          - tests
-          - scripts
-          - examples
+        args: ['src', 'tests', 'scripts', 'examples']
         additional_dependencies:
           - pydantic>=2.10.3
           - pydantic-settings>=2.7.0
@@ -100,6 +103,10 @@ repos:
           - rich>=13.9.4
           - httpx>=0.28.1
           - typing-extensions>=4.12.0
+          # Needed now that tests/ is analysed: the isolated virtualenv
+          # has to resolve what the test modules import, or every use of
+          # an unresolved name becomes an error under strict = true.
+          - pytest>=8.0.0
 
   # Requires a mirror, primary repo lacks .pre-commit-hooks.yaml
   - repo: https://github.com/DetachHead/basedpyright-prek-mirror

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,20 @@ module = [
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+# _version.py is generated at build time by hatch-vcs and is not in
+# version control, so it is absent from a bare checkout -- which is how
+# the pre-commit hook and pre-commit.ci see the tree. __init__.py guards
+# the import with try/except and falls back, but mypy reports the
+# missing module regardless of the handler. Every other consumer imports
+# the resolved string from the package, so this exemption covers the one
+# place that must name the generated module.
+#
+# A per-line type: ignore cannot be used here: warn_unused_ignores is
+# enabled, so it would error wherever the file *has* been generated.
+module = ["gha_workflow_linter._version"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["tests.*"]
 disallow_untyped_decorators = false
 disallow_untyped_defs = false

--- a/src/gha_workflow_linter/cache.py
+++ b/src/gha_workflow_linter/cache.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ._version import __version__
+from . import __version__
 from .models import (  # noqa: TC001
     CacheConfig,
     ValidationMethod,

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -35,8 +35,7 @@ from rich.progress import (
 from rich.table import Table
 import typer
 
-from . import exit_codes
-from ._version import __version__
+from . import __version__, exit_codes
 from .allow_list_check import AllowListChecker, AllowListOutcome
 from .allow_list_fix import AppliedFix
 from .allow_list_fix import apply_fixes as apply_allow_list_fixes

--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -11,19 +11,15 @@ from breaking when output formatting changes.
 from __future__ import annotations
 
 import json
-import logging
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
     from pathlib import Path
     from typing import TypeAlias
 
-    from rich.live import Live
     from rich.progress import Progress, TaskID
-
-    from gha_workflow_linter.file_edit import LineChange
 
     AutoFixResult: TypeAlias = tuple[
         dict[Path, list[dict[str, str]]],
@@ -36,7 +32,6 @@ from typer.testing import CliRunner
 
 from gha_workflow_linter.auto_fix import AutoFixer
 from gha_workflow_linter.cli import app
-from gha_workflow_linter.file_edit import replace_lines
 from gha_workflow_linter.models import (
     ActionCall,
     ActionCallType,
@@ -299,52 +294,6 @@ def not_pinned_to_sha_errors(
         )
         for file_path, call in iter_calls(action_calls)
     ]
-
-
-def stub_resolved_fixes_class(
-    version_fixes: dict[Path, dict[int, tuple[str, str]]],
-) -> type[AutoFixer]:
-    """Build a fixer whose reference-resolution step is replaced.
-
-    ``fix_validation_errors`` decides what to rewrite in two stages: it
-    resolves every call to its replacement, over the network, and then
-    writes the results out file by file. Only the second stage is under
-    test here, so the first is replaced with a prepared answer.
-
-    Unlike :func:`stub_auto_fixer_class`, this leaves
-    ``fix_validation_errors`` itself genuine, so the real writing loop
-    runs and the real files are rewritten.
-
-    Args:
-        version_fixes: Mapping of file path to a mapping of 1-based line
-            number to an ``(old_line, new_line)`` pair, as the batch
-            resolution step would have returned.
-
-    Returns:
-        A drop-in replacement for ``AutoFixer`` that resolves nothing
-        over the network but still writes.
-    """
-
-    class StubResolutionAutoFixer(AutoFixer):
-        """Fixer with pre-resolved replacements, without network use."""
-
-        async def _process_action_calls_batch(
-            self,
-            all_action_calls: dict[Path, dict[int, ActionCall]],
-            live: Live | None,
-            check_for_updates: bool = False,
-            validation_error_calls: set[tuple[Path, int]] | None = None,
-            validation_errors: list[ValidationError] | None = None,
-            show_live_updates: bool = True,
-        ) -> tuple[
-            dict[Path, dict[int, tuple[str, str]]],
-            dict[Path, dict[int, str]],
-            dict[str, list[dict[str, Any]]],
-        ]:
-            """Return the replacements supplied by the enclosing factory."""
-            return version_fixes, {}, {}
-
-    return StubResolutionAutoFixer
 
 
 class TestAutoFixBehaviorWithPinnedSHA:
@@ -2064,131 +2013,6 @@ jobs:
 
 class TestAutoFixErrorHandling:
     """Test auto-fix error handling and edge cases."""
-
-    @pytest.mark.asyncio
-    async def test_write_failure_on_one_file_spares_the_rest(
-        self,
-        temp_dir: Path,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """Test that one file failing to rewrite does not affect others."""
-        workflow_content = """name: Test
-on: [push]
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-"""
-        original_line = "      - uses: actions/checkout@v3"
-        pinned_line = (
-            "      - uses: actions/checkout@"
-            "11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2"
-        )
-
-        workflows = temp_dir / ".github" / "workflows"
-        workflows.mkdir(parents=True)
-        writable = workflows / "writable.yaml"
-        doomed = workflows / "doomed.yaml"
-        for path in (writable, doomed):
-            path.write_text(workflow_content)
-
-        # The same call appears in both files, at the same line.
-        action_call = ActionCall(
-            raw_line=original_line,
-            line_number=7,
-            organization="actions",
-            repository="checkout",
-            reference="v3",
-            reference_type=ReferenceType.TAG,
-            call_type=ActionCallType.ACTION,
-        )
-
-        errors = [
-            ValidationError(
-                file_path=file_path,
-                action_call=action_call,
-                result=ValidationResult.NOT_PINNED_TO_SHA,
-                error_message="Action not pinned to SHA",
-            )
-            for file_path in (writable, doomed)
-        ]
-        all_action_calls = {
-            file_path: {7: action_call} for file_path in (writable, doomed)
-        }
-
-        # Both files need the same line replaced. Working that out is the
-        # step that reaches the network, so it is answered in advance;
-        # the writing loop under test is left genuine.
-        #
-        # The doomed file is listed first deliberately. The loop writes
-        # files in this order, so an unhandled failure here would abandon
-        # the run before the healthy file was ever reached, and the
-        # assertions below would not be able to tell that apart from a
-        # failure that was handled.
-        version_fixes = {
-            file_path: {7: (original_line, pinned_line)}
-            for file_path in (doomed, writable)
-        }
-
-        def failing_replace_lines(
-            path: Path, replacements: Mapping[int, str]
-        ) -> list[LineChange]:
-            """Fail for one file; rewrite the other for real."""
-            if path == doomed:
-                raise OSError("Read-only file system")
-            return replace_lines(path, replacements)
-
-        config = Config(
-            require_pinned_sha=True,
-            auto_fix=True,
-            cache=CacheConfig(enabled=False),
-        )
-        fixer_class = stub_resolved_fixes_class(version_fixes)
-
-        with (
-            patch(
-                "gha_workflow_linter.auto_fix.replace_lines",
-                failing_replace_lines,
-            ),
-            caplog.at_level(
-                logging.ERROR, logger="gha_workflow_linter.auto_fix"
-            ),
-        ):
-            async with fixer_class(config, base_path=temp_dir) as fixer:
-                (
-                    applied_fixes,
-                    _redirects,
-                    _stale,
-                ) = await fixer.fix_validation_errors(
-                    errors,
-                    all_action_calls,
-                    check_for_updates=False,
-                )
-
-        # The healthy file went through the real writing path and is
-        # reported, so its fix is counted and rendered as usual.
-        assert writable.read_text().splitlines()[6] == pinned_line
-        assert applied_fixes[writable] == [
-            {
-                "line_number": "7",
-                "old_line": original_line,
-                "new_line": pinned_line,
-            }
-        ]
-
-        # The failing one keeps its contents and drops out of the
-        # report. That is what makes the logging below matter: absent
-        # from applied_fixes, it reaches neither the fix count, nor the
-        # rendered diff, nor the exit code.
-        assert doomed.read_text() == workflow_content
-        assert doomed not in applied_fixes
-
-        # So the only trace of it is the log, which must name the file
-        # and say what went wrong. Both _apply_fixes_to_file and its
-        # caller log this, so the message appears more than once.
-        assert f"Failed to apply fixes to {doomed}" in caplog.text
-        assert "Read-only file system" in caplog.text
 
     def test_auto_fix_with_network_errors(self, temp_dir: Path) -> None:
         """Test that auto-fix handles network errors gracefully."""

--- a/tests/test_auto_fix_write_failure.py
+++ b/tests/test_auto_fix_write_failure.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the per-file rewrite failure handler in the auto-fixer.
+
+``AutoFixer.fix_validation_errors`` applies its rewrites one file at a
+time and catches a failure per file, so one unwritable file does not cost
+the others their fixes. A file whose rewrite fails is absent from the
+returned mapping, and therefore from the fix count, the rendered diff,
+and the exit code, which keys off it.
+
+Nothing exercised that handler before. The rewrite itself is covered by
+``tests/test_file_edit.py`` and a failure of the fixing stage as a whole
+by ``test_auto_fix_failure_is_reported_not_raised``; this sits between
+them. Were the handler removed, broadened, or silenced, the suite would
+not have noticed.
+
+Reaching it needs the fixer to have resolved its replacements first, so
+resolution is stubbed and the write is made to fail. No network access,
+in keeping with the rest of the auto-fix tests.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from gha_workflow_linter.auto_fix import AutoFixer
+from gha_workflow_linter.models import (
+    ActionCall,
+    CacheConfig,
+    Config,
+    GitHubAPIConfig,
+    LogLevel,
+    ReferenceType,
+    ValidationError,
+    ValidationMethod,
+    ValidationResult,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from contextlib import AbstractContextManager
+    from pathlib import Path
+
+#: A SHA that resolves to nothing, so the call is an invalid reference
+#: and the fixer has something to repair.
+BROKEN_SHA = "0" * 40
+
+#: The commit v6.1.0 actually points at.
+GOOD_SHA = "b1476f6e6eb133afa41ed8589daba6dc69b4d3f5"
+
+REPO = "release-drafter/release-drafter"
+
+WORKFLOW = """---
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {repo}@{sha}  # v6.1.0
+"""
+
+#: 1-based line of the ``uses:`` call in WORKFLOW.
+USES_LINE = 7
+
+
+@pytest.fixture
+def config() -> Config:
+    """Configuration that repairs invalid references without upgrading."""
+    return Config(
+        log_level=LogLevel.DEBUG,
+        parallel_workers=2,
+        require_pinned_sha=True,
+        auto_fix=True,
+        update_actions=False,
+        two_space_comments=True,
+        skip_actions=False,
+        fix_test_calls=False,
+        validation_method=ValidationMethod.GITHUB_API,
+        cache=CacheConfig(enabled=False),
+        github_api=GitHubAPIConfig(token="test-token"),
+    )
+
+
+def write_workflow(directory: Path, name: str) -> Path:
+    """Write a workflow whose single action call needs repair.
+
+    Args:
+        directory: Directory to write into.
+        name: File name.
+
+    Returns:
+        Path to the written file.
+    """
+    target = directory / name
+    target.write_text(WORKFLOW.format(repo=REPO, sha=BROKEN_SHA))
+    return target
+
+
+def action_call() -> ActionCall:
+    """Build the action call the workflow contains.
+
+    Returns:
+        The parsed call, pinned to a SHA that resolves to nothing.
+    """
+    organization, repository = REPO.split("/")
+    return ActionCall(
+        organization=organization,
+        repository=repository,
+        reference=BROKEN_SHA,
+        reference_type=ReferenceType.COMMIT_SHA,
+        comment="v6.1.0",
+        raw_line=f"      - uses: {REPO}@{BROKEN_SHA}  # v6.1.0",
+        line_number=USES_LINE,
+    )
+
+
+def validation_error(file_path: Path, call: ActionCall) -> ValidationError:
+    """Build the invalid-reference error the fixer acts on.
+
+    Args:
+        file_path: Workflow the call appears in.
+        call: The call itself.
+
+    Returns:
+        The validation error.
+    """
+    return ValidationError(
+        file_path=file_path,
+        action_call=call,
+        result=ValidationResult.INVALID_REFERENCE,
+        error_message="Invalid reference",
+    )
+
+
+def stubbed_resolution() -> AbstractContextManager[Any]:
+    """Patch away every step of the fixer that would reach the network.
+
+    Returns:
+        A context manager stubbing version, SHA and redirect lookups.
+    """
+    return patch.multiple(
+        AutoFixer,
+        _get_latest_versions_batch=_async_value({REPO: ("v6.1.0", GOOD_SHA)}),
+        _get_shas_batch=_async_value({(REPO, "v6.1.0"): GOOD_SHA}),
+        _detect_repository_redirect=_async_value(None),
+    )
+
+
+def _async_value(value: Any) -> Any:
+    """Build an async stub returning a fixed value.
+
+    Args:
+        value: What the coroutine should return.
+
+    Returns:
+        An async callable suitable for ``patch.multiple``.
+    """
+
+    async def _stub(*_args: Any, **_kwargs: Any) -> Any:
+        return value
+
+    return _stub
+
+
+def failing_writer(
+    failing: Path,
+) -> Any:
+    """Build a ``replace_lines`` stub that fails for one file only.
+
+    Args:
+        failing: The file whose rewrite should raise.
+
+    Returns:
+        A callable matching ``file_edit.replace_lines``.
+    """
+    from gha_workflow_linter import file_edit
+
+    real = file_edit.replace_lines
+
+    def _replace(path: Path, replacements: Mapping[int, str]) -> list[Any]:
+        if path == failing:
+            raise OSError(f"disk full writing {path}")
+        return real(path, replacements)
+
+    return _replace
+
+
+def failing_apply(failing: Path) -> Any:
+    """Build an ``_apply_fixes_to_file`` stub that fails for one file.
+
+    ``_apply_fixes_to_file`` logs the same message as the handler above
+    it before re-raising, so a failure raised from inside it cannot show
+    which of the two emitted the log line. Raising from the method itself
+    leaves the handler as the only possible source.
+
+    Args:
+        failing: The file whose rewrite should raise.
+
+    Returns:
+        An async callable matching ``AutoFixer._apply_fixes_to_file``.
+    """
+
+    async def _apply(
+        _self: AutoFixer, path: Path, _line_fixes: Any
+    ) -> list[Any]:
+        if path == failing:
+            raise OSError(f"disk full writing {path}")
+        return []
+
+    return _apply
+
+
+class TestPerFileWriteFailure:
+    """One unwritable file must not cost the others their fixes."""
+
+    @pytest.mark.asyncio
+    async def test_other_files_are_still_fixed(
+        self, config: Config, tmp_path: Path
+    ) -> None:
+        # The failing file is processed first on purpose: with the
+        # healthy one first, a handler that broke out of the loop
+        # after a failure would still leave these assertions true.
+        bad = write_workflow(tmp_path, "bad.yaml")
+        good = write_workflow(tmp_path, "good.yaml")
+        call = action_call()
+        errors = [validation_error(bad, call), validation_error(good, call)]
+        all_calls = {bad: {USES_LINE: call}, good: {USES_LINE: call}}
+
+        with (
+            stubbed_resolution(),
+            patch(
+                # Patch where the name is looked up, not where it is defined.
+                "gha_workflow_linter.auto_fix.replace_lines",
+                failing_writer(bad),
+            ),
+        ):
+            async with AutoFixer(config, base_path=tmp_path) as fixer:
+                applied, _, _ = await fixer.fix_validation_errors(
+                    errors, all_calls, check_for_updates=False
+                )
+
+        assert good in applied, "a healthy file lost its fix"
+        assert bad not in applied, "a failed rewrite was reported as applied"
+
+    @pytest.mark.asyncio
+    async def test_surviving_file_is_written_to_disk(
+        self, config: Config, tmp_path: Path
+    ) -> None:
+        """The fix is real, not merely reported."""
+        # The failing file is processed first on purpose: with the
+        # healthy one first, a handler that broke out of the loop
+        # after a failure would still leave these assertions true.
+        bad = write_workflow(tmp_path, "bad.yaml")
+        good = write_workflow(tmp_path, "good.yaml")
+        call = action_call()
+        errors = [validation_error(bad, call), validation_error(good, call)]
+        all_calls = {bad: {USES_LINE: call}, good: {USES_LINE: call}}
+
+        with (
+            stubbed_resolution(),
+            patch(
+                "gha_workflow_linter.auto_fix.replace_lines",
+                failing_writer(bad),
+            ),
+        ):
+            async with AutoFixer(config, base_path=tmp_path) as fixer:
+                await fixer.fix_validation_errors(
+                    errors, all_calls, check_for_updates=False
+                )
+
+        assert GOOD_SHA in good.read_text()
+        assert BROKEN_SHA in bad.read_text(), "the failed file was modified"
+
+    @pytest.mark.asyncio
+    async def test_failure_is_logged_with_the_path(
+        self,
+        config: Config,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A silently dropped file would be worse than a noisy one.
+
+        The failure is raised from ``_apply_fixes_to_file`` rather than
+        from the writer beneath it, because that method logs the same
+        message before re-raising: a writer-level failure would satisfy
+        this assertion even with the handler's own logging removed.
+        """
+        # The failing file is processed first on purpose: with the
+        # healthy one first, a handler that broke out of the loop
+        # after a failure would still leave these assertions true.
+        bad = write_workflow(tmp_path, "bad.yaml")
+        good = write_workflow(tmp_path, "good.yaml")
+        call = action_call()
+        errors = [validation_error(bad, call), validation_error(good, call)]
+        all_calls = {bad: {USES_LINE: call}, good: {USES_LINE: call}}
+
+        with (
+            caplog.at_level("ERROR"),
+            stubbed_resolution(),
+            patch.object(AutoFixer, "_apply_fixes_to_file", failing_apply(bad)),
+        ):
+            async with AutoFixer(config, base_path=tmp_path) as fixer:
+                await fixer.fix_validation_errors(
+                    errors, all_calls, check_for_updates=False
+                )
+
+        assert str(bad) in caplog.text
+        assert "disk full" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_failure_does_not_propagate(
+        self, config: Config, tmp_path: Path
+    ) -> None:
+        """Every file failing still returns rather than raising."""
+        first = write_workflow(tmp_path, "first.yaml")
+        second = write_workflow(tmp_path, "second.yaml")
+        call = action_call()
+        errors = [
+            validation_error(first, call),
+            validation_error(second, call),
+        ]
+        all_calls = {first: {USES_LINE: call}, second: {USES_LINE: call}}
+
+        def _always_fails(path: Path, _replacements: Any) -> list[Any]:
+            raise OSError(f"disk full writing {path}")
+
+        with (
+            stubbed_resolution(),
+            patch("gha_workflow_linter.auto_fix.replace_lines", _always_fails),
+        ):
+            async with AutoFixer(config, base_path=tmp_path) as fixer:
+                applied, _, _ = await fixer.fix_validation_errors(
+                    errors, all_calls, check_for_updates=False
+                )
+
+        assert applied == {}

--- a/tests/test_cache_simple.py
+++ b/tests/test_cache_simple.py
@@ -300,7 +300,7 @@ class TestCachePrime:
         code because ``_cache_version`` was never updated)."""
         import json
 
-        from gha_workflow_linter._version import __version__
+        from gha_workflow_linter import __version__
 
         # A successful load: cache file's version equals current tool
         # version, so no purge happens. ``_cache_version`` should equal
@@ -333,7 +333,7 @@ class TestCachePrime:
         value)."""
         import json
 
-        from gha_workflow_linter._version import __version__
+        from gha_workflow_linter import __version__
 
         stale = {
             "_metadata": {
@@ -479,7 +479,7 @@ class TestStandaloneCacheConsumers:
         cache_path.write_text(json.dumps(stale))
 
     def test_autofixer_primes_own_cache_on_construct(self) -> None:
-        from gha_workflow_linter._version import __version__
+        from gha_workflow_linter import __version__
         from gha_workflow_linter.auto_fix import AutoFixer
         from gha_workflow_linter.models import Config
 
@@ -508,7 +508,7 @@ class TestStandaloneCacheConsumers:
         """
         import asyncio
 
-        from gha_workflow_linter._version import __version__
+        from gha_workflow_linter import __version__
         from gha_workflow_linter.models import Config, ValidationMethod
         from gha_workflow_linter.validator import ActionCallValidator
 

--- a/tests/test_validator_dedup.py
+++ b/tests/test_validator_dedup.py
@@ -465,58 +465,6 @@ class TestValidatorDeduplication:
 
         assert len(errors) == 0
 
-    @pytest.mark.skip(
-        reason="Error handling behavior has changed - ValidationAbortedError is now raised"
-    )
-    @pytest.mark.asyncio
-    async def test_network_error_propagation(
-        self,
-        test_config_no_sha_pinning: Config,
-        duplicate_action_calls: dict[Path, dict[int, ActionCall]],
-    ) -> None:
-        """Test that network errors are properly propagated to all duplicate calls."""
-        pytest.skip(
-            "Validator now raises ValidationAbortedError for unexpected errors"
-        )
-        mock_github_client = AsyncMock()
-
-        # Mock network failure
-        mock_github_client.validate_repositories_batch.side_effect = Exception(
-            "Network timeout"
-        )
-        mock_stats = APICallStats(
-            total_calls=0,
-            graphql_calls=0,
-            rest_calls=0,
-            git_calls=0,
-            cache_hits=0,
-            rate_limit_delays=0,
-            failed_calls=0,
-        )
-        mock_github_client.get_api_stats = Mock(return_value=mock_stats)
-        mock_github_client.get_rate_limit_info = Mock(
-            return_value=GitHubRateLimitInfo(
-                limit=5000,
-                remaining=5000,
-                reset_at=0,
-                used=0,
-            )
-        )
-
-        validator = ActionCallValidator(test_config_no_sha_pinning)
-        validator._github_client = mock_github_client
-
-        errors = await validator.validate_action_calls_async(
-            duplicate_action_calls
-        )
-
-        # Should have errors for all 5 action calls
-        assert len(errors) == 5
-
-        # All errors should be invalid repository errors (current behavior when network fails)
-        for error in errors:
-            assert error.result == ValidationResult.INVALID_REPOSITORY
-
     def test_synchronous_wrapper(
         self,
         test_config_no_sha_pinning: Config,


### PR DESCRIPTION
Rebased onto `main` at `b2fa1ad`. Both #316 and #317 were closed in the meantime by #318 and #319, so this PR no longer introduces those fixes — it **strengthens them**, and the description below has been rewritten accordingly.

Three commits.

### `Fix: let pyproject govern unresolved imports`

`main` already analyses a fixed file set, so imports resolve from `src/` on every run. But it also passes `--ignore-missing-imports`, carried over from the hook's defaults when `args` replaced them — and that flag overrides `ignore_missing_imports = false` in `pyproject.toml`.

The consequence is that anything absent from the hook's isolated virtualenv silently becomes `Any`, and every use of it goes unchecked. `pytest` was one such, so nothing any test module does with it was verified at all. A probe:

```python
import pytest
def probe() -> None:
    pytest.this_attribute_does_not_exist()
```

| config | result |
| --- | --- |
| `main` as merged | **Passed** — the error is invisible |
| this PR | `error: Module has no attribute "this_attribute_does_not_exist"` |

Dropping the flag leaves the per-module overrides in `[tool.mypy]` as the single account of what may go unresolved, and adds `pytest` to the virtualenv. `scripts/` and `examples/` stay in the analysed set.

**This surfaced a genuinely dead test.** `test_validator_dedup.test_network_error_propagation` carried an unconditional `pytest.skip()` as its first statement, *on top of* an `@pytest.mark.skip` decorator, leaving forty lines of unreachable body. The causal chain is worth spelling out, since it is exactly what the change buys: only when `pytest` resolves is `skip()` known to return `NoReturn`, and only then does `warn_unreachable` report the body. Confirmed both ways round with the dead test restored:

| config | result |
| --- | --- |
| `main` as merged | **Passed** — the dead body is hidden |
| this PR | `error: Statement is unreachable  [unreachable]` |

Its own stated reason records that the behaviour it asserted no longer exists — the validator now raises `ValidationAbortedError`, covered across six other test modules — so it is removed rather than resurrected.

### `Test: cover the per-file auto-fix write failure`

`fix_validation_errors` catches a rewrite failure per file, so one unwritable file does not cost the others their fixes.

`main` already has one test here, added in #319. It is **replaced** rather than duplicated, because it had two weaknesses this module fixes:

- it placed the healthy file first, so a handler that abandoned the loop after a failure would have satisfied it anyway
- its logging assertion could not fail, because `_apply_fixes_to_file` logs the same message before re-raising, so a failure from the writer beneath satisfied it whether or not the handler logged

Four tests now, one property each, failing file first. Every assertion was checked against a mutated handler rather than assumed to bite:

| mutation | result |
| --- | --- |
| Remove the per-file `except` | 4 failed ✅ |
| Broaden it to record a failed file as applied | 2 failed ✅ |
| `break` out of the loop after logging | 2 failed ✅ (passed before the ordering fix) |
| Drop the handler's own logging | 1 failed ✅ (passed before the seam was moved) |

The last two are the ones that were wrong before review. The logging test now raises from `_apply_fixes_to_file` itself, leaving the handler as the only possible source.

Worth noting the duplication that made that ambiguous: **the same message is logged twice on every failure**, once by the method and once by its caller. Pre-existing and outside both issues, so untouched here — worth a follow-up.

### `Fix: resolve the generated version module for mypy`

Analysing `src/` on every run means mypy always reads `__init__.py`, `cache.py` and `cli.py`, each of which imports `_version` — generated at build time by hatch-vcs and absent from a bare checkout, which is how pre-commit.ci sees the tree. Locally it exists, left behind by earlier builds, so the failure appeared only in CI.

`cache.py`, `cli.py` and `test_cache_simple.py` now take `__version__` from the package rather than importing the generated module directly, so one place knows it may be missing and each consumer gets a definite `str`. `__init__.py` must still name it, so that one module is exempted with `ignore_missing_imports`; a per-line `type: ignore` cannot serve, because `warn_unused_ignores` would then error wherever the file *has* been generated.

Verified with `_version.py` moved aside as well as present.

## Validation

- **1379 passed, 21 skipped**, coverage 82.9%
- `prek run --all-files`: every hook passes
- mypy hook verified on a single test file, on `--all-files`, and with `_version.py` absent
- Review feedback: all three items fixed, each verified by mutation or by probe rather than by inspection
