### PR TITLE
Feat: visit many repositories in one run

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,118 @@ at a worktree scans that worktree. Pointing it at a directory that
 merely *contains* repositories finds nothing, since each child is a
 boundary.
 
+### Multi-Repository Mode
+
+`--multi-repo` treats the given path as a container of git repositories
+and visits each in turn:
+
+```bash
+# Audit every checkout under a directory
+gha-workflow-linter lint ~/Repositories/lfreleng-actions --multi-repo
+
+# Fail if anything anywhere is stale
+gha-workflow-linter lint ~/Repositories --multi-repo --verify-allow-list
+
+# Bulk remediation across the estate
+gha-workflow-linter lint ~/Repositories --multi-repo --update-allow-list
+```
+
+A directory counts as a repository when it holds a `.git` entry, so
+clones, worktrees and submodules all qualify. `--repo-depth` controls how
+far below the path to look, defaulting to one level. Discovery stops at
+each repository rather than descending into it, so a checkout keeping
+worktrees under `.worktrees/` gets one visit, not one per branch.
+
+Pointing the linter at a repository with `--multi-repo` visits that
+repository alone, so the flag is safe to leave in a wrapper script.
+
+#### Why this rather than a shell loop
+
+The sweep builds one cache and shares it, so repositories pinning the
+same allow-list host share a single latest-release lookup.
+Twenty repositories cost one query rather than twenty.
+
+That sharing stops under a non-default release policy. A cooldown
+targets an older release by design, and prerelease eligibility changes
+which releases count as candidates; the cache records no more than a
+tag and a SHA, so a cached answer cannot say which policy produced it.
+Rather than let one repository's policy leak into another's, the sweep
+repeats the lookup per repository — twenty such repositories cost
+twenty queries. Correctness wins over the saving here, and the saving
+returns as soon as the default policy applies.
+
+Each repository still gets its own workflow organisation and its own
+Dependabot cooldown, since both belong to the repository rather than to
+the sweep.
+
+#### Failures and exit codes
+
+The sweep visits repositories one at a time, and one failing does not
+stop the others: it records the failure, carries on, and closes with a
+table listing every repository, its pin counts and its status.
+
+| Status       | Meaning                                              |
+| ------------ | ---------------------------------------------------- |
+| `clean`      | Nothing outstanding                                  |
+| `updated`    | The run rewrote something, leaving nothing to do     |
+| `findings`   | Something needs attention                            |
+| `unresolved` | A host did not resolve, leaving the check incomplete |
+| `failed`     | The sweep could not scan the repository              |
+
+`unresolved` gets its own label because an incomplete check says nothing
+about the repository: its counts are empty for want of an answer, not
+for want of a problem.
+
+What remains outranks what the run achieved, so a partial remediation —
+some pins rewritten, others still stale — reports `findings` rather than
+`updated`. Reading `updated` means the repository needs no further
+attention.
+
+The exit code is the most significant across the sweep, following the
+precedence in [Exit Codes](#exit-codes). A configuration error is the one
+exception: a bad setting applies to every repository, so it stops the run
+rather than repeating once per checkout.
+
+#### JSON output
+
+`--multi-repo --format json` emits a single document covering the whole
+sweep, rather than one object per repository:
+
+```json
+{
+  "repositories": [
+    {
+      "repository": "example-workflows",
+      "exit_code": 3,
+      "error": null,
+      "write_failures": 0,
+      "autofix_error": null,
+      "results": { "scan_summary": {}, "allow_list": {} }
+    }
+  ],
+  "summary": { "repositories": 1, "failed": 0, "exit_code": 3 }
+}
+```
+
+A repository the sweep could not scan carries its reason in `error`, so a
+failure stays distinguishable from a clean result. An empty container
+still emits a document, for the same reason.
+
+`write_failures` and `autofix_error` record the two failures that
+produce no validation error of their own: a rewrite that could not reach
+disk, and an auto-fix stage that did not complete. Without them a
+consumer reading `results` alone would find nothing to explain a
+non-zero `exit_code`.
+
+In this mode the sweep prints neither progress commentary nor the
+closing table. Diagnostics go to standard error throughout, so a
+redirect captures the document alone:
+
+```bash
+gha-workflow-linter lint ~/Repositories --multi-repo --format json \
+  > sweep.json
+```
+
 ### As a Pre-commit Hook
 
 Add to your `.pre-commit-config.yaml`:
@@ -794,6 +906,10 @@ Validation Errors:
 ```bash
 gha-workflow-linter lint --format json
 ```
+
+The tool writes the document to standard output on its own. Log records,
+warnings and progress commentary all go to standard error, so a parser
+can consume the output directly.
 
 ```json
 {

--- a/docs/ALLOW_LIST_FEATURE.md
+++ b/docs/ALLOW_LIST_FEATURE.md
@@ -1143,12 +1143,29 @@ Semantics:
   parallelism already saturates the API budget, and sequential
   processing keeps the Rich progress output legible and per-repo failures
   attributable.
-- **Shared state across repositories**: one `ValidationCache`, one
-  GitHub client, one allow-list resolution per host repo. Scanning
-  twenty repositories that all pin `lfreleng-actions/.github` costs
-  **one** latest-release lookup, not twenty. This is the main efficiency
+- **Shared state across repositories**: one `ValidationCache`, so one
+  allow-list resolution per host repository. Scanning twenty
+  repositories that all pin `lfreleng-actions/.github` costs **one**
+  latest-release lookup, not twenty. This is the main efficiency
   argument for building multi-repo into the tool rather than looping in
   a shell script.
+
+  The GitHub client is **not** shared. An earlier draft of this section
+  called for one client across the sweep; the implementation opens one
+  per repository, because the validator and auto-fixer each build their
+  client inside their own async context and threading a shared one
+  through both would mean either reordering those lifetimes or handing
+  each stage a client it does not own. What that would save is
+  connection setup, not API calls -- the calls themselves are already
+  saved by the shared cache -- so the trade was not judged worth the
+  coupling. Recorded here rather than left as an unmet claim; still
+  open as an optimisation if a sweep ever proves connection-bound.
+
+  Note also that cache sharing is suspended under a non-default release
+  policy: a cooldown or prerelease eligibility makes a cached
+  `(tag, sha)` policy-dependent, and the cache records no policy, so
+  each repository resolves for itself rather than inheriting another's
+  answer.
 - **Per-repository state**: workflow org (§6.3) and Dependabot cooldown
   (`dependabot.resolve_cooldown`) are resolved per repository, because
   both are repository properties.
@@ -1557,6 +1574,17 @@ endings.
 Phases 1–4 land in `gha-workflow-linter` and can proceed in parallel with
 nothing blocking them. Phase 5 depends on Phase 2 being released to PyPI
 (the workflow consumes the published tool via `uvx`).
+
+### Status
+
+All six phases have shipped. Phases 0 to 4 landed in
+`gha-workflow-linter`; phase 5 lives in `lfreleng-actions/.github` as
+`allow-list-bump.yaml`.
+
+Two kinds deferred along the way, per the rule that nothing ships until
+something emits it: `SHA_COMMENT_MISMATCH` and `OUTDATED_ACTION` remain
+unimplemented, and `--verify-actions` reports outdated action calls
+without them. Both return with whatever work produces them.
 
 ## 19. Risks, edge cases and open questions
 

--- a/src/gha_workflow_linter/allow_list_check.py
+++ b/src/gha_workflow_linter/allow_list_check.py
@@ -369,7 +369,9 @@ def _owner_from_remote_url(url: str) -> str:
     return owner if ORG_RE.match(owner) else ""
 
 
-def resolve_workflow_org(root: Path, *, configured: str = "") -> str:
+def resolve_workflow_org(
+    root: Path, *, configured: str = "", use_environment: bool = True
+) -> str:
     """Determine the org that owns the workflows being scanned.
 
     The shorthand ``@<sha>`` pin form names no host org and takes it from
@@ -377,7 +379,8 @@ def resolve_workflow_org(root: Path, *, configured: str = "") -> str:
     read?". Precedence follows design section 6.3:
 
     1. ``configured`` -- the config key, itself fed by the CLI flag.
-    2. The ``GITHUB_REPOSITORY_OWNER`` environment variable.
+    2. The ``GITHUB_REPOSITORY_OWNER`` environment variable, when
+       ``use_environment`` is set.
     3. The owner of the ``upstream`` Git remote.
     4. The owner of the ``origin`` Git remote.
 
@@ -389,6 +392,13 @@ def resolve_workflow_org(root: Path, *, configured: str = "") -> str:
             the Git remote probes.
         configured: Explicit org from configuration or the
             ``--allow-list-org`` flag.
+        use_environment: Whether ``GITHUB_REPOSITORY_OWNER`` may answer.
+            The variable describes the repository a workflow was
+            launched for, which is a sound default for a single run but
+            false for every repository of a multi-repository sweep bar
+            one. Callers visiting several checkouts clear it so each
+            resolves from its own remotes; an explicit ``configured``
+            value still outranks both.
 
     Returns:
         The org name, or ``""`` when it cannot be determined. An empty
@@ -412,9 +422,10 @@ def resolve_workflow_org(root: Path, *, configured: str = "") -> str:
             )
         return explicit
 
-    from_env = os.environ.get(ORG_ENV_VAR, "").strip()
-    if from_env and ORG_RE.match(from_env):
-        return from_env
+    if use_environment:
+        from_env = os.environ.get(ORG_ENV_VAR, "").strip()
+        if from_env and ORG_RE.match(from_env):
+            return from_env
 
     for remote in REMOTE_PRECEDENCE:
         url = _git_remote_url(root, remote)
@@ -707,7 +718,11 @@ class AllowListChecker:
             self.logger.debug("Allow-list check disabled by configuration")
             return _empty_outcome()
 
-        org = resolve_workflow_org(root, configured=settings.org)
+        org = resolve_workflow_org(
+            root,
+            configured=settings.org,
+            use_environment=settings.use_environment_org,
+        )
         pins = self._scan(paths, root, org)
         if not pins:
             if org:

--- a/src/gha_workflow_linter/allow_list_resolver.py
+++ b/src/gha_workflow_linter/allow_list_resolver.py
@@ -97,7 +97,11 @@ class AllowListResolver:
     def cache_usable(self) -> bool:
         """Whether persisted results may be used and written this run.
 
-        The cache stores ``(tag, sha)`` and nothing else, so a restored
+        The cache stores ``(tag, sha)`` and nothing else, so it cannot
+        record which release policy produced an entry. Two settings make
+        up that policy.
+
+        Under a **cooldown**, a restored
         :class:`~gha_workflow_linter.latest_release.LatestRelease` has an
         empty ``commit_tags`` and cannot say whether a pin is behind the
         target or ahead of it. That is harmless without a cooldown --
@@ -106,15 +110,22 @@ class AllowListResolver:
         release, and losing direction would turn a correct pin into a
         recommendation to downgrade.
 
-        Bypassing the cache while a cooldown is active also keeps the
-        stored entries honest: only unconstrained "newest release"
-        answers are ever written, so a later run without a cooldown
-        cannot read back a cooldown-shifted target.
+        **Prerelease eligibility** changes which releases are candidates
+        at all, so a prerelease-enabled run could cache a prerelease that
+        a later default run consumes, or consume a stable-only entry and
+        miss a newer prerelease.
+
+        Bypassing the cache under either also keeps the stored entries
+        honest: only default-policy answers are ever written, so a later
+        run cannot read back a policy-shifted target.
 
         Returns:
-            ``True`` when no cooldown is in force.
+            ``True`` when the default policy applies, so a stored answer
+            means the same thing to every reader.
         """
-        return self.config.cooldown_days <= 0
+        return self.config.cooldown_days <= 0 and not (
+            self.config.allow_prerelease
+        )
 
     async def resolve(
         self, repo_keys: Iterable[str]
@@ -158,8 +169,9 @@ class AllowListResolver:
 
         if not cache_usable:
             self.logger.debug(
-                "Cooldown active; bypassing the latest-release cache so "
-                "the release each pinned commit belongs to stays known"
+                "Non-default release policy (cooldown or prerelease "
+                "eligibility); bypassing the latest-release cache so the "
+                "release each pinned commit belongs to stays known"
             )
 
         self.logger.debug(

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -43,6 +43,8 @@ class AutoFixer(_VersionResolutionMixin):
         config: Config,
         base_path: Path | None = None,
         cache: ValidationCache | None = None,
+        *,
+        quiet: bool = False,
     ) -> None:
         """
         Initialize the auto-fixer.
@@ -53,10 +55,22 @@ class AutoFixer(_VersionResolutionMixin):
             cache: Optional pre-built ``ValidationCache`` shared with the
                 validator. When ``None`` the auto-fixer builds its own
                 cache.
+            quiet: Suppress the live progress display outright. Without
+                it the display is gated on the logger level, which the
+                CLI sets but a library caller does not -- so a caller
+                assembling JSON on standard output would find Rich
+                progress in the middle of it.
         """
         self.config = config
         self.base_path = base_path or Path.cwd()
         self.logger = logging.getLogger(__name__)
+        self._quiet = quiet
+        #: Files a rewrite was planned for but could not be written. A
+        #: failure here is invisible everywhere else: the planned change
+        #: is absent from ``applied_fixes``, and under ``update_actions``
+        #: the call was never recorded as stale either, so the run would
+        #: otherwise look like one with nothing to do.
+        self.write_failures: list[Path] = []
         self._http_client: httpx.AsyncClient | None = None
         self._graphql_client: GitHubGraphQLClient | None = None
         if cache is not None:
@@ -86,6 +100,23 @@ class AutoFixer(_VersionResolutionMixin):
         )  # Track unique redirected actions
         self._redirect_updates: int = (
             0  # Count of action calls updated due to redirects
+        )
+
+    def _show_live_updates(self) -> bool:
+        """Whether to open the live progress display.
+
+        The display writes to standard output, so anything assembling a
+        JSON document there must be able to switch it off. The logger
+        level alone cannot serve: the CLI sets it, but a library caller
+        never runs that setup, and would find Rich progress in the
+        middle of its document.
+
+        Returns:
+            True when neither the caller nor the logger level has asked
+            for silence.
+        """
+        return (
+            not self._quiet and self.logger.getEffectiveLevel() < logging.ERROR
         )
 
     async def __aenter__(self) -> AutoFixer:
@@ -238,8 +269,7 @@ class AutoFixer(_VersionResolutionMixin):
             )
 
         # Use batch processing for performance
-        # Check if we should show live updates (not in quiet mode)
-        show_live_updates = self.logger.getEffectiveLevel() < logging.ERROR
+        show_live_updates = self._show_live_updates()
 
         # Use Live context only when not in quiet mode, otherwise use nullcontext
         live_context = (
@@ -282,6 +312,7 @@ class AutoFixer(_VersionResolutionMixin):
                 changes = await self._apply_fixes_to_file(file_path, line_fixes)
                 applied_fixes[file_path] = changes
             except Exception as e:
+                self.write_failures.append(file_path)
                 self.logger.error(f"Failed to apply fixes to {file_path}: {e}")
 
         # Add skipped items to the output

--- a/src/gha_workflow_linter/auto_fix_versions.py
+++ b/src/gha_workflow_linter/auto_fix_versions.py
@@ -46,6 +46,46 @@ class _VersionResolutionMixin(_ReferenceResolutionMixin):
     higher-level latest-version lookups that build on them.
     """
 
+    @property
+    def _persistent_cache_usable(self) -> bool:
+        """Whether persisted latest versions may be read or written.
+
+        The persistent cache is keyed on the repository alone, so it
+        cannot record which release policy produced an entry. Two
+        settings make up that policy.
+
+        A **cooldown** deliberately selects an *older* release, so a
+        shared entry would cross policies in both directions: a
+        repository with a short cooldown could publish a version that a
+        longer-cooled repository is not yet entitled to, and a
+        cooldown-shifted entry could later suppress a valid update for a
+        repository running no cooldown at all.
+
+        **Prerelease eligibility** changes which releases are candidates
+        at all, so a prerelease-enabled run could cache a prerelease that
+        a later default run consumes, or consume a stable-only entry and
+        miss a newer prerelease.
+
+        This matters most in a multi-repository sweep, where one cache
+        serves every repository and each resolves its own policy, but it
+        applies equally to successive single-repository runs sharing the
+        on-disk cache.
+
+        The session cache is unaffected: it lives on one ``AutoFixer``,
+        which serves exactly one repository and therefore one policy.
+
+        Mirrors
+        :attr:`gha_workflow_linter.allow_list_resolver.AllowListResolver.cache_usable`,
+        which bypasses its own cache under the same conditions.
+
+        Returns:
+            ``True`` when the default policy applies, so a stored answer
+            means the same thing to every reader.
+        """
+        return (
+            self.config.cooldown_days <= 0 and not self.config.allow_prerelease
+        )
+
     async def _get_latest_versions_batch(
         self, repo_keys: list[str]
     ) -> dict[str, tuple[str, str]]:
@@ -70,7 +110,11 @@ class _VersionResolutionMixin(_ReferenceResolutionMixin):
                     session_cache_hits += 1
                     continue
 
-            cached_version = self._cache.get_latest_version(repo_key)
+            cached_version = (
+                self._cache.get_latest_version(repo_key)
+                if self._persistent_cache_usable
+                else None
+            )
             if cached_version:
                 tag, sha = cached_version
                 results[repo_key] = (tag, sha)
@@ -108,7 +152,8 @@ class _VersionResolutionMixin(_ReferenceResolutionMixin):
                         sha,
                         current_time,
                     )
-                    self._cache.put_latest_version(repo_key, tag, sha)
+                    if self._persistent_cache_usable:
+                        self._cache.put_latest_version(repo_key, tag, sha)
 
                 repos_to_fetch = [
                     repo
@@ -147,8 +192,12 @@ class _VersionResolutionMixin(_ReferenceResolutionMixin):
                 results[repo_key] = (tag, sha)
                 # Cache in both session and persistent storage
                 self._latest_versions_cache[repo_key] = (tag, sha, current_time)
-                self._cache.put_latest_version(repo_key, tag, sha)
+                if self._persistent_cache_usable:
+                    self._cache.put_latest_version(repo_key, tag, sha)
 
+        # Saved unconditionally: the cache holds validation results
+        # written elsewhere in the run, and those are unaffected by the
+        # cooldown that suppressed the latest-version writes above.
         self._cache.save()
 
         return results

--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 import dataclasses
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import logging
 from pathlib import Path
@@ -69,6 +69,7 @@ from .models import (
     ValidationMethod,
     ValidationResult,
 )
+from .multi_repo import find_repositories, is_repository
 from .scanner import WorkflowScanner
 from .system_utils import get_default_workers
 from .utils import has_test_comment
@@ -265,6 +266,7 @@ def _preprocess_args_for_default_command(
         "-f",
         "--files",
         "--allow-list-org",
+        "--repo-depth",
     }
 
     # No args at all: behave like the explicit `lint` subcommand.
@@ -388,8 +390,12 @@ def setup_logging(log_level: LogLevel, quiet: bool = False) -> None:
         root_logger.removeHandler(handler)
 
     # Add our handler
+    # Diagnostics belong on standard error. The JSON output modes write
+    # their document to standard output, and a single log record landing
+    # there would make it unparsable -- a certainty in a sweep, which
+    # logs an error for every repository it survives.
     rich_handler = RichHandler(
-        console=console,
+        console=err_console,
         show_time=False,
         show_path=False,
         markup=True,
@@ -775,6 +781,24 @@ def lint(
             "remote, then 'origin', when not given"
         ),
     ),
+    multi_repo: bool = typer.Option(
+        False,
+        "--multi-repo",
+        "-M",
+        help=(
+            "Treat PATH as a container of git repositories and visit each "
+            "in turn, sharing one cache across them"
+        ),
+    ),
+    repo_depth: int = typer.Option(
+        1,
+        "--repo-depth",
+        help=(
+            "How many levels below PATH to look for repositories when "
+            "--multi-repo is given"
+        ),
+        min=0,
+    ),
     _help: bool = typer.Option(
         False,
         "--help",
@@ -895,6 +919,11 @@ def lint(
         config_manager = ConfigManager()
         config = config_manager.load_config(config_file)
 
+        # Refused before any backend preflight: that preflight makes
+        # network calls and can exit on a rate limit, which would retire
+        # an invalid invocation as a success without ever reporting it.
+        _reject_files_with_multi_repo(files, multi_repo=multi_repo)
+
         # Override config with CLI options
         cli_options = CLIOptions(
             path=path,
@@ -925,6 +954,8 @@ def lint(
             update_allow_list=update_allow_list,
             show_suppressed=show_suppressed,
             allow_list_org=allow_list_org,
+            multi_repo=multi_repo,
+            repo_depth=repo_depth,
         )
 
         # Apply CLI overrides to config
@@ -933,8 +964,17 @@ def lint(
         # Resolve the action-update cooldown window. Precedence: explicit
         # --cooldown flag, then the repository's Dependabot configuration,
         # then 0 (no cooldown / original behaviour).
-        config.cooldown_days = _resolve_cooldown_days(
-            cooldown, path, quiet, output_format
+        #
+        # A sweep skips this. The cooldown belongs to each checkout, and
+        # ``_run_repository_in_sweep`` resolves it there from that
+        # repository's own configuration, so reading the container's
+        # would announce a value that is then discarded -- and an
+        # unreadable one would abort the whole command before the
+        # per-repository failure boundary exists.
+        config.cooldown_days = (
+            0
+            if multi_repo
+            else _resolve_cooldown_days(cooldown, path, quiet, output_format)
         )
 
         logger.debug(f"Starting gha-workflow-linter {__version__}")
@@ -1097,11 +1137,45 @@ class _ValidationOutcome:
 
 @dataclass(frozen=True)
 class _AutoFixOutcome:
-    """Files changed and statistics produced by the auto-fixer."""
+    """Files changed and statistics produced by the auto-fixer.
+
+    Attributes:
+        fixed_files: Changes applied, per file.
+        redirect_stats: Repository-redirect counters.
+        stale_actions_summary: Outdated calls detected but not applied.
+        write_failures: Files a rewrite was planned for but could not be
+            written.
+        stage_error: Why the stage failed outright, or None. Failures
+            here are logged and swallowed so validation results still
+            reach the reader, which leaves nothing else to show that the
+            requested fixing never happened.
+    """
 
     fixed_files: dict[Path, list[dict[str, str]]]
     redirect_stats: dict[str, int]
     stale_actions_summary: dict[str, list[dict[str, Any]]]
+    write_failures: list[Path] = field(default_factory=list)
+    stage_error: str | None = None
+
+
+@dataclass(frozen=True)
+class _ScanShortCircuit:
+    """A scan/validate stage that ended before producing results.
+
+    Carries the reason as well as the code, so a caller aggregating many
+    repositories can tell a repository that *failed* from one that merely
+    had findings. Collapsing both to an integer made an unreadable
+    checkout indistinguishable from a lint result, which is the sharper
+    edge of reporting an unusable input as an absence of problems.
+
+    Attributes:
+        exit_code: What this stage alone would exit with.
+        error: Why the run stopped, or ``None`` when nothing went wrong
+            (there was simply nothing to validate).
+    """
+
+    exit_code: int
+    error: str | None = None
 
 
 def _handle_validation_aborted(
@@ -1163,17 +1237,67 @@ def _handle_validation_aborted(
     return 1
 
 
+def _describe_exception(error: Exception) -> str:
+    """Describe a failure, even one carrying no message.
+
+    ``str(RuntimeError())`` is empty, and every consumer of a recorded
+    reason tests it for truth, so an empty description reads as no
+    failure at all. The class name is a poor description but an honest
+    one.
+
+    Args:
+        error: The exception to describe.
+
+    Returns:
+        The exception's message, or its class name when it has none.
+    """
+    return str(error) or type(error).__name__
+
+
+def _reject_files_with_multi_repo(
+    files: list[str] | None, *, multi_repo: bool
+) -> None:
+    """Refuse ``--files`` combined with ``--multi-repo``.
+
+    ``--files`` names individual paths, and the scanner honours an
+    absolute one whatever root it is given. Combined with a sweep it
+    would scan -- and under ``--update-allow-list`` rewrite -- the same
+    file once per repository, attributing it to each in turn. The two
+    options ask for different things, so the combination is refused
+    rather than given an arbitrary meaning.
+
+    Called from the command before any backend preflight, since that
+    preflight makes network calls and can exit on a rate limit, which
+    would retire an invalid invocation as a success. Called again from
+    the sweep itself, which a library caller can reach directly.
+
+    Args:
+        files: Individual paths the caller named, if any.
+        multi_repo: Whether a sweep was requested.
+
+    Raises:
+        ConfigurationError: If both were given.
+    """
+    if multi_repo and files:
+        raise ConfigurationError(
+            "--files cannot be combined with --multi-repo: --files names "
+            "individual paths, which a sweep would scan once per "
+            "repository. Run the linter in the repository that owns "
+            "those files instead."
+        )
+
+
 def _scan_and_validate(
     config: Config,
     options: CLIOptions,
     scanner: WorkflowScanner,
     shared_cache: ValidationCache,
-) -> int | _ValidationOutcome:
+) -> _ScanShortCircuit | _ValidationOutcome:
     """Scan workflows and validate their action calls.
 
-    Returns an ``int`` exit code when the run short-circuits (scan error,
-    nothing to validate, or aborted validation); otherwise returns a
-    :class:`_ValidationOutcome` for downstream processing.
+    Returns a :class:`_ScanShortCircuit` when the run stops early (scan
+    error, nothing to validate, or aborted validation); otherwise returns
+    a :class:`_ValidationOutcome` for downstream processing.
     """
     logger = logging.getLogger(__name__)
 
@@ -1193,13 +1317,16 @@ def _scan_and_validate(
                 options.path, progress, scan_task, specific_files=options.files
             )
         except Exception as e:
-            logger.error(f"Error scanning workflows: {e}")
-            return 1
+            reason = _describe_exception(e)
+            logger.error(f"Error scanning workflows: {reason}")
+            return _ScanShortCircuit(1, f"Error scanning workflows: {reason}")
 
         if not workflow_calls:
             if not options.quiet:
                 console.print("[yellow]No workflows found to validate[/yellow]")
-            return 0
+            # Not a failure: a repository with no workflows is a valid,
+            # clean result rather than one that could not be scanned.
+            return _ScanShortCircuit(0)
 
         # Count total calls for progress tracking
         total_calls = sum(len(calls) for calls in workflow_calls.values())
@@ -1214,14 +1341,24 @@ def _scan_and_validate(
                 workflow_calls, progress, validate_task
             )
         except ValidationAbortedError as e:
-            return _handle_validation_aborted(
-                e,
-                suppress_console=options.quiet
-                or options.output_format == "json",
+            return _ScanShortCircuit(
+                _handle_validation_aborted(
+                    e,
+                    suppress_console=options.quiet
+                    or options.output_format == "json",
+                ),
+                # str(e) rather than e.message: the message is the
+                # generic summary and the reason carries the underlying
+                # failure, so reporting the message alone would drop the
+                # network or authentication detail a reader needs.
+                f"Validation aborted: {e}",
             )
         except Exception as e:
-            logger.error(f"Unexpected error validating action calls: {e}")
-            return 1
+            reason = _describe_exception(e)
+            logger.error(f"Unexpected error validating action calls: {reason}")
+            return _ScanShortCircuit(
+                1, f"Unexpected error validating action calls: {reason}"
+            )
 
     return _ValidationOutcome(
         workflow_calls, validation_errors, validator, total_calls
@@ -1241,9 +1378,18 @@ def _run_auto_fix_stage(
     """
     logger = logging.getLogger(__name__)
 
+    # Derived once and used for every display in this stage. The fixer's
+    # live progress, the applied-changes listing and the failure notice
+    # all write to standard output, which in JSON mode carries the
+    # document -- and a programmatic caller of ``run_linter`` gets none
+    # of the command layer's quiet coercion.
+    silent = options.quiet or options.output_format == "json"
+
     fixed_files: dict[Path, list[dict[str, str]]] = {}
     redirect_stats: dict[str, int] = {"actions_moved": 0, "calls_updated": 0}
     stale_actions_summary: dict[str, list[dict[str, Any]]] = {}
+    write_failures: list[Path] = []
+    stage_error: str | None = None
 
     # Determine if we should run auto-fix:
     # - If auto_fix is enabled, fix validation errors and check for outdated
@@ -1263,11 +1409,13 @@ def _run_auto_fix_stage(
             dict[Path, list[dict[str, str]]],
             dict[str, int],
             dict[str, list[dict[str, Any]]],
+            list[Path],
         ]:
             async with AutoFixer(
                 config,
                 base_path=options.path,
                 cache=shared_cache,
+                quiet=silent,
             ) as auto_fixer:
                 # When auto_fix is enabled, always pass all action calls to
                 # check. check_for_updates=True only when update_actions is
@@ -1275,25 +1423,42 @@ def _run_auto_fix_stage(
                 # validation errors, report outdated versions.
                 all_calls = validation.workflow_calls if config.auto_fix else {}
                 check_for_updates = config.update_actions
-                return await auto_fixer.fix_validation_errors(
+                result = await auto_fixer.fix_validation_errors(
                     validation.validation_errors,
                     all_calls,
                     check_for_updates=check_for_updates,
                 )
+                # Read inside the context: a rewrite that failed leaves
+                # no trace in the returned tuple.
+                return (*result, list(auto_fixer.write_failures))
 
-        fixed_files, redirect_stats, stale_actions_summary = asyncio.run(
-            run_auto_fix()
-        )
+        (
+            fixed_files,
+            redirect_stats,
+            stale_actions_summary,
+            write_failures,
+        ) = asyncio.run(run_auto_fix())
 
-        if fixed_files and not options.quiet:
+        if fixed_files and not silent:
             _display_auto_fix_changes(fixed_files, options)
 
     except Exception as e:
-        logger.warning(f"Auto-fix failed: {e}")
-        if not options.quiet:
-            console.print(f"[yellow]Auto-fix failed: {e} ⚠️[/yellow]")
+        # Swallowed so validation results still reach the reader, but
+        # recorded: with nothing applied, nothing stale and no
+        # validation error, an all-empty outcome would otherwise report
+        # a successful run that did no fixing at all.
+        stage_error = _describe_exception(e)
+        logger.warning(f"Auto-fix failed: {stage_error}")
+        if not silent:
+            console.print(f"[yellow]Auto-fix failed: {stage_error} ⚠️[/yellow]")
 
-    return _AutoFixOutcome(fixed_files, redirect_stats, stale_actions_summary)
+    return _AutoFixOutcome(
+        fixed_files,
+        redirect_stats,
+        stale_actions_summary,
+        write_failures,
+        stage_error,
+    )
 
 
 def _display_auto_fix_changes(
@@ -1368,8 +1533,26 @@ def _emit_results(
     autofix: _AutoFixOutcome,
     config: Config,
     allow_list: AllowListOutcome | None = None,
-) -> None:
-    """Generate and display the scan/validation results."""
+    *,
+    collect_json: bool = False,
+) -> dict[str, Any] | None:
+    """Generate and display the scan/validation results.
+
+    Args:
+        options: Resolved CLI options.
+        scanner: The scanner that produced the workflow calls.
+        validation: Outcome of the scan/validate stage.
+        autofix: Outcome of the auto-fix stage.
+        config: Resolved configuration.
+        allow_list: Outcome of the allow-list stage, when it ran.
+        collect_json: Return the JSON payload instead of printing it, so
+            a sweep can assemble one document from many repositories.
+
+    Returns:
+        The JSON payload when ``collect_json`` is set and the output
+        format is JSON, so a caller may aggregate it; ``None``
+        otherwise.
+    """
     scan_summary = scanner.get_scan_summary(validation.workflow_calls)
 
     # Calculate unique calls for statistics
@@ -1384,6 +1567,17 @@ def _emit_results(
     )
 
     if options.output_format == "json":
+        if collect_json:
+            # The caller is assembling one document from several
+            # repositories, so hand back the payload rather than
+            # printing a top-level object of our own.
+            return build_json_results(
+                scan_summary,
+                validation_summary,
+                validation.validation_errors,
+                options.path,
+                allow_list,
+            )
         output_json_results(
             scan_summary,
             validation_summary,
@@ -1391,25 +1585,27 @@ def _emit_results(
             options.path,
             allow_list,
         )
-    else:
-        output_text_results(
-            scan_summary,
-            validation_summary,
-            validation.validation_errors,
-            options.path,
-            options.quiet,
-            autofix.fixed_files,
-            autofix.redirect_stats,
-            autofix.stale_actions_summary,
+        return None
+
+    output_text_results(
+        scan_summary,
+        validation_summary,
+        validation.validation_errors,
+        options.path,
+        options.quiet,
+        autofix.fixed_files,
+        autofix.redirect_stats,
+        autofix.stale_actions_summary,
+    )
+    if allow_list is not None and not options.quiet:
+        # Only suggest remediation when it has not already run.
+        render_allow_list(
+            allow_list,
+            root=options.path,
+            show_suppressed=config.allow_list.show_suppressed,
+            update_hint=not config.allow_list.update,
         )
-        if allow_list is not None and not options.quiet:
-            # Only suggest remediation when it has not already run.
-            render_allow_list(
-                allow_list,
-                root=options.path,
-                show_suppressed=config.allow_list.show_suppressed,
-                update_hint=not config.allow_list.update,
-            )
+    return None
 
 
 #: Sentinel host key used when the allow-list stage itself fails, rather
@@ -1463,7 +1659,24 @@ def _run_allow_list_stage(
         # --allow-list-org would silently disable the whole check.
         raise
     except Exception as e:  # noqa: BLE001 - advisory unless enforcing
-        logger.warning(f"Allow-list check failed: {e}")
+        logger.warning(f"Allow-list check failed: {_describe_exception(e)}")
+        if config.allow_list.update:
+            # Updating was explicitly requested, so silently doing none
+            # of it -- or part of it, if earlier files were already
+            # rewritten -- must not report success. Same reasoning as
+            # the action fixer's stage error.
+            if not options.quiet:
+                console.print(
+                    f"[red]Allow-list update could not complete: "
+                    f"{_describe_exception(e)} ❌[/red]"
+                )
+            return AllowListOutcome(
+                findings=[],
+                hosts={},
+                unresolved={STAGE_FAILURE_HOST: _describe_exception(e)},
+                suppressed_count=0,
+                checked=True,
+            )
         if not config.allow_list.verify:
             # Advisory mode: a developer offline on a train must still be
             # able to commit, so the check is skipped entirely.
@@ -1474,12 +1687,13 @@ def _run_allow_list_stage(
         # ALLOW_LIST_UNRESOLVED.
         if not options.quiet:
             console.print(
-                f"[red]Allow-list verification could not run: {e} ❌[/red]"
+                f"[red]Allow-list verification could not run: "
+                f"{_describe_exception(e)} ❌[/red]"
             )
         return AllowListOutcome(
             findings=[],
             hosts={},
-            unresolved={STAGE_FAILURE_HOST: str(e)},
+            unresolved={STAGE_FAILURE_HOST: _describe_exception(e)},
             suppressed_count=0,
             checked=True,
         )
@@ -1621,6 +1835,24 @@ def _determine_exit_code(
     """
     codes: list[int] = []
 
+    # A rewrite the caller asked for that could not be written is a
+    # failure, and one that shows up nowhere else: the planned change is
+    # absent from the applied fixes, and under --update-actions the call
+    # was never recorded as stale either. Reporting success would tell
+    # the caller the work was done.
+    if autofix.write_failures:
+        codes.append(exit_codes.DEFECTS_FOUND)
+
+    # A stage that failed outright leaves even less behind. It only
+    # fails the run when updating was explicitly requested, though:
+    # auto-fix runs by default, and a stage that could not reach the
+    # network must not stop a developer committing, exactly as the
+    # allow-list check degrades in advisory mode. Asking for
+    # --update-actions is asking for work to be done, so silently doing
+    # none of it is a different matter.
+    if autofix.stage_error and config.update_actions:
+        codes.append(exit_codes.DEFECTS_FOUND)
+
     # Files modified on disk are reported as a failure so a CI job or a
     # pre-commit hook notices that the tree changed underneath it.
     if autofix.fixed_files:
@@ -1656,13 +1888,18 @@ def _determine_exit_code(
             # Files changed on disk, so the caller must notice, exactly as
             # for the action-call fixer.
             codes.append(exit_codes.DEFECTS_FOUND)
-        if config.allow_list.verify:
-            if allow_list.unresolved:
-                codes.append(exit_codes.ALLOW_LIST_UNRESOLVED)
-            elif allow_list.outstanding:
-                # Anything remediation already rewrote is no longer a
-                # problem, so only what remains can fail the run.
-                codes.append(exit_codes.ALLOW_LIST_STALE)
+        # An incomplete check fails when enforcement was requested, and
+        # equally when updating was: asking for an update and silently
+        # getting none of it -- or part of it, if earlier files were
+        # already rewritten -- must not report success.
+        if allow_list.unresolved and (
+            config.allow_list.verify or config.allow_list.update
+        ):
+            codes.append(exit_codes.ALLOW_LIST_UNRESOLVED)
+        elif config.allow_list.verify and allow_list.outstanding:
+            # Anything remediation already rewrote is no longer a
+            # problem, so only what remains can fail the run.
+            codes.append(exit_codes.ALLOW_LIST_STALE)
 
     return exit_codes.combine(*codes) if codes else exit_codes.SUCCESS
 
@@ -1682,6 +1919,42 @@ def _has_outdated_actions(autofix: _AutoFixOutcome) -> bool:
     )
 
 
+@dataclasses.dataclass(frozen=True)
+class RunOutcome:
+    """What one repository's run produced.
+
+    Attributes:
+        exit_code: The code this repository alone would have exited with.
+        allow_list: Outcome of the allow-list stage, when it ran.
+        files_changed: How many files a fixer rewrote.
+        defects: Validation errors left unrepaired, excluding test
+            references and anything the auto-fixer rewrote.
+        outdated: Action calls with a newer release available. Advisory
+            unless ``--verify-actions``, so the exit code alone cannot
+            reveal them.
+        write_failures: Files a rewrite was planned for but could not be
+            written. Counted separately because such a file appears in
+            no other tally.
+        autofix_error: Why the auto-fix stage failed outright, or None.
+            Recorded for the same reason: a stage that never ran leaves
+            nothing else behind.
+        error: Description of a failure that stopped the run, or None.
+        json_payload: This repository's JSON results, present only when
+            the caller asked for them to be collected rather than
+            printed.
+    """
+
+    exit_code: int
+    allow_list: AllowListOutcome | None = None
+    files_changed: int = 0
+    defects: int = 0
+    outdated: int = 0
+    write_failures: int = 0
+    autofix_error: str | None = None
+    error: str | None = None
+    json_payload: dict[str, Any] | None = None
+
+
 def run_linter(config: Config, options: CLIOptions) -> int:
     """
     Run the main linting process.
@@ -1693,29 +1966,61 @@ def run_linter(config: Config, options: CLIOptions) -> int:
     Returns:
         Exit code from :mod:`gha_workflow_linter.exit_codes`.
     """
-    scanner = WorkflowScanner(config)
+    if options.multi_repo:
+        return _run_multi_repo(config, options)
 
-    # Build a single ValidationCache and share it across the validator
-    # and (later) the auto-fixer to avoid duplicate disk I/O and
-    # competing save() calls.
     shared_cache = ValidationCache(config.cache)
-
     # Eagerly load the cache and run all startup-time checks so any
     # banners render *before* opening the Rich Progress UI (printing
     # inside the progress block would interleave with the active
     # spinner and corrupt output).
     _render_cache_prime_banners(shared_cache.prime(), quiet=options.quiet)
+    return _run_one_repository(config, options, shared_cache).exit_code
+
+
+def _run_one_repository(
+    config: Config,
+    options: CLIOptions,
+    shared_cache: ValidationCache,
+    *,
+    collect_json: bool = False,
+) -> RunOutcome:
+    """Scan, validate, fix and report a single repository.
+
+    Args:
+        config: Resolved configuration for this repository.
+        options: Resolved CLI options, with ``path`` set to it.
+        shared_cache: Cache shared with every other stage, and across
+            repositories in a multi-repository run.
+        collect_json: Return the JSON payload on the outcome instead of
+            printing it, so a sweep can assemble one document rather
+            than emitting several.
+
+    Returns:
+        What the run produced, for aggregation by the caller.
+    """
+    scanner = WorkflowScanner(config)
 
     scan_result = _scan_and_validate(config, options, scanner, shared_cache)
-    if isinstance(scan_result, int):
-        return scan_result
+    if isinstance(scan_result, _ScanShortCircuit):
+        return RunOutcome(
+            exit_code=scan_result.exit_code, error=scan_result.error
+        )
     validation = scan_result
 
     autofix = _run_auto_fix_stage(config, options, shared_cache, validation)
 
     allow_list = _run_allow_list_stage(config, options, shared_cache)
 
-    _emit_results(options, scanner, validation, autofix, config, allow_list)
+    payload = _emit_results(
+        options,
+        scanner,
+        validation,
+        autofix,
+        config,
+        allow_list,
+        collect_json=collect_json,
+    )
 
     # Report outdated actions when auto-fix repaired validation errors but
     # version bumps were only detected, not applied. This is presentation
@@ -1731,9 +2036,447 @@ def run_linter(config: Config, options: CLIOptions) -> int:
             autofix.stale_actions_summary, options
         )
 
-    return _determine_exit_code(
-        options, validation, autofix, config, allow_list
+    repaired = _repaired_locations(autofix)
+
+    return RunOutcome(
+        exit_code=_determine_exit_code(
+            options, validation, autofix, config, allow_list
+        ),
+        allow_list=allow_list,
+        files_changed=sum(
+            1
+            for changes in autofix.fixed_files.values()
+            if any(change.get("skipped") != "true" for change in changes)
+        ),
+        defects=sum(
+            1
+            for error in validation.validation_errors
+            if not has_test_comment(error.action_call)
+            and (error.file_path, error.action_call.line_number) not in repaired
+        ),
+        outdated=sum(
+            len(items) for items in autofix.stale_actions_summary.values()
+        ),
+        write_failures=len(autofix.write_failures),
+        autofix_error=autofix.stage_error,
+        json_payload=payload,
     )
+
+
+def _repaired_locations(autofix: _AutoFixOutcome) -> set[tuple[Path, int]]:
+    """Locate the calls the auto-fixer actually rewrote.
+
+    Used to keep a repaired call out of the outstanding-defect tally: it
+    was a validation error when the run began, but it is not one the
+    reader still has to deal with, and counting it as both fixed and
+    outstanding reads as a contradiction.
+
+    Skipped entries are excluded, since those record a call the fixer
+    deliberately left alone.
+
+    Args:
+        autofix: Outcome of the auto-fix stage.
+
+    Returns:
+        ``(file path, line number)`` pairs that were rewritten on disk.
+    """
+    repaired: set[tuple[Path, int]] = set()
+    for file_path, changes in autofix.fixed_files.items():
+        for change in changes:
+            if change.get("skipped") == "true":
+                continue
+            line_number = change.get("line_number")
+            if line_number is None:
+                continue
+            try:
+                repaired.add((file_path, int(line_number)))
+            except ValueError:  # pragma: no cover - defensive
+                continue
+    return repaired
+
+
+def _repository_label(repository: Path, root: Path) -> str:
+    """Name a repository for the sweep's output.
+
+    Grouped layouts put more than one ``service`` under a container, so
+    the basename alone cannot attribute a finding. The path relative to
+    the sweep root can, except when the two are the same -- the
+    root-repository shortcut -- where it degrades to ``.``.
+
+    That shortcut takes the basename instead, but of the *resolved*
+    path: a caller may name a repository ``Path(".")``, whose basename
+    is empty, and a blank label loses the attribution this exists to
+    provide. A checkout at the filesystem root has no basename either,
+    so the path itself is the last resort.
+
+    Args:
+        repository: The repository being described.
+        root: The container the sweep was pointed at.
+
+    Returns:
+        A non-empty label distinguishing this repository from its
+        siblings.
+    """
+    relative = str(_get_relative_path(repository, root))
+    if relative != ".":
+        return relative
+
+    try:
+        resolved = repository.resolve()
+    except OSError:  # pragma: no cover - defensive
+        resolved = repository
+    return resolved.name or str(resolved)
+
+
+def _run_multi_repo(config: Config, options: CLIOptions) -> int:
+    """Visit every repository beneath the given path in turn.
+
+    Repositories are processed sequentially. The intra-repository
+    parallelism already saturates the API budget, and one repository at a
+    time keeps the progress output legible and attributes a failure to
+    the repository that caused it.
+
+    The cache is built once and shared, so twenty repositories pinning
+    the same allow-list host cost one latest-release lookup rather than
+    twenty -- under the default release policy. A cooldown or prerelease
+    eligibility makes a cached answer policy-dependent, so both bypass
+    the cache and each repository resolves the host for itself.
+    Configuration is copied per repository, because the workflow
+    organisation and the Dependabot cooldown are properties of each one.
+
+    In JSON output mode every repository's payload is collected into a
+    single document rather than printed as it goes, so standard output
+    stays parseable, and the progress commentary is suppressed for the
+    same reason.
+
+    Args:
+        config: Resolved configuration, used as the template per
+            repository.
+        options: Resolved CLI options, with ``path`` as the container.
+
+    Returns:
+        The most significant exit code across every repository.
+    """
+    logger = logging.getLogger(__name__)
+
+    _reject_files_with_multi_repo(options.files, multi_repo=True)
+
+    json_mode = options.output_format == "json"
+    # Anything written to standard output would sit alongside the JSON
+    # document, so the commentary goes quiet in JSON mode as well.
+    silent = options.quiet or json_mode
+
+    try:
+        repositories = find_repositories(options.path, depth=options.repo_depth)
+    except ValueError as error:
+        logger.error(f"Invalid repository depth: {error}")
+        return exit_codes.RUNTIME_ERROR
+    except OSError as error:
+        # An unreadable root means nothing was examined. Reporting an
+        # empty sweep would be indistinguishable from a container with
+        # no repositories in it, and would exit successfully.
+        logger.error(
+            f"Cannot read {options.path}: {_describe_exception(error)}"
+        )
+        return exit_codes.RUNTIME_ERROR
+
+    if not repositories:
+        if json_mode:
+            # An empty sweep still owes the caller a document, or a
+            # consumer cannot tell it from a crash.
+            _output_multi_repo_json([], options.path)
+        elif not options.quiet:
+            console.print(
+                f"[yellow]No repositories found under {options.path} "
+                f"at depth {options.repo_depth} ⚠️[/yellow]"
+            )
+        return exit_codes.SUCCESS
+
+    shared_cache = ValidationCache(config.cache)
+    _render_cache_prime_banners(shared_cache.prime(), quiet=silent)
+
+    if not silent:
+        console.print(
+            f"\n[bold]Scanning {len(repositories)} repositories under "
+            f"{options.path}[/bold]\n"
+        )
+
+    results: list[tuple[Path, RunOutcome]] = []
+    for repository in repositories:
+        results.append(
+            (
+                repository,
+                _run_repository_in_sweep(
+                    config,
+                    options,
+                    shared_cache,
+                    repository,
+                    silent=silent,
+                    # Pointing --multi-repo at a checkout visits that one
+                    # repository, which is the case
+                    # GITHUB_REPOSITORY_OWNER describes correctly, so the
+                    # shortcut keeps whatever was configured. A genuine
+                    # sweep forces it off regardless.
+                    use_environment_org=(
+                        config.allow_list.use_environment_org
+                        and is_repository(options.path)
+                    ),
+                    label=_repository_label(repository, options.path),
+                ),
+            )
+        )
+
+    if json_mode:
+        _output_multi_repo_json(results, options.path)
+    elif not options.quiet:
+        _display_multi_repo_summary(results, options.path)
+
+    return exit_codes.combine(*(outcome.exit_code for _, outcome in results))
+
+
+def _output_multi_repo_json(
+    results: list[tuple[Path, RunOutcome]],
+    root: Path,
+) -> None:
+    """Emit one JSON document covering the whole sweep.
+
+    Printing each repository's payload as it completed would put several
+    top-level objects on standard output, which no JSON parser accepts.
+    Wrapping them keeps ``--multi-repo --format json`` machine-readable.
+
+    Args:
+        results: Per-repository outcomes, in visit order.
+        root: The container the sweep was pointed at, used to label each
+            repository relatively.
+    """
+    document = {
+        "repositories": [
+            {
+                "repository": _repository_label(repository, root),
+                "exit_code": outcome.exit_code,
+                "error": outcome.error,
+                # Both are otherwise-invisible reasons for a non-zero
+                # exit: neither produces a validation error, so a
+                # consumer reading only ``results`` would find nothing
+                # to explain the code.
+                "write_failures": outcome.write_failures,
+                "autofix_error": outcome.autofix_error,
+                "results": outcome.json_payload,
+            }
+            for repository, outcome in results
+        ],
+        "summary": {
+            "repositories": len(results),
+            "failed": sum(1 for _, o in results if o.error),
+            "exit_code": exit_codes.combine(
+                *(outcome.exit_code for _, outcome in results)
+            )
+            if results
+            else exit_codes.SUCCESS,
+        },
+    }
+
+    # Plain print() avoids Rich formatting/ANSI codes in JSON output.
+    print(json.dumps(document, indent=2))
+
+
+def _run_repository_in_sweep(
+    config: Config,
+    options: CLIOptions,
+    shared_cache: ValidationCache,
+    repository: Path,
+    *,
+    silent: bool = False,
+    use_environment_org: bool = False,
+    label: str | None = None,
+) -> RunOutcome:
+    """Run one repository of a sweep, surviving its failure.
+
+    A repository that raises is recorded and the sweep continues: one
+    unreadable checkout in twenty must not cost the other nineteen their
+    results.
+
+    Args:
+        config: Template configuration.
+        options: Template CLI options.
+        shared_cache: Cache shared across the sweep.
+        repository: The repository to visit.
+        silent: Suppress this repository's console commentary, either
+            because the caller asked for quiet or because a JSON
+            document is being assembled on standard output.
+        use_environment_org: Whether ``GITHUB_REPOSITORY_OWNER`` may name
+            this repository's workflow organisation. False for a genuine
+            sweep, where the variable describes one repository at most;
+            true for the root-repository shortcut, which is the ordinary
+            single-repository case wearing a different flag.
+        label: How to name the repository in output. Defaults to its
+            basename.
+
+    Returns:
+        What that repository produced, or a runtime error outcome.
+    """
+    logger = logging.getLogger(__name__)
+
+    if not silent:
+        console.print(f"[bold cyan]── {label or repository.name}[/bold cyan]")
+
+    # Both the workflow organisation and the cooldown are properties of
+    # the repository being scanned, so each gets its own copy rather than
+    # inheriting whatever the previous one resolved.
+    # Preparation sits inside the failure boundary alongside the run
+    # itself. Resolving the cooldown reads this repository's
+    # ``dependabot.yml``, and a malformed one raises past the narrow
+    # handling in the resolver -- which outside the boundary would abort
+    # the whole sweep, contradicting the promise that one bad checkout
+    # costs only itself.
+    try:
+        repo_config = config.model_copy(deep=True)
+        # ``silent`` rather than ``options.quiet``: the repository's own
+        # run prints progress and messages such as "No workflows found
+        # to validate" to standard output, which would sit inside the
+        # aggregate JSON document. The command layer coerces quiet for
+        # JSON output already, but relying on that leaves the sweep
+        # correct only by distance, and a programmatic caller of
+        # ``run_linter`` gets no such coercion.
+        repo_options = options.model_copy(
+            update={"path": repository, "quiet": silent}
+        )
+        repo_config.cooldown_days = _resolve_cooldown_days(
+            options.cooldown, repository, quiet=True, output_format="text"
+        )
+        # GITHUB_REPOSITORY_OWNER names the repository the workflow was
+        # launched for, so across a sweep it would answer identically
+        # for every checkout and resolve their shorthand pins against
+        # one, possibly foreign, organisation. Each repository resolves
+        # from its own remotes instead; an explicit --allow-list-org
+        # still outranks both.
+        repo_config.allow_list.use_environment_org = use_environment_org
+
+        return _run_one_repository(
+            repo_config,
+            repo_options,
+            shared_cache,
+            collect_json=options.output_format == "json",
+        )
+    except ConfigurationError:
+        # A bad setting is a usage error and applies to every repository,
+        # so there is nothing to be gained by continuing.
+        raise
+    except Exception as e:  # noqa: BLE001 - one repository must not stop the sweep
+        # Computed once so the log, the console and the outcome all
+        # describe the failure the same way.
+        reason = _describe_exception(e)
+        logger.error(f"Failed to scan {repository}: {reason}")
+        if not silent:
+            console.print(f"[red]  failed: {reason} ❌[/red]")
+        return RunOutcome(
+            exit_code=exit_codes.RUNTIME_ERROR,
+            error=reason,
+        )
+
+
+def _display_multi_repo_summary(
+    results: list[tuple[Path, RunOutcome]],
+    root: Path,
+) -> None:
+    """Render the aggregate table closing a sweep.
+
+    Args:
+        results: Per-repository outcomes, in visit order.
+        root: The container the sweep was pointed at. Rows are labelled
+            relative to it, so grouped layouts such as ``group-a/service``
+            and ``group-b/service`` stay distinguishable.
+    """
+    table = Table(title="Repository Summary")
+    table.add_column("Repository", style="cyan")
+    table.add_column("Pins", justify="right")
+    table.add_column("Stale", justify="right")
+    table.add_column("Fixed", justify="right")
+    table.add_column("Defects", justify="right")
+    table.add_column("Status")
+
+    for repository, outcome in results:
+        allow_list = outcome.allow_list
+        pins = len(allow_list.findings) if allow_list else 0
+        # What still needs attention, not what was found: a pin the
+        # sweep rewrote is no longer stale, and showing it as both
+        # stale and fixed reads as a contradiction.
+        stale = len(allow_list.outstanding) if allow_list else 0
+        fixed = allow_list.fixed_count if allow_list else 0
+        table.add_row(
+            _repository_label(repository, root),
+            str(pins),
+            str(stale),
+            str(fixed),
+            str(outcome.defects),
+            _sweep_status(outcome),
+        )
+
+    console.print()
+    console.print(table)
+
+    failures = [name for name, o in results if o.error]
+    if failures:
+        console.print(
+            f"\n[red]{len(failures)} repository(s) could not be "
+            f"scanned ❌[/red]"
+        )
+
+
+def _sweep_status(outcome: RunOutcome) -> str:
+    """Describe one repository's outcome for the summary table.
+
+    ``clean`` is reserved for a repository with nothing outstanding, and
+    ``updated`` for one whose outstanding work is *finished*. The exit
+    code alone can establish neither: allow-list findings and outdated
+    action calls both stay advisory unless ``--verify-*`` asks
+    otherwise, and defects survive ``--no-fail-on-error``. Reading the
+    code alone produced rows marked ``clean`` beside a non-zero Stale
+    column, which is a contradiction in the same row.
+
+    What remains is therefore tested before what was done. A partial
+    remediation changes files *and* leaves pins outstanding, and calling
+    that ``updated`` would tell the reader the repository needs no
+    further attention when it does.
+
+    A repository whose hosts could not be resolved gets its own label
+    rather than sharing ``findings``: the check did not complete, so its
+    empty counts say nothing, and a row of zeros marked ``findings``
+    gives the reader no way to tell the two apart. The order below
+    follows the exit-code precedence in ``exit_codes``, so an unresolved
+    check outranks work that was carried out.
+
+    Args:
+        outcome: What the repository produced.
+
+    Returns:
+        A short, styled status.
+    """
+    if outcome.error:
+        return "[red]failed[/red]"
+
+    allow_list = outcome.allow_list
+    if allow_list and allow_list.unresolved:
+        return "[red]unresolved[/red]"
+
+    if (
+        (allow_list and allow_list.outstanding)
+        or outcome.defects
+        or outcome.outdated
+        or outcome.write_failures
+        or outcome.autofix_error
+    ):
+        return "[yellow]findings[/yellow]"
+
+    # Nothing outstanding, so any rewriting that happened finished the
+    # job. Allow-list rewrites are tracked on their own outcome rather
+    # than in the action-call fixer's tally, so both count here.
+    if outcome.files_changed or (allow_list and allow_list.fixed_count):
+        return "[yellow]updated[/yellow]"
+
+    if outcome.exit_code == exit_codes.SUCCESS:
+        return "[green]clean[/green]"
+    return "[yellow]findings[/yellow]"
 
 
 def _create_scan_summary_table(
@@ -2185,15 +2928,19 @@ def output_text_results(
                 _print_deduplicated_action_refs(test_warnings[file_path])
 
 
-def output_json_results(
+def build_json_results(
     scan_summary: dict[str, Any],
     validation_summary: dict[str, Any],
     errors: list[Any],
     scan_path: Path,
     allow_list: AllowListOutcome | None = None,
-) -> None:
+) -> dict[str, Any]:
     """
-    Output results in JSON format.
+    Build the JSON results document for one repository.
+
+    Kept separate from printing so a multi-repository sweep can collect
+    each repository's payload and emit a single document, rather than
+    concatenating several top-level objects onto standard output.
 
     Args:
         scan_summary: Scan statistics
@@ -2202,6 +2949,9 @@ def output_json_results(
         scan_path: Base path for computing relative paths
         allow_list: Allow-list outcome, merged in under an ``allow_list``
             key when the check ran
+
+    Returns:
+        The results as a JSON-serialisable mapping.
     """
     result = {
         "scan_summary": scan_summary,
@@ -2227,6 +2977,31 @@ def output_json_results(
 
     if allow_list is not None:
         result.update(build_allow_list_json(allow_list, root=scan_path))
+
+    return result
+
+
+def output_json_results(
+    scan_summary: dict[str, Any],
+    validation_summary: dict[str, Any],
+    errors: list[Any],
+    scan_path: Path,
+    allow_list: AllowListOutcome | None = None,
+) -> None:
+    """
+    Output results in JSON format.
+
+    Args:
+        scan_summary: Scan statistics
+        validation_summary: Validation statistics
+        errors: List of validation errors
+        scan_path: Base path for computing relative paths
+        allow_list: Allow-list outcome, merged in under an ``allow_list``
+            key when the check ran
+    """
+    result = build_json_results(
+        scan_summary, validation_summary, errors, scan_path, allow_list
+    )
 
     # Use plain print() to avoid Rich formatting/ANSI codes in JSON output
     print(json.dumps(result, indent=2))

--- a/src/gha_workflow_linter/dependabot.py
+++ b/src/gha_workflow_linter/dependabot.py
@@ -10,8 +10,10 @@ hastily-retracted releases.
 
 This module locates the repository's ``.github/dependabot.yml`` (or
 ``.yaml``) file by walking up the directory hierarchy from a starting
-path, then extracts the ``cooldown.default-days`` value so the linter can
-apply the same policy when updating action calls.
+path -- stopping at the enclosing repository root, since a cooldown is
+that repository's own release policy -- then extracts the
+``cooldown.default-days`` value so the linter can apply the same policy
+when updating action calls.
 """
 
 from __future__ import annotations
@@ -21,6 +23,8 @@ import logging
 from typing import TYPE_CHECKING
 
 import yaml
+
+from .multi_repo import is_repository
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -57,7 +61,16 @@ def find_dependabot_config(start_path: Path) -> Path | None:
 
     Walks up the directory hierarchy from ``start_path`` (or its parent if
     ``start_path`` is a file) until a Dependabot configuration file is
-    found or the filesystem root is reached.
+    found, a repository root is passed, or the filesystem root is
+    reached.
+
+    The search stops at a repository root because a cooldown is that
+    repository's own release policy. Without the boundary, a checkout
+    lacking a Dependabot file inherits whatever directory happens to
+    contain it -- so a multi-repository sweep whose container carries a
+    configuration would silently apply it to every repository beneath,
+    and a lone checkout would answer differently depending on where it
+    was cloned.
 
     Args:
         start_path: Path to begin searching from (typically the directory
@@ -65,19 +78,23 @@ def find_dependabot_config(start_path: Path) -> Path | None:
 
     Returns:
         Path to the Dependabot configuration file, or ``None`` if no file
-        is found.
+        is found at or below the enclosing repository root.
     """
     start = start_path.resolve()
     search_dir = start if start.is_dir() else start.parent
 
     for directory in (search_dir, *search_dir.parents):
         github_dir = directory / ".github"
-        if not github_dir.is_dir():
-            continue
-        for filename in _DEPENDABOT_FILENAMES:
-            candidate = github_dir / filename
-            if candidate.is_file():
-                return candidate
+        if github_dir.is_dir():
+            for filename in _DEPENDABOT_FILENAMES:
+                candidate = github_dir / filename
+                if candidate.is_file():
+                    return candidate
+        # Checked after this directory's own configuration, so a
+        # repository root's file is still found -- it is ascending
+        # *past* the root that leaks policy across the boundary.
+        if is_repository(directory):
+            break
 
     return None
 

--- a/src/gha_workflow_linter/models.py
+++ b/src/gha_workflow_linter/models.py
@@ -531,6 +531,17 @@ class AllowListConfig(BaseModel):
             "then the 'upstream' git remote, then 'origin'"
         ),
     )
+    use_environment_org: bool = Field(
+        default=True,
+        description=(
+            "Whether GITHUB_REPOSITORY_OWNER may supply the workflow "
+            "organisation. The variable names the repository a workflow "
+            "was launched for, which is right for a single run but wrong "
+            "for every repository of a multi-repository sweep bar one, so "
+            "the sweep clears it and each checkout resolves from its own "
+            "remotes. An explicit 'org' still takes precedence either way"
+        ),
+    )
     filename: str = Field(
         default="allow_list.txt",
         description=(
@@ -755,6 +766,15 @@ class CLIOptions(BaseModel):
     allow_list_org: str | None = Field(
         default=None,
         description="Workflow organisation for '@<sha>' shorthand resolution",
+    )
+    multi_repo: bool = Field(
+        default=False,
+        description="Treat the given path as a container of repositories",
+    )
+    repo_depth: int = Field(
+        default=1,
+        ge=0,
+        description="How deep below the path to look for repositories",
     )
 
     @field_validator("output_format")

--- a/src/gha_workflow_linter/multi_repo.py
+++ b/src/gha_workflow_linter/multi_repo.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Discovery of the repositories a multi-repository run should visit.
+
+Scanning stops at repository boundaries (see
+:meth:`gha_workflow_linter.scanner.WorkflowScanner._crosses_repository_boundary`),
+so pointing the linter at a directory that merely *contains* repositories
+finds nothing: every child is a boundary. That is the correct behaviour
+for a single run, and this module is the sanctioned way to cover many --
+each repository is visited as its own root, so its workflow organisation,
+its Dependabot cooldown and its findings all belong to it.
+
+Discovery is deliberately separate from the run itself, so a caller that
+already knows which repositories it wants -- a scheduled workflow using a
+matrix of one-repository checkouts, for instance -- can skip it without
+duplicating anything.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: How far below the given root to look when none is specified. One level
+#: matches the usual layout of a directory of checkouts.
+DEFAULT_DEPTH = 1
+
+#: Directory names never worth descending into. Discovery stops at
+#: repository boundaries anyway, so this only saves walking large trees
+#: that cannot contain a sibling checkout. These names suppress descent
+#: alone: a checkout genuinely called ``venv`` is still recognised,
+#: because the repository test runs first.
+_SKIP_DIRECTORIES = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+        "venv",
+    }
+)
+
+__all__ = [
+    "DEFAULT_DEPTH",
+    "find_repositories",
+    "is_repository",
+]
+
+
+def is_repository(path: Path) -> bool:
+    """Report whether a directory is the root of a Git repository.
+
+    A plain clone carries a ``.git`` directory; a worktree or submodule
+    carries a ``.git`` file pointing elsewhere. Both count, so a
+    directory of worktrees is as valid a target as a directory of
+    clones.
+
+    Args:
+        path: Directory to test.
+
+    Returns:
+        True when the directory contains a ``.git`` entry.
+    """
+    try:
+        return (path / ".git").exists()
+    except OSError:
+        # An unreadable directory is not a repository we can visit.
+        return False
+
+
+def find_repositories(root: Path, *, depth: int = DEFAULT_DEPTH) -> list[Path]:
+    """Find the repositories to visit beneath a container directory.
+
+    The search stops descending as soon as it finds a repository, so a
+    checkout keeping worktrees under ``.worktrees/`` yields the checkout
+    itself rather than the checkout and each of its worktrees. Results
+    are sorted, so a run's output order does not depend on the
+    filesystem.
+
+    Args:
+        root: Directory holding the repositories.
+        depth: How many levels below ``root`` to search. ``0`` considers
+            only ``root`` itself.
+
+    Returns:
+        Repository roots, sorted by path. Empty when none is found.
+
+    Raises:
+        ValueError: If ``depth`` is negative.
+        OSError: If ``root`` itself cannot be listed. A descendant that
+            cannot be read is skipped with a warning, since the rest of
+            the sweep is still worth doing -- but an unreadable *root*
+            means nothing was examined at all, and returning an empty
+            list would make that indistinguishable from a container
+            holding no repositories.
+    """
+    if depth < 0:
+        raise ValueError(f"depth must not be negative, got {depth}")
+
+    # The root being a repository is unambiguous: visit it and nothing
+    # else, so `--multi-repo` inside a checkout does something sensible
+    # rather than nothing.
+    if is_repository(root):
+        logger.debug(f"{root} is itself a repository")
+        return [root]
+
+    # Listed strictly, and the result reused: a root that cannot be read
+    # raises rather than yielding the same empty list as a root with
+    # nothing in it. Listing it a second time through the tolerant
+    # ``_children`` would reopen exactly that ambiguity if the root
+    # became unreadable in between.
+    found: list[Path] = []
+    _visit(_list_subdirectories(root), depth, found, {}, set())
+    found.sort()
+
+    logger.debug(f"Found {len(found)} repositories under {root}")
+    return found
+
+
+def _descend(
+    directory: Path,
+    remaining: int,
+    found: list[Path],
+    explored: dict[Path, int],
+    reported: set[Path],
+) -> None:
+    """Collect repositories below a directory, depth-first.
+
+    Args:
+        directory: Directory to search.
+        remaining: Levels still permitted below this one.
+        found: Accumulator, appended to in place.
+        explored: Largest budget each identity has been searched with,
+            updated in place.
+        reported: Identities already recorded in ``found``, updated in
+            place.
+    """
+    if remaining <= 0:
+        return
+    _visit(_children(directory), remaining, found, explored, reported)
+
+
+def _visit(
+    children: Iterable[Path],
+    remaining: int,
+    found: list[Path],
+    explored: dict[Path, int],
+    reported: set[Path],
+) -> None:
+    """Examine one directory's children.
+
+    Split from :func:`_descend` so the root can be traversed from a
+    listing obtained strictly, rather than being listed a second time by
+    the tolerant path.
+
+    Directory identity is tracked by resolved path, because both the
+    directory test and the ``.git`` probe follow symbolic links. Without
+    it, a container holding a checkout *and* a link to it yields the same
+    repository twice -- and a sweep would scan, and under remediation
+    rewrite, one working tree once per name it goes by -- while a link
+    pointing back into the tree being searched recurses until the depth
+    runs out.
+
+    Identity alone is not enough, though. A directory first reached
+    through a deep symbolic link arrives with little budget left, and
+    marking it visited would then hide it from a later, shallower route
+    that could still afford to explore it. So the *budget* each identity
+    was explored with is recorded, and a larger one supersedes it.
+    Budgets strictly decrease and an identity is re-entered only with a
+    strictly larger one, so this terminates.
+
+    Repositories are reported once per identity, by the first path that
+    reaches them, so the output still names what the caller asked about.
+
+    Args:
+        children: Subdirectories to examine, in order.
+        remaining: Levels still permitted at this depth.
+        found: Accumulator, appended to in place.
+        explored: Largest budget each identity has been searched with,
+            updated in place.
+        reported: Identities already recorded in ``found``, updated in
+            place.
+    """
+    if remaining <= 0:
+        return
+
+    for child in children:
+        identity = _identity(child)
+
+        # Test for a repository before consulting the skip list, so a
+        # checkout whose name happens to collide with a build directory
+        # is still visited. The skip list exists to avoid walking large
+        # trees, not to disqualify a repository.
+        if is_repository(child):
+            if identity in reported:
+                logger.debug(f"Skipping {child}: already found as {identity}")
+                continue
+            reported.add(identity)
+            found.append(child)
+            # Do not descend into a repository: its worktrees and
+            # submodules belong to it, and visiting them separately
+            # would report the same findings several times over.
+            continue
+        if child.name in _SKIP_DIRECTORIES:
+            continue
+
+        budget = remaining - 1
+        if explored.get(identity, -1) >= budget:
+            continue
+        explored[identity] = budget
+        _descend(child, budget, found, explored, reported)
+
+
+def _identity(path: Path) -> Path:
+    """Reduce a path to something two names for one directory share.
+
+    Args:
+        path: Path to identify.
+
+    Returns:
+        The resolved path, or the original when it cannot be resolved.
+    """
+    try:
+        return path.resolve()
+    except OSError:
+        # A path that cannot be resolved is its own identity; it will
+        # fail the repository test anyway.
+        return path
+
+
+def _children(directory: Path) -> Iterable[Path]:
+    """List a directory's subdirectories, tolerating an unreadable one.
+
+    Sorted, so traversal order does not depend on the filesystem. That
+    matters beyond tidiness: which of several names for one directory is
+    reported depends on which is reached first.
+
+    Args:
+        directory: Directory to list.
+
+    Returns:
+        Its subdirectories in name order, or nothing when it cannot be
+        read.
+    """
+    try:
+        return _list_subdirectories(directory)
+    except OSError as error:
+        logger.warning(f"Cannot read {directory}: {error}")
+        return []
+
+
+def _list_subdirectories(directory: Path) -> list[Path]:
+    """List a directory's subdirectories, or raise.
+
+    The strict counterpart of :func:`_children`, used where an
+    unreadable directory must not pass for an empty one.
+
+    Args:
+        directory: Directory to list.
+
+    Returns:
+        Its subdirectories in name order.
+
+    Raises:
+        OSError: If the directory cannot be read.
+    """
+    return sorted(child for child in directory.iterdir() if child.is_dir())

--- a/src/gha_workflow_linter/validator.py
+++ b/src/gha_workflow_linter/validator.py
@@ -100,10 +100,20 @@ class ActionCallValidator:
         self._cache = (
             cache if cache is not None else ValidationCache(config.cache)
         )
+        # Refreshed on context entry; see ``_own_cache_hits``.
+        self._cache_hits_at_start = self._cache.stats.hits
         self._validation_method: ValidationMethod | None = None
 
     async def __aenter__(self) -> ActionCallValidator:
         """Async context manager entry."""
+        # The cache's hit counter is cumulative, and a multi-repository
+        # sweep shares one cache across every repository. Taking the
+        # baseline here rather than at construction means each context
+        # reports the hits *it* caused: a validator entered twice does
+        # not count the first pass again, and hits made through the
+        # shared cache before this one began are not claimed.
+        self._cache_hits_at_start = self._cache.stats.hits
+
         # Determine validation method
         self._validation_method = self._determine_validation_method()
 
@@ -137,8 +147,10 @@ class ActionCallValidator:
                 git_stats.repositories_validated
             )
 
-        # Merge cache stats into API stats
-        self.api_stats.cache_hits += self._cache.stats.hits
+        # Merge cache stats into API stats. Counted as a delta, since a
+        # shared cache carries the hits of every repository visited
+        # before this one. This is the only place the tally is merged.
+        self.api_stats.cache_hits += self._own_cache_hits
         self._cache.save()
 
     async def validate_action_calls_async(
@@ -704,28 +716,52 @@ class ActionCallValidator:
             )
         return all_repo_results, all_ref_results, all_subpath_results
 
+    @property
+    def _own_cache_hits(self) -> int:
+        """Cache hits this validator is responsible for.
+
+        The cache's counter is cumulative and a multi-repository sweep
+        shares one cache, so the raw value credits this validator with
+        every hit since the sweep began. The baseline is taken on
+        context entry, so each pass reports only its own.
+
+        Returns:
+            Hits recorded since this validator's context was entered.
+        """
+        return self._cache.stats.hits - self._cache_hits_at_start
+
     def _log_final_statistics(self, use_github_api: bool) -> None:
-        """Emit end-of-run API/Git statistics at debug level."""
+        """Emit end-of-run API/Git statistics at debug level.
+
+        Reads the cache tally rather than merging it. The merge belongs
+        to ``__aexit__``, and performing it here as well counted every
+        hit twice on the Git path.
+
+        Args:
+            use_github_api: Whether the GitHub API backend was used.
+        """
+        # What __aexit__ will add, shown here so the debug line agrees
+        # with the final statistics without altering them.
+        cache_hits = self.api_stats.cache_hits + self._own_cache_hits
+
         if use_github_api and self._github_client:
             rate_limit_info = self._github_client.get_rate_limit_info()
             self.logger.debug(
                 f"API Statistics: {self.api_stats.total_calls} total calls "
                 f"(GraphQL: {self.api_stats.graphql_calls}, "
                 f"REST: {self.api_stats.rest_calls}, "
-                f"Cache hits: {self.api_stats.cache_hits})"
+                f"Cache hits: {cache_hits})"
             )
             self.logger.debug(
                 f"GitHub Rate Limit: {rate_limit_info.remaining}/{rate_limit_info.limit} remaining"
             )
         else:
-            # Merge cache statistics before printing
-            self.api_stats.cache_hits += self._cache.stats.hits
             self.logger.debug(
                 f"Git Statistics: {self.api_stats.total_calls} total calls "
                 f"(Git: {self.api_stats.git_calls}, "
                 f"Clone ops: {self.api_stats.git_clone_operations}, "
                 f"ls-remote ops: {self.api_stats.git_ls_remote_operations}, "
-                f"Cache hits: {self.api_stats.cache_hits})"
+                f"Cache hits: {cache_hits})"
             )
 
         if self.api_stats.rate_limit_delays > 0:

--- a/tests/test_allow_list_check.py
+++ b/tests/test_allow_list_check.py
@@ -497,6 +497,147 @@ class TestCachedTargetDirection:
         assert classify_pins([pin], hosts, verify=False) == []
 
 
+class TestPolicyScopedCaching:
+    """Only a default-policy run may share the persistent cache.
+
+    ``ValidationCache`` stores ``(tag, sha)`` and records no policy, so
+    one entry means different things to runs configured differently.
+    :class:`TestCachedTargetDirection` covers the cooldown hazard through
+    its user-visible consequence; this class pins the guard itself --
+    which policies may touch the cache at all -- and the prerelease
+    hazard, which is about *which releases are candidates* rather than
+    about direction.
+    """
+
+    @pytest.mark.parametrize(
+        ("cooldown_days", "allow_prerelease", "usable"),
+        [
+            (0, False, True),
+            (7, False, False),
+            (0, True, False),
+            (7, True, False),
+        ],
+    )
+    def test_only_the_default_policy_is_cacheable(
+        self,
+        tmp_path: Path,
+        cooldown_days: int,
+        allow_prerelease: bool,
+        usable: bool,
+    ) -> None:
+        """A stored answer must mean the same to every reader."""
+        config = Config(
+            cooldown_days=cooldown_days,
+            allow_prerelease=allow_prerelease,
+            cache=CacheConfig(enabled=False, cache_dir=tmp_path),
+        )
+        resolver = AllowListResolver(config, ValidationCache(config.cache))
+
+        assert resolver.cache_usable is usable
+
+    @pytest.mark.asyncio
+    async def test_a_prerelease_run_ignores_a_cached_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An entry chosen under another policy could hide a prerelease.
+
+        The seeded v0.1.1 stands in for any target a differently
+        configured run left behind. Consuming it would report the
+        correctly-pinned v0.12.2 as stale, since a restored record
+        carries no commit map.
+        """
+        config = Config(
+            allow_prerelease=True,
+            cache=CacheConfig(enabled=True, cache_dir=tmp_path),
+        )
+        cache = ValidationCache(config.cache)
+        cache.put_latest_version(HOST_REPO, STALE_TAG, STALE_SHA)
+        resolver = AllowListResolver(config, cache)
+        resolved: list[list[str]] = []
+
+        async def fake_uncached(
+            repo_keys: list[str],
+        ) -> dict[str, LatestRelease | None]:
+            """Answer with the current target, carrying its commit map.
+
+            Args:
+                repo_keys: Keys the resolver could not answer locally.
+
+            Returns:
+                The unconstrained target for every key.
+            """
+            resolved.append(repo_keys)
+            return dict.fromkeys(repo_keys, CURRENT_TARGET)
+
+        monkeypatch.setattr(resolver, "_resolve_uncached", fake_uncached)
+        hosts = await resolver.resolve([HOST_REPO])
+
+        pin = make_pin(ref=CURRENT_SHA, version_comment=CURRENT_TAG)
+        assert resolved == [[HOST_REPO]]
+        assert classify_pins([pin], hosts, verify=False) == []
+
+    @pytest.mark.asyncio
+    async def test_a_prerelease_run_does_not_cache_its_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A later default run must not read back a prerelease."""
+        config = Config(
+            allow_prerelease=True,
+            cache=CacheConfig(enabled=True, cache_dir=tmp_path),
+        )
+        cache = ValidationCache(config.cache)
+        resolver = AllowListResolver(config, cache)
+
+        async def fake_uncached(
+            repo_keys: list[str],
+        ) -> dict[str, LatestRelease | None]:
+            """Answer every key without reaching a backend.
+
+            Args:
+                repo_keys: Keys the resolver could not answer locally.
+
+            Returns:
+                The unconstrained target for every key.
+            """
+            return dict.fromkeys(repo_keys, CURRENT_TARGET)
+
+        monkeypatch.setattr(resolver, "_resolve_uncached", fake_uncached)
+        hosts = await resolver.resolve([HOST_REPO])
+
+        assert hosts == {HOST_REPO: CURRENT_TARGET}
+        assert cache.get_latest_version(HOST_REPO) is None
+
+    @pytest.mark.asyncio
+    async def test_a_default_policy_run_caches_its_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard: the bypass must stay policy-scoped."""
+        config = Config(
+            cache=CacheConfig(enabled=True, cache_dir=tmp_path),
+        )
+        cache = ValidationCache(config.cache)
+        resolver = AllowListResolver(config, cache)
+
+        async def fake_uncached(
+            repo_keys: list[str],
+        ) -> dict[str, LatestRelease | None]:
+            """Answer every key without reaching a backend.
+
+            Args:
+                repo_keys: Keys the resolver could not answer locally.
+
+            Returns:
+                The unconstrained target for every key.
+            """
+            return dict.fromkeys(repo_keys, CURRENT_TARGET)
+
+        monkeypatch.setattr(resolver, "_resolve_uncached", fake_uncached)
+        hosts = await resolver.resolve([HOST_REPO])
+
+        assert hosts == {HOST_REPO: CURRENT_TARGET}
+        assert cache.get_latest_version(HOST_REPO) == (CURRENT_TAG, CURRENT_SHA)
+
+
 class TestOutOfScopeKinds:
     """``INVALID_SPEC`` and ``UNRESOLVABLE`` are never manufactured."""
 
@@ -934,6 +1075,40 @@ class TestWorkflowOrgPrecedence:
         self._git_repo(tmp_path, {"upstream": "git@github.com:up-org/r.git"})
 
         assert resolve_workflow_org(tmp_path) == "env-org"
+
+    def test_environment_is_ignored_when_not_trusted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sweep resolves each checkout from its own remotes.
+
+        ``GITHUB_REPOSITORY_OWNER`` names the repository a workflow was
+        launched for. That is right for a single run, but in a
+        multi-repository sweep it answers identically for every
+        checkout, resolving them all against one organisation's
+        ``.github`` repository.
+        """
+        monkeypatch.setenv(ORG_ENV_VAR, "env-org")
+        self._git_repo(
+            tmp_path, {"upstream": "https://github.com/up-org/r.git"}
+        )
+
+        assert resolve_workflow_org(tmp_path, use_environment=False) == "up-org"
+
+    def test_configured_still_wins_when_not_trusted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit --allow-list-org outranks both sources."""
+        monkeypatch.setenv(ORG_ENV_VAR, "env-org")
+        self._git_repo(
+            tmp_path, {"upstream": "https://github.com/up-org/r.git"}
+        )
+
+        assert (
+            resolve_workflow_org(
+                tmp_path, configured="asked-for", use_environment=False
+            )
+            == "asked-for"
+        )
 
     def test_upstream_beats_origin(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_auto_fix.py
+++ b/tests/test_auto_fix.py
@@ -1867,10 +1867,12 @@ jobs:
         # Scanner handles syntax errors gracefully, skips invalid files
         # So we get exit code 0 if no valid workflows found
         assert result.exit_code == 0
-        # Should report scanning issues (as WARNING), not validation errors
+        # Should report scanning issues (as WARNING), not validation errors.
+        # Diagnostics go to standard error, keeping standard output
+        # reserved for results.
         assert (
-            "Invalid YAML" in result.stdout
-            or "parsing" in result.stdout.lower()
+            "Invalid YAML" in result.stderr
+            or "parsing" in result.stderr.lower()
         )
 
     def test_auto_fix_exit_codes(self, temp_dir: Path) -> None:

--- a/tests/test_auto_fix_cli_flags.py
+++ b/tests/test_auto_fix_cli_flags.py
@@ -186,11 +186,12 @@ jobs:
             ],
         )
 
-        # Should fail due to invalid configuration
+        # Should fail due to invalid configuration. Diagnostics go to
+        # standard error, keeping standard output reserved for results.
         assert result.exit_code != 0
         assert (
-            "Configuration validation failed" in result.stdout
-            or "validation" in result.stdout.lower()
+            "Configuration validation failed" in result.stderr
+            or "validation" in result.stderr.lower()
         )
 
     def test_default_config_generation_includes_auto_fix_settings(

--- a/tests/test_auto_fix_write_failure.py
+++ b/tests/test_auto_fix_write_failure.py
@@ -248,6 +248,66 @@ class TestPerFileWriteFailure:
         assert bad not in applied, "a failed rewrite was reported as applied"
 
     @pytest.mark.asyncio
+    async def test_the_failure_is_recorded_on_the_fixer(
+        self, config: Config, tmp_path: Path
+    ) -> None:
+        """A failed rewrite must leave a trace the caller can read.
+
+        It appears in no other tally: the planned change is absent from
+        the applied fixes, and under ``--update-actions`` the call was
+        never recorded as stale either, so a run that failed to write
+        would otherwise look like a run with nothing to do.
+
+        Args:
+            config: Auto-fixer configuration.
+            tmp_path: Directory holding the workflows.
+        """
+        bad = write_workflow(tmp_path, "bad.yaml")
+        good = write_workflow(tmp_path, "good.yaml")
+        call = action_call()
+        errors = [validation_error(bad, call), validation_error(good, call)]
+        all_calls = {bad: {USES_LINE: call}, good: {USES_LINE: call}}
+
+        with (
+            stubbed_resolution(),
+            patch(
+                "gha_workflow_linter.auto_fix.replace_lines",
+                failing_writer(bad),
+            ),
+        ):
+            async with AutoFixer(config, base_path=tmp_path) as fixer:
+                await fixer.fix_validation_errors(
+                    errors, all_calls, check_for_updates=False
+                )
+                failures = list(fixer.write_failures)
+
+        assert failures == [bad]
+
+    @pytest.mark.asyncio
+    async def test_a_clean_run_records_no_failure(
+        self, config: Config, tmp_path: Path
+    ) -> None:
+        """The guard against reporting a failure for every rewrite.
+
+        Args:
+            config: Auto-fixer configuration.
+            tmp_path: Directory holding the workflows.
+        """
+        good = write_workflow(tmp_path, "good.yaml")
+        call = action_call()
+
+        with stubbed_resolution():
+            async with AutoFixer(config, base_path=tmp_path) as fixer:
+                await fixer.fix_validation_errors(
+                    [validation_error(good, call)],
+                    {good: {USES_LINE: call}},
+                    check_for_updates=False,
+                )
+                failures = list(fixer.write_failures)
+
+        assert failures == []
+
+    @pytest.mark.asyncio
     async def test_surviving_file_is_written_to_disk(
         self, config: Config, tmp_path: Path
     ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,7 +249,9 @@ class TestCLICommands:
             )
 
         assert result.exit_code == 1
-        assert "Configuration error" in result.stdout
+        # Diagnostics go to standard error, keeping standard output
+        # reserved for results.
+        assert "Configuration error" in result.stderr
 
     def test_lint_purge_cache(self) -> None:
         """Test that lint command does NOT have --purge-cache flag (it was removed)."""
@@ -284,7 +286,9 @@ class TestCLICommands:
             result = self.runner.invoke(app, ["lint", tmpdir])
 
         assert result.exit_code == 1
-        assert "Error scanning workflows" in result.stdout
+        # Diagnostics go to standard error, keeping standard output
+        # reserved for results.
+        assert "Error scanning workflows" in result.stderr
 
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.WorkflowScanner")
@@ -411,7 +415,9 @@ class TestCLICommands:
 
         # Should fail with validation error
         assert result.exit_code == 1
-        assert "Output format must be one of: text, json" in result.stdout
+        # Diagnostics go to standard error, keeping standard output
+        # reserved for results.
+        assert "Output format must be one of: text, json" in result.stderr
 
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.WorkflowScanner")

--- a/tests/test_cli_comprehensive.py
+++ b/tests/test_cli_comprehensive.py
@@ -1055,7 +1055,9 @@ class TestCLIIntegration:
             result = self.runner.invoke(app, ["lint", temp_dir])
 
             assert result.exit_code == 1
-            assert "Fatal error" in result.stdout
+            # Diagnostics go to standard error, keeping standard output
+            # reserved for results.
+            assert "Fatal error" in result.stderr
 
     @patch("gha_workflow_linter.cli.ConfigManager")
     @patch("gha_workflow_linter.cli.run_linter")

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -7,13 +7,17 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 import logging
-from typing import TYPE_CHECKING, Any
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
 
 from gha_workflow_linter import cli
 from gha_workflow_linter.auto_fix import (
     AutoFixer,
 )
-from gha_workflow_linter.models import Config
+from gha_workflow_linter.cache import ValidationCache
+from gha_workflow_linter.models import CacheConfig, Config, ValidationMethod
 from gha_workflow_linter.version_utils import (
     _parse_iso_datetime,
     _select_version_with_cooldown,
@@ -22,7 +26,17 @@ from gha_workflow_linter.version_utils import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from gha_workflow_linter.github_api import GitHubGraphQLClient
+
 NOW = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+REPO_KEY = "actions/checkout"
+# The version a previous run left in the persistent cache.
+CACHED_TAG = "v4"
+CACHED_SHA = "a" * 40
+# The version this run resolves from a (stubbed) backend.
+FRESH_TAG = "v5"
+FRESH_SHA = "b" * 40
 
 
 def _days_ago(days: int) -> datetime:
@@ -33,16 +47,131 @@ def _iso_days_ago(days: int) -> str:
     return _days_ago(days).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _make_fixer(cooldown_days: int) -> AutoFixer:
+def _make_fixer(
+    cooldown_days: int, *, allow_prerelease: bool = False
+) -> AutoFixer:
     """Build an AutoFixer without running its heavyweight ``__init__``.
 
     The cooldown selection helpers only rely on ``config`` and ``logger``,
     so we bypass the cache priming and network client setup.
+
+    Args:
+        cooldown_days: Cooldown window to apply, in days.
+        allow_prerelease: Whether prereleases are eligible candidates.
+
+    Returns:
+        A fixer carrying nothing but the release policy under test.
     """
     fixer = AutoFixer.__new__(AutoFixer)
-    fixer.config = Config(cooldown_days=cooldown_days)
+    fixer.config = Config(
+        cooldown_days=cooldown_days, allow_prerelease=allow_prerelease
+    )
     fixer.logger = logging.getLogger("test.cooldown")
     return fixer
+
+
+def _make_batch_fixer(
+    cooldown_days: int,
+    cache_dir: Path,
+    *,
+    allow_prerelease: bool = False,
+    graphql: bool = False,
+) -> tuple[AutoFixer, ValidationCache]:
+    """Build a fully initialised AutoFixer over a throwaway disk cache.
+
+    Args:
+        cooldown_days: Cooldown window to apply, in days.
+        cache_dir: Directory backing the persistent ``ValidationCache``.
+        allow_prerelease: Whether prereleases are eligible candidates.
+        graphql: Whether to arm the batched GraphQL path. The client is a
+            bare sentinel purely to satisfy the ``self._graphql_client``
+            gate; the batch call itself is always stubbed, so no test
+            reaches the network.
+
+    Returns:
+        The fixer and the cache it was handed, so tests can inspect what
+        the run persisted.
+    """
+    config = Config(
+        cooldown_days=cooldown_days,
+        allow_prerelease=allow_prerelease,
+        validation_method=ValidationMethod.GITHUB_API,
+        cache=CacheConfig(enabled=True, cache_dir=cache_dir),
+    )
+    cache = ValidationCache(config.cache)
+    fixer = AutoFixer(config, base_path=cache_dir, cache=cache)
+    if graphql:
+        fixer._graphql_client = cast("GitHubGraphQLClient", object())
+    return fixer, cache
+
+
+def _stub_single_lookup(
+    fixer: AutoFixer,
+    monkeypatch: pytest.MonkeyPatch,
+    result: tuple[str, str] | None,
+) -> list[str]:
+    """Replace the per-repository backend lookup with a canned answer.
+
+    Args:
+        fixer: Fixer whose lookup should be stubbed.
+        monkeypatch: Fixture used to patch the bound method.
+        result: The ``(tag, sha)`` pair to answer with, or ``None``.
+
+    Returns:
+        A list, appended to in call order, of every repository the fixer
+        could not answer from a cache and therefore queued for
+        resolution.
+    """
+    fetched: list[str] = []
+
+    async def fake_single(repo_key: str) -> tuple[str, str] | None:
+        """Answer one repository without touching the network.
+
+        Args:
+            repo_key: Repository queued for resolution.
+
+        Returns:
+            The canned pair supplied by the caller.
+        """
+        fetched.append(repo_key)
+        return result
+
+    monkeypatch.setattr(fixer, "_get_latest_version_single", fake_single)
+    return fetched
+
+
+def _stub_graphql_lookup(
+    fixer: AutoFixer,
+    monkeypatch: pytest.MonkeyPatch,
+    results: dict[str, tuple[str, str]],
+) -> list[list[str]]:
+    """Replace the batched GraphQL lookup with a canned answer.
+
+    Args:
+        fixer: Fixer whose batch lookup should be stubbed.
+        monkeypatch: Fixture used to patch the bound method.
+        results: The ``repo_key -> (tag, sha)`` mapping to answer with.
+
+    Returns:
+        A list, appended to in call order, of every batch the fixer could
+        not answer from a cache and therefore queued for resolution.
+    """
+    batches: list[list[str]] = []
+
+    async def fake_batch(repo_keys: list[str]) -> dict[str, tuple[str, str]]:
+        """Answer a whole batch without touching the network.
+
+        Args:
+            repo_keys: Repositories queued for resolution.
+
+        Returns:
+            The canned mapping supplied by the caller.
+        """
+        batches.append(repo_keys)
+        return results
+
+    monkeypatch.setattr(fixer, "_get_latest_versions_graphql_batch", fake_batch)
+    return batches
 
 
 class TestParseIsoDatetime:
@@ -272,3 +401,200 @@ class TestResolveCooldownDays:
         )
         assert result == 7
         assert printed == []
+
+
+class TestPersistentCacheUnderReleasePolicy:
+    """A non-default release policy must not share persisted versions.
+
+    ``ValidationCache`` keys latest versions on the repository alone and
+    records no policy, so an answer written by one run could be read back
+    by a run whose policy would have chosen differently. Two settings
+    make up that policy: a **cooldown** shifts the answer to an older
+    release, and **prerelease eligibility** changes which releases are
+    candidates at all. The fixer therefore bypasses the persistent cache
+    entirely unless both are at their defaults, mirroring
+    ``AllowListResolver.cache_usable``.
+
+    The session cache is deliberately left alone: it lives on one
+    ``AutoFixer``, which serves exactly one repository and therefore one
+    policy.
+    """
+
+    @pytest.mark.parametrize(
+        ("cooldown_days", "allow_prerelease", "usable"),
+        [
+            pytest.param(0, False, True, id="default-policy"),
+            pytest.param(7, False, False, id="cooldown"),
+            pytest.param(0, True, False, id="prerelease"),
+            pytest.param(7, True, False, id="cooldown-and-prerelease"),
+        ],
+    )
+    def test_only_the_default_policy_is_cacheable(
+        self, cooldown_days: int, allow_prerelease: bool, usable: bool
+    ) -> None:
+        """Only a default-policy entry means the same to every reader."""
+        fixer = _make_fixer(cooldown_days, allow_prerelease=allow_prerelease)
+
+        assert fixer._persistent_cache_usable is usable
+
+    @pytest.mark.asyncio
+    async def test_a_cooldown_run_ignores_a_persisted_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The persisted v4 is passed over and the repository re-resolved."""
+        fixer, cache = _make_batch_fixer(7, tmp_path)
+        cache.put_latest_version(REPO_KEY, CACHED_TAG, CACHED_SHA)
+        fetched = _stub_single_lookup(
+            fixer, monkeypatch, (FRESH_TAG, FRESH_SHA)
+        )
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert fetched == [REPO_KEY]
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+
+    @pytest.mark.asyncio
+    async def test_a_cooldown_run_does_not_persist_a_resolved_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A version resolved per-repository stays out of the cache."""
+        fixer, cache = _make_batch_fixer(7, tmp_path)
+        _stub_single_lookup(fixer, monkeypatch, (FRESH_TAG, FRESH_SHA))
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        assert cache.get_latest_version(REPO_KEY) is None
+
+    @pytest.mark.asyncio
+    async def test_a_cooldown_run_does_not_persist_a_batched_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The GraphQL path suppresses its write for the same reason."""
+        fixer, cache = _make_batch_fixer(7, tmp_path, graphql=True)
+        batches = _stub_graphql_lookup(
+            fixer, monkeypatch, {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        )
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert batches == [[REPO_KEY]]
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        assert cache.get_latest_version(REPO_KEY) is None
+
+    @pytest.mark.asyncio
+    async def test_a_cooldown_run_still_uses_the_session_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the *persistent* cache crosses release policies.
+
+        One ``AutoFixer`` serves one repository and therefore one
+        cooldown, so a session entry cannot have been produced under a
+        different policy. Guarding it too would cost a lookup per
+        repository for no safety gain.
+        """
+        fixer, _ = _make_batch_fixer(7, tmp_path)
+        fixer._latest_versions_cache[REPO_KEY] = (
+            CACHED_TAG,
+            CACHED_SHA,
+            time.time(),
+        )
+        fetched = _stub_single_lookup(
+            fixer, monkeypatch, (FRESH_TAG, FRESH_SHA)
+        )
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert fetched == []
+        assert results == {REPO_KEY: (CACHED_TAG, CACHED_SHA)}
+
+    @pytest.mark.asyncio
+    async def test_a_prerelease_run_ignores_a_persisted_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stable-only entry could hide a newer prerelease."""
+        fixer, cache = _make_batch_fixer(0, tmp_path, allow_prerelease=True)
+        cache.put_latest_version(REPO_KEY, CACHED_TAG, CACHED_SHA)
+        fetched = _stub_single_lookup(
+            fixer, monkeypatch, (FRESH_TAG, FRESH_SHA)
+        )
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert fetched == [REPO_KEY]
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+
+    @pytest.mark.asyncio
+    async def test_a_prerelease_run_does_not_persist_a_resolved_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A default run must not later consume a cached prerelease."""
+        fixer, cache = _make_batch_fixer(0, tmp_path, allow_prerelease=True)
+        _stub_single_lookup(fixer, monkeypatch, (FRESH_TAG, FRESH_SHA))
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        assert cache.get_latest_version(REPO_KEY) is None
+
+    @pytest.mark.asyncio
+    async def test_a_prerelease_run_does_not_persist_a_batched_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The GraphQL path suppresses its write for the same reason."""
+        fixer, cache = _make_batch_fixer(
+            0, tmp_path, allow_prerelease=True, graphql=True
+        )
+        batches = _stub_graphql_lookup(
+            fixer, monkeypatch, {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        )
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert batches == [[REPO_KEY]]
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        assert cache.get_latest_version(REPO_KEY) is None
+
+    @pytest.mark.asyncio
+    async def test_a_default_policy_run_reads_a_persisted_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard: the fix must not disable caching outright."""
+        fixer, cache = _make_batch_fixer(0, tmp_path)
+        cache.put_latest_version(REPO_KEY, CACHED_TAG, CACHED_SHA)
+        fetched = _stub_single_lookup(
+            fixer, monkeypatch, (FRESH_TAG, FRESH_SHA)
+        )
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert fetched == []
+        assert results == {REPO_KEY: (CACHED_TAG, CACHED_SHA)}
+
+    @pytest.mark.asyncio
+    async def test_a_default_policy_run_persists_a_resolved_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard for the per-repository write site."""
+        fixer, cache = _make_batch_fixer(0, tmp_path)
+        _stub_single_lookup(fixer, monkeypatch, (FRESH_TAG, FRESH_SHA))
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        assert cache.get_latest_version(REPO_KEY) == (FRESH_TAG, FRESH_SHA)
+
+    @pytest.mark.asyncio
+    async def test_a_default_policy_run_persists_a_batched_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard for the GraphQL write site."""
+        fixer, cache = _make_batch_fixer(0, tmp_path, graphql=True)
+        _stub_graphql_lookup(
+            fixer, monkeypatch, {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        )
+
+        results = await fixer._get_latest_versions_batch([REPO_KEY])
+
+        assert results == {REPO_KEY: (FRESH_TAG, FRESH_SHA)}
+        assert cache.get_latest_version(REPO_KEY) == (FRESH_TAG, FRESH_SHA)

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -78,6 +78,89 @@ class TestFindDependabotConfig:
         assert find_dependabot_config(tmp_path) == yml
 
 
+class TestRepositoryBoundary:
+    """A cooldown is the scanned repository's own release policy.
+
+    The search walks upwards, which is right within a checkout but wrong
+    past its root: a sweep container carrying a Dependabot file would
+    otherwise impose its cooldown on every repository beneath it, and a
+    lone checkout would answer differently depending on where it was
+    cloned.
+    """
+
+    @staticmethod
+    def _make_repository(path: Path) -> Path:
+        """Create a directory that looks like a checkout.
+
+        Args:
+            path: Directory to create; parents are created as needed.
+
+        Returns:
+            The same path, now carrying a ``.git`` directory.
+        """
+        (path / ".git").mkdir(parents=True)
+        return path
+
+    def test_a_checkout_does_not_inherit_its_containers_cooldown(
+        self, tmp_path: Path
+    ) -> None:
+        """The container's policy stops at the repository boundary.
+
+        Args:
+            tmp_path: Container directory, carrying a Dependabot file.
+        """
+        _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        repository = self._make_repository(tmp_path / "checkout")
+
+        assert find_dependabot_config(repository) is None
+
+    def test_a_checkouts_own_configuration_is_still_found(
+        self, tmp_path: Path
+    ) -> None:
+        """The boundary is checked after the directory's own file.
+
+        Args:
+            tmp_path: Container directory, carrying a Dependabot file.
+        """
+        _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        repository = self._make_repository(tmp_path / "checkout")
+        own = _write_dependabot(repository, GITHUB_ACTIONS_CONFIG)
+
+        assert find_dependabot_config(repository) == own
+
+    def test_a_subdirectory_still_reaches_the_repository_root(
+        self, tmp_path: Path
+    ) -> None:
+        """Walking up within a checkout is the behaviour being kept.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        repository = self._make_repository(tmp_path / "checkout")
+        own = _write_dependabot(repository, GITHUB_ACTIONS_CONFIG)
+        nested = repository / "a" / "b"
+        nested.mkdir(parents=True)
+
+        assert find_dependabot_config(nested) == own
+
+    def test_a_worktree_marker_file_is_also_a_boundary(
+        self, tmp_path: Path
+    ) -> None:
+        """Worktrees and submodules mark their root with a ``.git`` file.
+
+        Args:
+            tmp_path: Container directory, carrying a Dependabot file.
+        """
+        _write_dependabot(tmp_path, GITHUB_ACTIONS_CONFIG)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        (worktree / ".git").write_text(
+            "gitdir: ../.git/worktrees/wt\n", encoding="utf-8"
+        )
+
+        assert find_dependabot_config(worktree) is None
+
+
 class TestResolveCooldown:
     """Tests for resolving the cooldown value from configuration."""
 

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -247,11 +247,15 @@ def _validation(
 def _autofix(
     fixed_files: dict[Path, list[dict[str, str]]] | None = None,
     stale: dict[str, list[dict[str, Any]]] | None = None,
+    write_failures: list[Path] | None = None,
+    stage_error: str | None = None,
 ) -> _AutoFixOutcome:
     return _AutoFixOutcome(
         fixed_files or {},
         {"actions_moved": 0, "calls_updated": 0},
         stale or {},
+        write_failures or [],
+        stage_error,
     )
 
 
@@ -437,6 +441,99 @@ class TestPresentationDoesNotAffectExitCode:
         assert code == exit_codes.SUCCESS
 
 
+class TestWriteFailureExitCode:
+    """A rewrite the caller asked for that could not be written.
+
+    Such a failure appears in no other tally: the planned change is
+    absent from the applied fixes, and under ``--update-actions`` the
+    call was never recorded as stale either. Reporting success would
+    tell the caller the work was done.
+    """
+
+    def test_a_failed_rewrite_fails_the_run(self) -> None:
+        """Nothing else in the outcome would reveal it."""
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(write_failures=[Path(".github/workflows/ci.yaml")]),
+        )
+
+        assert code == exit_codes.DEFECTS_FOUND
+
+    def test_a_run_that_wrote_everything_still_succeeds(self) -> None:
+        """The guard against failing every run that rewrites nothing."""
+        assert (
+            _exit_code(_options(), _validation(), _autofix())
+            == exit_codes.SUCCESS
+        )
+
+    def test_presentation_does_not_change_it(self) -> None:
+        """Exit codes stay independent of how results are shown."""
+        codes = {
+            _exit_code(
+                _options(**presentation),
+                _validation(),
+                _autofix(write_failures=[Path("a.yaml")]),
+            )
+            for presentation in (
+                {},
+                {"quiet": True},
+                {"output_format": "json", "quiet": True},
+            )
+        }
+
+        assert codes == {exit_codes.DEFECTS_FOUND}
+
+
+class TestAutoFixStageFailureExitCode:
+    """A stage that failed outright leaves nothing else behind.
+
+    Auto-fix runs by default, so a stage failure alone stays advisory:
+    a developer who cannot reach the network must still be able to
+    commit, exactly as the allow-list check degrades. Asking for
+    ``--update-actions`` is asking for work to be done, so silently
+    doing none of it is a different matter.
+    """
+
+    def test_an_update_run_fails_when_the_stage_did(self) -> None:
+        """The requested updating never happened."""
+        config = Config()
+        config.update_actions = True
+
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(stage_error="boom"),
+            config=config,
+        )
+
+        assert code == exit_codes.DEFECTS_FOUND
+
+    def test_an_ordinary_run_stays_advisory(self) -> None:
+        """The guard against failing every offline run.
+
+        ``auto_fix`` defaults to true, so failing here would stop a
+        developer committing whenever the network was unavailable.
+        """
+        code = _exit_code(
+            _options(),
+            _validation(),
+            _autofix(stage_error="boom"),
+        )
+
+        assert code == exit_codes.SUCCESS
+
+    def test_an_update_run_that_worked_still_succeeds(self) -> None:
+        """The guard against failing every update run."""
+        config = Config()
+        config.update_actions = True
+
+        assert (
+            _exit_code(_options(), _validation(), _autofix(), config=config)
+            == exit_codes.SUCCESS
+        )
+
+
 def _allow_list_outcome(
     *, unsuppressed: int = 0, unresolved: bool = False
 ) -> AllowListOutcome:
@@ -582,12 +679,13 @@ class TestAllowListStageFailure:
 
     @staticmethod
     def _stage(
-        *, verify: bool, quiet: bool = True
+        *, verify: bool, quiet: bool = True, update: bool = False
     ) -> tuple[AllowListOutcome | None, Config]:
         from gha_workflow_linter.cli import _run_allow_list_stage
 
         config = Config()
         config.allow_list.verify = verify
+        config.allow_list.update = update
         cache = ValidationCache(config.cache)
         options = _options(quiet=quiet, path=Path("/nonexistent-path-xyz"))
 
@@ -620,6 +718,29 @@ class TestAllowListStageFailure:
             _options(), _validation(), _autofix(), outcome, config
         )
         assert code == exit_codes.SUCCESS
+
+    def test_a_requested_update_reports_its_failure(self) -> None:
+        """Asking for an update and getting none must not read as clean.
+
+        Advisory mode skips a broken check, which is right when nothing
+        was asked for. But ``--update-allow-list`` asks for work to be
+        done, and returning ``None`` leaves no applied-fix count and no
+        failure -- so the repository is labelled clean and the run
+        exits zero, possibly after earlier files were already rewritten.
+        """
+        outcome, _ = self._stage(verify=False, update=True)
+
+        assert outcome is not None
+        assert outcome.unresolved
+
+    def test_a_requested_update_exits_unresolved(self) -> None:
+        """The failure has to reach the exit code, not just the outcome."""
+        outcome, config = self._stage(verify=False, update=True)
+        code = _exit_code(
+            _options(), _validation(), _autofix(), outcome, config
+        )
+
+        assert code == exit_codes.ALLOW_LIST_UNRESOLVED
 
 
 class TestShowSuppressedIsConfigDriven:

--- a/tests/test_multi_repo.py
+++ b/tests/test_multi_repo.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for repository discovery in multi-repository mode.
+
+Discovery decides which trees a sweep visits, so every one of its rules
+is a behaviour a user can observe: a directory of checkouts is expanded,
+a checkout is not expanded into its own worktrees, and the visit order
+is the same on every machine. Those rules are cheap to state and easy to
+break silently -- a stray descent into ``.worktrees/`` reports the same
+findings several times over, and an unsorted result makes a sweep's
+output differ run to run -- so they are pinned here rather than left to
+the integration tests.
+
+Repositories are built by creating a ``.git`` entry directly rather than
+by shelling out to ``git``. Discovery only ever asks whether that entry
+exists, so a real clone would buy nothing and cost the suite a
+subprocess and a dependency on the host's git.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from gha_workflow_linter import multi_repo
+from gha_workflow_linter.multi_repo import (
+    DEFAULT_DEPTH,
+    find_repositories,
+    is_repository,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def make_clone(path: Path) -> Path:
+    """Create a directory that looks like a plain clone.
+
+    Args:
+        path: Directory to create; parents are created as needed.
+
+    Returns:
+        The same path, now carrying a ``.git`` directory.
+    """
+    (path / ".git").mkdir(parents=True)
+    return path
+
+
+def make_worktree(
+    path: Path, *, points_at: str = "../.git/worktrees/x"
+) -> Path:
+    """Create a directory that looks like a worktree or submodule.
+
+    Git marks these with a ``.git`` *file* holding a ``gitdir:`` pointer
+    rather than a directory, which is exactly the case a naive
+    ``is_dir()`` check would miss.
+
+    Args:
+        path: Directory to create; parents are created as needed.
+        points_at: Value written after the ``gitdir:`` prefix.
+
+    Returns:
+        The same path, now carrying a ``.git`` file.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".git").write_text(f"gitdir: {points_at}\n", encoding="utf-8")
+    return path
+
+
+class TestIsRepository:
+    """What counts as a repository root."""
+
+    def test_clone_is_a_repository(self, tmp_path: Path) -> None:
+        """A ``.git`` directory marks a plain clone."""
+        assert is_repository(make_clone(tmp_path / "clone")) is True
+
+    def test_worktree_file_is_a_repository(self, tmp_path: Path) -> None:
+        """A ``.git`` file marks a worktree or submodule."""
+        assert is_repository(make_worktree(tmp_path / "worktree")) is True
+
+    def test_plain_directory_is_not_a_repository(self, tmp_path: Path) -> None:
+        """A directory with no ``.git`` entry is not a repository."""
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        assert is_repository(plain) is False
+
+    def test_missing_directory_is_not_a_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """A path that does not exist is not a repository."""
+        assert is_repository(tmp_path / "absent") is False
+
+    def test_unreadable_directory_is_not_a_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """A directory we cannot stat is reported as 'not a repository'.
+
+        Raising here would abort a sweep because one checkout in twenty
+        had awkward permissions, so the error is swallowed instead.
+        """
+        with mock.patch.object(
+            Path, "exists", side_effect=PermissionError("denied")
+        ):
+            assert is_repository(tmp_path) is False
+
+
+class TestFindRepositoriesRoot:
+    """How the root directory itself is treated."""
+
+    def test_root_that_is_a_repository_yields_only_itself(
+        self, tmp_path: Path
+    ) -> None:
+        """``--multi-repo`` inside a checkout visits that checkout.
+
+        The child repository is deliberately *not* visited: the root
+        being a repository is unambiguous, and expanding it as a
+        container as well would scan the same tree twice.
+        """
+        root = make_clone(tmp_path / "checkout")
+        make_clone(root / "vendored")
+
+        assert find_repositories(root) == [root]
+
+    def test_root_that_is_a_repository_ignores_depth(
+        self, tmp_path: Path
+    ) -> None:
+        """The root shortcut applies whatever depth was requested."""
+        root = make_clone(tmp_path / "checkout")
+        make_clone(root / "nested")
+
+        assert find_repositories(root, depth=0) == [root]
+        assert find_repositories(root, depth=5) == [root]
+
+    def test_empty_container_finds_nothing(self, tmp_path: Path) -> None:
+        """A container with no repositories yields an empty list."""
+        assert find_repositories(tmp_path) == []
+
+
+class TestFindRepositoriesDepth:
+    """How far below the root the search reaches."""
+
+    def test_default_depth_is_one_level(self, tmp_path: Path) -> None:
+        """The default matches a flat directory of checkouts."""
+        assert DEFAULT_DEPTH == 1
+
+        repository = make_clone(tmp_path / "one")
+
+        assert find_repositories(tmp_path) == [repository]
+
+    @pytest.mark.parametrize(
+        ("depth", "expected_count"),
+        [(0, 0), (1, 0), (2, 3), (3, 3)],
+    )
+    def test_grouped_repositories_need_two_levels(
+        self, tmp_path: Path, depth: int, expected_count: int
+    ) -> None:
+        """Repositories nested one group deep appear only at depth 2.
+
+        A layout of ``group-a/one``, ``group-a/two`` and ``group-b/three``
+        is invisible at the default depth, which is the observable
+        consequence of ``--repo-depth`` existing at all.
+
+        Args:
+            tmp_path: Container directory.
+            depth: Depth passed to discovery.
+            expected_count: Repositories that depth should reach.
+        """
+        make_clone(tmp_path / "group-a" / "one")
+        make_clone(tmp_path / "group-a" / "two")
+        make_clone(tmp_path / "group-b" / "three")
+
+        found = find_repositories(tmp_path, depth=depth)
+
+        assert len(found) == expected_count
+
+    def test_depth_zero_considers_only_the_root(self, tmp_path: Path) -> None:
+        """Depth 0 never looks at children."""
+        make_clone(tmp_path / "one")
+
+        assert find_repositories(tmp_path, depth=0) == []
+
+    def test_negative_depth_is_rejected(self, tmp_path: Path) -> None:
+        """A negative depth is a caller error, not an empty result."""
+        with pytest.raises(ValueError, match="must not be negative"):
+            find_repositories(tmp_path, depth=-1)
+
+
+class TestFindRepositoriesTraversal:
+    """Which directories the search walks into, and which it skips."""
+
+    def test_does_not_descend_into_a_repository(self, tmp_path: Path) -> None:
+        """A checkout's worktrees belong to it, not to the sweep.
+
+        Keeping worktrees under ``.worktrees/`` is a common layout. If
+        discovery descended into the checkout it would report the same
+        findings once per worktree.
+        """
+        checkout = make_clone(tmp_path / "checkout")
+        make_worktree(checkout / ".worktrees" / "feature")
+
+        assert find_repositories(tmp_path, depth=4) == [checkout]
+
+    def test_worktree_container_is_expanded(self, tmp_path: Path) -> None:
+        """A directory of worktrees is as valid a target as clones."""
+        first = make_worktree(tmp_path / "feature-a")
+        second = make_worktree(tmp_path / "feature-b")
+
+        assert find_repositories(tmp_path) == [first, second]
+
+    def test_mixed_clones_and_worktrees(self, tmp_path: Path) -> None:
+        """Clones and worktrees are discovered side by side."""
+        clone = make_clone(tmp_path / "clone")
+        worktree = make_worktree(tmp_path / "worktree")
+
+        assert find_repositories(tmp_path) == [clone, worktree]
+
+    @pytest.mark.parametrize(
+        "skipped",
+        ["node_modules", ".venv", "venv", "__pycache__", ".tox"],
+    )
+    def test_skipped_directories_are_not_searched(
+        self, tmp_path: Path, skipped: str
+    ) -> None:
+        """Vendored trees cannot hide a repository worth visiting.
+
+        Args:
+            tmp_path: Container directory.
+            skipped: Directory name discovery must not walk into.
+        """
+        make_clone(tmp_path / skipped / "buried")
+        wanted = make_clone(tmp_path / "wanted")
+
+        assert find_repositories(tmp_path, depth=3) == [wanted]
+
+    @pytest.mark.parametrize(
+        "name",
+        ["node_modules", ".venv", "venv", "__pycache__", ".tox"],
+    )
+    def test_a_checkout_named_like_a_skipped_directory_is_found(
+        self, tmp_path: Path, name: str
+    ) -> None:
+        """The skip list suppresses descent, not recognition.
+
+        A repository whose name collides with a vendored-tree name is
+        still a repository, and omitting it would silently drop it from
+        a sweep. The names exist to avoid walking large trees, so they
+        are consulted only once the child has been ruled out as a
+        checkout in its own right.
+
+        Args:
+            tmp_path: Container directory.
+            name: Repository name colliding with the skip list.
+        """
+        repository = make_clone(tmp_path / name)
+
+        assert find_repositories(tmp_path) == [repository]
+
+    def test_a_checkout_named_like_a_skipped_directory_is_not_entered(
+        self, tmp_path: Path
+    ) -> None:
+        """Recognising such a checkout must not also mean descending it.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        repository = make_clone(tmp_path / "venv")
+        make_clone(tmp_path / "venv" / "nested")
+
+        assert find_repositories(tmp_path, depth=3) == [repository]
+
+    def test_files_are_not_mistaken_for_repositories(
+        self, tmp_path: Path
+    ) -> None:
+        """A regular file beside the repositories is ignored."""
+        (tmp_path / "README.md").write_text("notes\n", encoding="utf-8")
+        repository = make_clone(tmp_path / "one")
+
+        assert find_repositories(tmp_path) == [repository]
+
+    def test_results_are_sorted(self, tmp_path: Path) -> None:
+        """Visit order is the same whatever order the filesystem lists.
+
+        Creation order here is deliberately not alphabetical, so a
+        result that merely echoed ``iterdir()`` would fail on at least
+        some filesystems.
+        """
+        make_clone(tmp_path / "zeta")
+        make_clone(tmp_path / "alpha")
+        make_clone(tmp_path / "middle")
+
+        found = find_repositories(tmp_path)
+
+        assert [path.name for path in found] == ["alpha", "middle", "zeta"]
+        assert found == sorted(found)
+
+    def test_a_symlink_to_a_checkout_is_not_a_second_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """One working tree is visited once, whatever it is called.
+
+        Both the directory test and the ``.git`` probe follow symbolic
+        links, so a container holding a checkout and a link to it would
+        otherwise report the same repository twice -- and a sweep under
+        ``--update-allow-list`` would rewrite one working tree once per
+        name it goes by.
+
+        Which name is reported is not asserted: it is whichever the
+        traversal reaches first, and both denote the same tree.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        repository = make_clone(tmp_path / "real")
+        (tmp_path / "link").symlink_to(repository, target_is_directory=True)
+
+        found = find_repositories(tmp_path)
+
+        assert len(found) == 1
+        assert found[0].resolve() == repository.resolve()
+
+    def test_a_symlink_back_into_the_tree_does_not_duplicate(
+        self, tmp_path: Path
+    ) -> None:
+        """A link pointing at an ancestor cannot re-report its contents.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        repository = make_clone(tmp_path / "group" / "real")
+        (tmp_path / "loop").symlink_to(tmp_path, target_is_directory=True)
+
+        assert find_repositories(tmp_path, depth=4) == [repository]
+
+    def test_a_shallow_symlink_does_not_hide_a_deeper_route(
+        self, tmp_path: Path
+    ) -> None:
+        """Identity alone would lose repositories within the depth.
+
+        ``deep/link`` reaches ``group`` with only one level of budget
+        left, too little to see the repository two levels below it.
+        Recording the identity as merely "visited" would then hide
+        ``group`` from the direct route, which still has the budget to
+        find it. The budget explored with is recorded instead, so a
+        larger one supersedes a smaller.
+
+        Traversal is in name order, so ``deep`` is reached before
+        ``group`` and the shallow route genuinely comes first.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        repository = make_clone(tmp_path / "group" / "nested" / "real")
+        (tmp_path / "deep").mkdir()
+        (tmp_path / "deep" / "link").symlink_to(
+            tmp_path / "group", target_is_directory=True
+        )
+
+        assert find_repositories(tmp_path, depth=3) == [repository]
+
+    def test_distinct_repositories_are_all_reported(
+        self, tmp_path: Path
+    ) -> None:
+        """Deduplication must not collapse genuinely separate checkouts.
+
+        This is the guard against identifying repositories too coarsely.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        first = make_clone(tmp_path / "one")
+        second = make_clone(tmp_path / "two")
+
+        assert find_repositories(tmp_path) == [first, second]
+
+    def test_unreadable_directory_is_logged_and_skipped(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """One unreadable directory must not cost the others their scan.
+
+        Args:
+            tmp_path: Container directory.
+            monkeypatch: Used to make one directory raise on listing.
+            caplog: Captures the warning discovery emits.
+        """
+        blocked = tmp_path / "blocked"
+        blocked.mkdir()
+        wanted = make_clone(tmp_path / "wanted")
+
+        real_iterdir = Path.iterdir
+
+        def guarded_iterdir(self: Path) -> Iterator[Path]:
+            if self == blocked:
+                raise PermissionError("Permission denied")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", guarded_iterdir)
+
+        with caplog.at_level(logging.WARNING, logger=multi_repo.__name__):
+            found = find_repositories(tmp_path, depth=2)
+
+        assert found == [wanted]
+        assert "Cannot read" in caplog.text
+        assert "blocked" in caplog.text
+
+    def test_an_unreadable_root_is_raised_rather_than_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing examined must not read as nothing found.
+
+        Skipping an unreadable *descendant* is right: the rest of the
+        sweep is still worth doing. Skipping an unreadable *root* would
+        return the same empty list as a container holding no
+        repositories, and the sweep would report success having looked
+        at nothing at all.
+
+        Args:
+            tmp_path: The root, made unreadable.
+            monkeypatch: Used to make the root raise on listing.
+        """
+        real_iterdir = Path.iterdir
+
+        def guarded_iterdir(self: Path) -> Iterator[Path]:
+            """Refuse to list the root.
+
+            Args:
+                self: Directory being listed.
+
+            Returns:
+                Its entries, for any directory but the root.
+
+            Raises:
+                PermissionError: When the root is listed.
+            """
+            if self == tmp_path:
+                raise PermissionError("Permission denied")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", guarded_iterdir)
+
+        with pytest.raises(PermissionError):
+            find_repositories(tmp_path)
+
+    def test_an_empty_root_is_still_simply_empty(self, tmp_path: Path) -> None:
+        """The guard against turning every empty container into an error.
+
+        Args:
+            tmp_path: An empty, readable container.
+        """
+        assert find_repositories(tmp_path) == []
+
+    def test_the_root_is_listed_exactly_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The strict listing is reused, not thrown away.
+
+        Listing the root strictly and then again through the tolerant
+        path would reopen the ambiguity the strict listing exists to
+        close: were the root to become unreadable between the two, the
+        second listing would swallow the failure and discovery would
+        return an empty list after all.
+
+        Args:
+            tmp_path: Container directory.
+            monkeypatch: Counts listings of the root.
+        """
+        make_clone(tmp_path / "one")
+        listings = 0
+        real_iterdir = Path.iterdir
+
+        def counting_iterdir(self: Path) -> Iterator[Path]:
+            """Count listings of the root, then defer to the real one.
+
+            Args:
+                self: Directory being listed.
+
+            Returns:
+                Its entries.
+            """
+            nonlocal listings
+            if self == tmp_path:
+                listings += 1
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", counting_iterdir)
+
+        find_repositories(tmp_path)
+
+        assert listings == 1

--- a/tests/test_multi_repo_cli.py
+++ b/tests/test_multi_repo_cli.py
@@ -1,0 +1,1723 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the multi-repository sweep driver in the CLI.
+
+A sweep is orchestration: the work of scanning a repository is already
+covered elsewhere, and what remains to be shown is that the driver hands
+each repository the right things and survives one of them failing. So
+``_run_one_repository`` is replaced with a recorder here -- patched in
+``gha_workflow_linter.cli``, which is both where it is defined and where
+it is looked up -- and the assertions are about what the driver passed,
+in what order, and what it did with the answers.
+
+Three claims carry the feature and are each pinned by name below:
+
+* every discovered repository is visited, sequentially and in sorted
+  order, with its own path;
+* one :class:`~gha_workflow_linter.cache.ValidationCache` is shared
+  across the sweep, so twenty repositories pinning the same host cost
+  one latest-release resolution rather than twenty -- the efficiency
+  argument for building the mode into the tool at all;
+* a repository that raises is recorded and the sweep continues, except
+  for :class:`ConfigurationError`, which applies to every repository and
+  so is re-raised.
+
+Nothing here touches the network, and every cache is written under
+``tmp_path`` rather than the user's cache directory.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from gha_workflow_linter import cli, exit_codes
+from gha_workflow_linter.allow_list_check import (
+    AllowListFinding,
+    AllowListOutcome,
+)
+from gha_workflow_linter.allow_list_scanner import (
+    AllowListPin,
+    CommentPosition,
+    QuoteStyle,
+)
+from gha_workflow_linter.allow_list_spec import resolve_spec
+from gha_workflow_linter.cache import ValidationCache
+from gha_workflow_linter.cli import (
+    RunOutcome,
+    _display_multi_repo_summary,
+    _preprocess_args_for_default_command,
+    _run_multi_repo,
+    _run_repository_in_sweep,
+    _sweep_status,
+    app,
+)
+from gha_workflow_linter.exceptions import ConfigurationError
+from gha_workflow_linter.models import (
+    AllowListFindingKind,
+    CacheConfig,
+    CLIOptions,
+    Config,
+    Severity,
+)
+from tests.conftest import strip_ansi
+
+#: Host repository a pin would name. Any allow-list host would do; what
+#: matters is that every repository in the sweep asks about the same one.
+HOST_REPOSITORY = "lfreleng-actions/.github"
+
+
+def make_repository(path: Path) -> Path:
+    """Create a directory discovery will recognise as a repository.
+
+    Args:
+        path: Directory to create; parents are created as needed.
+
+    Returns:
+        The same path, now carrying a ``.git`` directory.
+    """
+    (path / ".git").mkdir(parents=True)
+    return path
+
+
+def make_container(root: Path, *names: str) -> list[Path]:
+    """Create a container directory holding several repositories.
+
+    Args:
+        root: Directory to create the repositories under.
+        *names: Repository directory names, in creation order.
+
+    Returns:
+        The created repository paths, in creation order.
+    """
+    return [make_repository(root / name) for name in names]
+
+
+def make_config(tmp_path: Path) -> Config:
+    """Build a template configuration with a throwaway cache.
+
+    Args:
+        tmp_path: Test-scoped directory to hold the cache file.
+
+    Returns:
+        A configuration safe to use without touching the user's cache.
+    """
+    return Config(cache=CacheConfig(cache_dir=tmp_path / "cache"))
+
+
+def make_options(container: Path, *, quiet: bool = True) -> CLIOptions:
+    """Build the CLI options a sweep is driven with.
+
+    Args:
+        container: Path the sweep treats as a container of repositories.
+        quiet: Whether to suppress the sweep's console output.
+
+    Returns:
+        Options with multi-repository mode enabled.
+    """
+    return CLIOptions(path=container, multi_repo=True, quiet=quiet)
+
+
+def write_dependabot_cooldown(repository: Path, days: int) -> None:
+    """Give a repository its own Dependabot cooldown policy.
+
+    Args:
+        repository: Repository root to write the configuration into.
+        days: Value for ``cooldown.default-days``.
+    """
+    github = repository / ".github"
+    github.mkdir(exist_ok=True)
+    (github / "dependabot.yml").write_text(
+        "version: 2\n"
+        "updates:\n"
+        "  - package-ecosystem: github-actions\n"
+        "    directory: /\n"
+        "    cooldown:\n"
+        f"      default-days: {days}\n",
+        encoding="utf-8",
+    )
+
+
+def make_stale_finding(line: int) -> AllowListFinding:
+    """Build one unsuppressed, stale allow-list finding.
+
+    Only the fields the summary consults carry meaning here; the rest
+    exist because the dataclasses require them.
+
+    Args:
+        line: Line number the pin sits on. Findings are keyed by
+            ``(file, line)``, so distinct values keep them distinct.
+
+    Returns:
+        A finding that counts towards ``outstanding``.
+    """
+    pin = AllowListPin(
+        file_path=Path(".github/workflows/ci.yaml"),
+        line_number=line,
+        column=0,
+        key_path=("jobs", "b", "steps", "0", "with", "config"),
+        raw_line="        config: '@18d9c444'  # v0.1.1",
+        raw_value="@18d9c4446bea555d0783e850f6d295f844fe8f67",
+        quote_style=QuoteStyle.SINGLE,
+        comment_position=CommentPosition.YAML,
+        version_comment="v0.1.1",
+        directives=frozenset(),
+        suppressed_by=None,
+        suppression_reason=None,
+        spec=resolve_spec(
+            "@18d9c4446bea555d0783e850f6d295f844fe8f67",
+            workflow_org="lfreleng-actions",
+        ),
+        auto_fixable=True,
+    )
+    return AllowListFinding(
+        pin=pin,
+        kind=AllowListFindingKind.STALE,
+        severity=Severity.WARNING,
+        message="stale",
+        current_sha="18d9c4446bea555d0783e850f6d295f844fe8f67",
+        target_sha="bf6642f68d58c1b81bbe993e676d6cc339ac3654",
+        target_version="v0.12.2",
+        suppressed=False,
+    )
+
+
+def make_allow_list_outcome(
+    *, outstanding: int = 0, unresolved: bool = False, fixed: int = 0
+) -> AllowListOutcome:
+    """Build an allow-list outcome with the given shape.
+
+    Args:
+        outstanding: How many unsuppressed findings to leave unfixed.
+        unresolved: Whether a host failed to resolve.
+        fixed: How many further findings to include and mark as
+            rewritten, so partial remediation can be described.
+
+    Returns:
+        An outcome the summary can be asked to describe.
+    """
+    findings = [make_stale_finding(n + 1) for n in range(outstanding + fixed)]
+    # Remediation is recorded by line, and the fixed ones are taken from
+    # the tail so the outstanding count is the leading slice.
+    fixed_lines = frozenset(
+        (str(finding.pin.file_path), finding.pin.line_number)
+        for finding in findings[outstanding:]
+    )
+    return AllowListOutcome(
+        findings=findings,
+        hosts={},
+        unresolved={HOST_REPOSITORY: "no releases"} if unresolved else {},
+        suppressed_count=0,
+        checked=True,
+        fixed_lines=fixed_lines,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class Visit:
+    """One call the driver made into a repository's run.
+
+    Attributes:
+        config: Configuration that call received.
+        options: CLI options that call received.
+        cache: Validation cache that call received.
+        collect_json: Whether the driver asked for the JSON payload to be
+            collected rather than printed.
+    """
+
+    config: Config
+    options: CLIOptions
+    cache: ValidationCache
+    collect_json: bool = False
+
+
+class RecordingRun:
+    """Stand-in for ``_run_one_repository`` that records its arguments.
+
+    Attributes:
+        visits: Every call made, in the order the driver made them.
+    """
+
+    def __init__(
+        self, outcomes: dict[str, int | Exception] | None = None
+    ) -> None:
+        """Record visits and answer with per-repository outcomes.
+
+        Args:
+            outcomes: Exit code (or exception to raise) keyed by
+                repository directory name. Repositories absent from the
+                mapping succeed.
+        """
+        self.visits: list[Visit] = []
+        self._outcomes: dict[str, int | Exception] = outcomes or {}
+
+    def __call__(
+        self,
+        config: Config,
+        options: CLIOptions,
+        shared_cache: ValidationCache,
+        *,
+        collect_json: bool = False,
+    ) -> RunOutcome:
+        """Record one visit and return its configured outcome.
+
+        Args:
+            config: Configuration the driver resolved for this
+                repository.
+            options: CLI options the driver resolved for this
+                repository.
+            shared_cache: Cache the driver passed in.
+            collect_json: Whether the driver asked for the payload to be
+                collected rather than printed.
+
+        Returns:
+            The outcome configured for this repository.
+
+        Raises:
+            Exception: Whatever was configured for this repository.
+        """
+        self.visits.append(
+            Visit(
+                config=config,
+                options=options,
+                cache=shared_cache,
+                collect_json=collect_json,
+            )
+        )
+        outcome = self._outcomes.get(options.path.name, exit_codes.SUCCESS)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return RunOutcome(exit_code=outcome)
+
+    @property
+    def visited(self) -> list[Path]:
+        """Paths the driver asked for, in visit order.
+
+        Returns:
+            The ``path`` of every visit, in order.
+        """
+        return [visit.options.path for visit in self.visits]
+
+
+class TestSweepVisits:
+    """Which repositories a sweep visits, and with what."""
+
+    def test_visits_every_repository_in_sorted_order(
+        self, tmp_path: Path
+    ) -> None:
+        """All discovered repositories are visited, sorted by path.
+
+        Creation order is deliberately not alphabetical, so a driver
+        that echoed the filesystem's order would fail here on at least
+        some filesystems.
+        """
+        make_container(tmp_path, "zeta", "alpha", "middle")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            exit_code = _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path)
+            )
+
+        assert [path.name for path in recorder.visited] == [
+            "alpha",
+            "middle",
+            "zeta",
+        ]
+        assert exit_code == exit_codes.SUCCESS
+
+    def test_each_visit_receives_its_own_repository_path(
+        self, tmp_path: Path
+    ) -> None:
+        """Each run is rooted at a repository, never at the container.
+
+        Scanning stops at repository boundaries, so a run left pointed
+        at the container would find nothing at all.
+        """
+        repositories = make_container(tmp_path, "one", "two")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        assert recorder.visited == sorted(repositories)
+        assert tmp_path not in recorder.visited
+
+    def test_no_repositories_found_is_a_notice_not_a_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An empty container succeeds and says why nothing happened.
+
+        Args:
+            tmp_path: Empty container directory.
+            capsys: Captures the notice.
+        """
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            exit_code = _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path, quiet=False)
+            )
+
+        assert exit_code == exit_codes.SUCCESS
+        assert recorder.visits == []
+        output = " ".join(strip_ansi(capsys.readouterr().out).split())
+        assert "No repositories found" in output
+
+    def test_invalid_depth_is_a_runtime_error(self, tmp_path: Path) -> None:
+        """A discovery failure ends the sweep rather than propagating."""
+        recorder = RecordingRun()
+
+        with (
+            mock.patch.object(cli, "_run_one_repository", recorder),
+            mock.patch.object(
+                cli,
+                "find_repositories",
+                side_effect=ValueError("depth must not be negative, got -1"),
+            ),
+        ):
+            exit_code = _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path)
+            )
+
+        assert exit_code == exit_codes.RUNTIME_ERROR
+        assert recorder.visits == []
+
+
+class TestSharedCache:
+    """The one piece of state a sweep deliberately shares."""
+
+    def test_same_cache_instance_reaches_every_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """One cache is built and handed to every repository."""
+        make_container(tmp_path, "one", "two", "three")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        assert len(recorder.visits) == 3
+        first = recorder.visits[0].cache
+        assert isinstance(first, ValidationCache)
+        assert all(visit.cache is first for visit in recorder.visits)
+
+    def test_host_is_resolved_once_for_the_whole_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        """Three repositories pinning one host cost one resolution.
+
+        This is the efficiency argument for the mode: the second and
+        third repositories find the host already cached and never look
+        it up. The recorder stands in for the allow-list resolver,
+        recording a resolution only on a cache miss.
+        """
+        make_container(tmp_path, "one", "two", "three")
+        resolutions: list[str] = []
+
+        def resolve_once(
+            _config: Config,
+            options: CLIOptions,
+            shared_cache: ValidationCache,
+            *,
+            collect_json: bool = False,  # noqa: ARG001 - matches the driver
+        ) -> RunOutcome:
+            """Resolve the host on a cache miss, as a real run would.
+
+            Args:
+                _config: Unused; the repository's configuration.
+                options: Supplies the repository being visited.
+                shared_cache: Cache consulted before resolving.
+                collect_json: Unused; accepted to match the driver.
+
+            Returns:
+                A successful outcome.
+            """
+            if shared_cache.get_latest_version(HOST_REPOSITORY) is None:
+                resolutions.append(options.path.name)
+                shared_cache.put_latest_version(
+                    HOST_REPOSITORY, "v1.0.0", "a" * 40
+                )
+            return RunOutcome(exit_code=exit_codes.SUCCESS)
+
+        with mock.patch.object(cli, "_run_one_repository", resolve_once):
+            _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        assert resolutions == ["one"]
+
+
+class TestPerRepositoryState:
+    """What a sweep deliberately does *not* share."""
+
+    def test_configuration_is_copied_per_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """No repository can see, or corrupt, another's configuration."""
+        make_container(tmp_path, "one", "two", "three")
+        template = make_config(tmp_path)
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(template, make_options(tmp_path))
+
+        configs = [visit.config for visit in recorder.visits]
+        assert all(config is not template for config in configs)
+        assert len({id(config) for config in configs}) == len(configs)
+
+    def test_cooldown_is_resolved_from_each_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """Two Dependabot policies stay attached to their repositories.
+
+        Without a per-repository copy the second repository would
+        inherit the first one's cooldown, and its action updates would
+        be held back (or released) by a policy it never declared.
+        """
+        repositories = make_container(tmp_path, "slow", "quick")
+        for repository, days in zip(repositories, (7, 3), strict=True):
+            write_dependabot_cooldown(repository, days)
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        cooldowns = {
+            visit.options.path.name: visit.config.cooldown_days
+            for visit in recorder.visits
+        }
+        assert cooldowns == {"quick": 3, "slow": 7}
+
+    def test_explicit_cooldown_flag_still_wins(self, tmp_path: Path) -> None:
+        """``--cooldown`` overrides every repository's Dependabot file."""
+        repository = make_repository(tmp_path / "one")
+        write_dependabot_cooldown(repository, 7)
+        options = CLIOptions(
+            path=tmp_path, multi_repo=True, quiet=True, cooldown=2
+        )
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), options)
+
+        assert recorder.visits[0].config.cooldown_days == 2
+
+
+class TestSweepFailures:
+    """What a failing repository costs the rest of the sweep."""
+
+    def test_failure_does_not_stop_later_repositories(
+        self, tmp_path: Path
+    ) -> None:
+        """One unreadable checkout must not cost the others their scan."""
+        make_container(tmp_path, "first", "second", "third")
+        recorder = RecordingRun({"second": RuntimeError("boom")})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            exit_code = _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path)
+            )
+
+        assert [path.name for path in recorder.visited] == [
+            "first",
+            "second",
+            "third",
+        ]
+        assert exit_code == exit_codes.RUNTIME_ERROR
+
+    def test_failure_is_recorded_on_the_outcome(self, tmp_path: Path) -> None:
+        """The failure is described, not merely counted."""
+        repository = make_repository(tmp_path / "one")
+        recorder = RecordingRun({"one": RuntimeError("boom")})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            outcome = _run_repository_in_sweep(
+                make_config(tmp_path),
+                make_options(tmp_path),
+                ValidationCache(make_config(tmp_path).cache),
+                repository,
+            )
+
+        assert outcome.error == "boom"
+        assert outcome.exit_code == exit_codes.RUNTIME_ERROR
+
+    def test_failure_is_reported_to_the_user(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A silently skipped repository would be worse than a failure.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures the sweep's output.
+        """
+        make_container(tmp_path, "one", "two")
+        recorder = RecordingRun({"one": RuntimeError("boom")})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path, quiet=False)
+            )
+
+        output = " ".join(strip_ansi(capsys.readouterr().out).split())
+        assert "failed: boom" in output
+        assert "could not be scanned" in output
+
+    def test_configuration_error_stops_the_sweep(self, tmp_path: Path) -> None:
+        """A bad setting applies everywhere, so continuing is pointless."""
+        make_container(tmp_path, "first", "second")
+        recorder = RecordingRun(
+            {"first": ConfigurationError("unparsable allow-list spec")}
+        )
+
+        with (
+            mock.patch.object(cli, "_run_one_repository", recorder),
+            pytest.raises(ConfigurationError, match="unparsable"),
+        ):
+            _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        assert [path.name for path in recorder.visited] == ["first"]
+
+
+class TestSweepExitCode:
+    """How per-repository results combine into one exit code."""
+
+    @pytest.mark.parametrize(
+        ("codes", "expected"),
+        [
+            pytest.param(
+                (exit_codes.SUCCESS, exit_codes.SUCCESS),
+                exit_codes.SUCCESS,
+                id="all-clean",
+            ),
+            pytest.param(
+                (exit_codes.SUCCESS, exit_codes.DEFECTS_FOUND),
+                exit_codes.DEFECTS_FOUND,
+                id="defects-beat-success",
+            ),
+            pytest.param(
+                (exit_codes.ALLOW_LIST_STALE, exit_codes.DEFECTS_FOUND),
+                exit_codes.ALLOW_LIST_STALE,
+                id="stale-beats-defects",
+            ),
+            pytest.param(
+                (exit_codes.ACTIONS_OUTDATED, exit_codes.DEFECTS_FOUND),
+                exit_codes.ACTIONS_OUTDATED,
+                id="outdated-beats-defects",
+            ),
+            pytest.param(
+                (exit_codes.ALLOW_LIST_STALE, exit_codes.ACTIONS_OUTDATED),
+                exit_codes.ALLOW_LIST_STALE,
+                id="stale-beats-outdated",
+            ),
+            pytest.param(
+                (exit_codes.ALLOW_LIST_STALE, exit_codes.ALLOW_LIST_UNRESOLVED),
+                exit_codes.ALLOW_LIST_UNRESOLVED,
+                id="unresolved-wins",
+            ),
+        ],
+    )
+    def test_codes_combine_by_precedence(
+        self, tmp_path: Path, codes: tuple[int, int], expected: int
+    ) -> None:
+        """The §8 precedence (4 > 3 > 5 > 1 > 0) holds across a sweep.
+
+        Args:
+            tmp_path: Container directory.
+            codes: Exit codes the two repositories return.
+            expected: The aggregate the sweep must report.
+        """
+        make_container(tmp_path, "one", "two")
+        first, second = codes
+        recorder = RecordingRun({"one": first, "two": second})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            exit_code = _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path)
+            )
+
+        assert exit_code == expected
+
+    def test_order_does_not_change_the_aggregate(self, tmp_path: Path) -> None:
+        """The worst result wins wherever in the sweep it occurred."""
+        make_container(tmp_path, "one", "two")
+        forwards = RecordingRun(
+            {"one": exit_codes.ALLOW_LIST_UNRESOLVED, "two": exit_codes.SUCCESS}
+        )
+        backwards = RecordingRun(
+            {"one": exit_codes.SUCCESS, "two": exit_codes.ALLOW_LIST_UNRESOLVED}
+        )
+
+        codes: list[int] = []
+        for recorder in (forwards, backwards):
+            with mock.patch.object(cli, "_run_one_repository", recorder):
+                codes.append(
+                    _run_multi_repo(
+                        make_config(tmp_path), make_options(tmp_path)
+                    )
+                )
+
+        assert codes == [
+            exit_codes.ALLOW_LIST_UNRESOLVED,
+            exit_codes.ALLOW_LIST_UNRESOLVED,
+        ]
+
+
+class TestSweepSummary:
+    """The table that closes a sweep."""
+
+    @pytest.mark.parametrize(
+        ("outcome", "expected"),
+        [
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.SUCCESS),
+                "[green]clean[/green]",
+                id="clean",
+            ),
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.DEFECTS_FOUND, files_changed=2),
+                "[yellow]updated[/yellow]",
+                id="updated",
+            ),
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.ALLOW_LIST_STALE),
+                "[yellow]findings[/yellow]",
+                id="findings",
+            ),
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.RUNTIME_ERROR, error="boom"),
+                "[red]failed[/red]",
+                id="failed",
+            ),
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.SUCCESS, error="boom"),
+                "[red]failed[/red]",
+                id="failure-outranks-a-clean-code",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.SUCCESS,
+                    allow_list=make_allow_list_outcome(outstanding=1),
+                ),
+                "[yellow]findings[/yellow]",
+                id="advisory-stale-is-not-clean",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.SUCCESS,
+                    allow_list=make_allow_list_outcome(unresolved=True),
+                ),
+                "[red]unresolved[/red]",
+                id="advisory-unresolved-is-not-clean",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.DEFECTS_FOUND,
+                    files_changed=1,
+                    allow_list=make_allow_list_outcome(unresolved=True),
+                ),
+                "[red]unresolved[/red]",
+                id="unresolved-outranks-work-carried-out",
+            ),
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.SUCCESS, defects=3),
+                "[yellow]findings[/yellow]",
+                id="defects-without-a-failing-code-are-not-clean",
+            ),
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.SUCCESS, outdated=2),
+                "[yellow]findings[/yellow]",
+                id="advisory-outdated-actions-are-not-clean",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.DEFECTS_FOUND, write_failures=1
+                ),
+                "[yellow]findings[/yellow]",
+                id="a-rewrite-that-failed-is-not-clean",
+            ),
+            pytest.param(
+                RunOutcome(exit_code=exit_codes.SUCCESS, autofix_error="boom"),
+                "[yellow]findings[/yellow]",
+                id="an-auto-fix-stage-that-failed-is-not-clean",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.DEFECTS_FOUND,
+                    files_changed=2,
+                    write_failures=1,
+                ),
+                "[yellow]findings[/yellow]",
+                id="a-partly-written-run-is-not-merely-updated",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.DEFECTS_FOUND,
+                    allow_list=make_allow_list_outcome(outstanding=1, fixed=1),
+                ),
+                "[yellow]findings[/yellow]",
+                id="partial-remediation-is-not-merely-updated",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.DEFECTS_FOUND,
+                    allow_list=make_allow_list_outcome(fixed=2),
+                ),
+                "[yellow]updated[/yellow]",
+                id="complete-remediation-is-updated",
+            ),
+            pytest.param(
+                RunOutcome(
+                    exit_code=exit_codes.DEFECTS_FOUND,
+                    files_changed=1,
+                    defects=2,
+                ),
+                "[yellow]findings[/yellow]",
+                id="fixed-files-beside-remaining-defects-are-findings",
+            ),
+        ],
+    )
+    def test_status_label(self, outcome: RunOutcome, expected: str) -> None:
+        """Each outcome shape gets its own label.
+
+        Args:
+            outcome: What one repository produced.
+            expected: The label the summary must show.
+        """
+        assert _sweep_status(outcome) == expected
+
+    def test_summary_lists_every_repository(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The closing table accounts for every repository visited.
+
+        Args:
+            tmp_path: Supplies repository paths.
+            capsys: Captures the table.
+        """
+        _display_multi_repo_summary(
+            [
+                (tmp_path / "alpha", RunOutcome(exit_code=exit_codes.SUCCESS)),
+                (
+                    tmp_path / "beta",
+                    RunOutcome(
+                        exit_code=exit_codes.RUNTIME_ERROR, error="boom"
+                    ),
+                ),
+            ],
+            tmp_path,
+        )
+
+        output = " ".join(strip_ansi(capsys.readouterr().out).split())
+        assert "alpha" in output
+        assert "beta" in output
+        assert "clean" in output
+        assert "failed" in output
+        assert "1 repository(s) could not be scanned" in output
+
+
+class TestMultiRepoCLI:
+    """The flags that reach the driver from the command line."""
+
+    def test_multi_repo_flag_is_honoured(self, tmp_path: Path) -> None:
+        """``--multi-repo`` treats PATH as a container, not a checkout.
+
+        An empty container is the one outcome that needs no scanning at
+        all, so it exercises the flag end to end without a network or a
+        cache.
+        """
+        result = CliRunner().invoke(
+            app,
+            [
+                "lint",
+                str(tmp_path),
+                "--multi-repo",
+                "--validation-method",
+                "git",
+            ],
+        )
+
+        output = " ".join(strip_ansi(result.stdout).split())
+        assert result.exit_code == exit_codes.SUCCESS
+        assert "No repositories found" in output
+        assert "at depth 1" in output
+
+    def test_short_flag_is_honoured(self, tmp_path: Path) -> None:
+        """``-M`` is the same flag."""
+        result = CliRunner().invoke(
+            app,
+            ["lint", str(tmp_path), "-M", "--validation-method", "git"],
+        )
+
+        assert result.exit_code == exit_codes.SUCCESS
+        assert "No repositories found" in " ".join(
+            strip_ansi(result.stdout).split()
+        )
+
+    def test_repo_depth_reaches_the_driver(self, tmp_path: Path) -> None:
+        """``--repo-depth`` changes how far discovery looks."""
+        result = CliRunner().invoke(
+            app,
+            [
+                "lint",
+                str(tmp_path),
+                "--multi-repo",
+                "--repo-depth",
+                "3",
+                "--validation-method",
+                "git",
+            ],
+        )
+
+        assert result.exit_code == exit_codes.SUCCESS
+        assert "at depth 3" in " ".join(strip_ansi(result.stdout).split())
+
+    def test_repo_depth_is_rejected_when_negative(self, tmp_path: Path) -> None:
+        """Typer rejects a negative depth before the sweep starts."""
+        result = CliRunner().invoke(
+            app,
+            ["lint", str(tmp_path), "--multi-repo", "--repo-depth", "-1"],
+        )
+
+        assert result.exit_code == exit_codes.CLI_USAGE_ERROR
+
+    def test_a_broken_container_dependabot_file_is_not_read(
+        self, tmp_path: Path
+    ) -> None:
+        """The container's own cooldown is never the sweep's business.
+
+        The command layer resolves a cooldown eagerly before dispatching.
+        In a sweep that value is discarded in favour of each checkout's
+        own, so reading the container's buys nothing -- and an unreadable
+        one would abort the command before any per-repository failure
+        boundary exists.
+
+        Args:
+            tmp_path: Container directory, carrying an unreadable
+                Dependabot configuration.
+        """
+        make_repository(tmp_path / "one")
+        github = tmp_path / ".github"
+        github.mkdir()
+        (github / "dependabot.yml").write_bytes(b"\xff\xfe not utf-8")
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "lint",
+                str(tmp_path),
+                "--multi-repo",
+                "--validation-method",
+                "git",
+                "--quiet",
+            ],
+        )
+
+        output = strip_ansi(result.stdout + (result.stderr or ""))
+        assert "UnicodeDecodeError" not in output
+        assert result.exit_code == exit_codes.SUCCESS
+
+    def test_files_is_refused_before_any_backend_preflight(
+        self, tmp_path: Path
+    ) -> None:
+        """The usage error must not depend on reaching the sweep.
+
+        Backend configuration runs first and makes network calls; when
+        rate-limited it exits successfully. An invalid invocation would
+        then retire as a success without the error ever being reported.
+        Asserting no backend was configured is what pins the ordering.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        make_repository(tmp_path / "one")
+        workflow = tmp_path / "one" / "ci.yaml"
+        workflow.write_text("name: t\n", encoding="utf-8")
+
+        with mock.patch.object(cli, "_configure_validation_backend") as backend:
+            result = CliRunner().invoke(
+                app,
+                [
+                    "lint",
+                    str(tmp_path),
+                    "--multi-repo",
+                    "--files",
+                    str(workflow),
+                ],
+            )
+
+        backend.assert_not_called()
+        assert result.exit_code == exit_codes.RUNTIME_ERROR
+        assert "--files cannot be combined with --multi-repo" in strip_ansi(
+            result.stdout + (result.stderr or "")
+        )
+
+    def test_a_single_run_still_resolves_its_cooldown(
+        self, tmp_path: Path
+    ) -> None:
+        """The guard against skipping the resolution for everyone.
+
+        Only a sweep discards the eagerly resolved value. A single run
+        depends on it, and nothing else in the suite covers the command
+        layer's wiring of it.
+
+        Args:
+            tmp_path: The repository being linted.
+        """
+        make_repository(tmp_path)
+        write_dependabot_cooldown(tmp_path, 5)
+        seen: list[int] = []
+
+        def capture(config: Config, _options: CLIOptions) -> int:
+            """Record the cooldown the command layer resolved.
+
+            Args:
+                config: Configuration the command built.
+                _options: Unused.
+
+            Returns:
+                A successful exit code.
+            """
+            seen.append(config.cooldown_days)
+            return exit_codes.SUCCESS
+
+        with mock.patch.object(cli, "run_linter", capture):
+            CliRunner().invoke(
+                app,
+                [
+                    "lint",
+                    str(tmp_path),
+                    "--validation-method",
+                    "git",
+                    "--quiet",
+                ],
+            )
+
+        assert seen == [5]
+
+    def test_a_sweep_defers_the_cooldown_to_each_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """The container's value never reaches the template config.
+
+        Args:
+            tmp_path: Container directory, carrying its own cooldown.
+        """
+        make_repository(tmp_path / "one")
+        write_dependabot_cooldown(tmp_path, 5)
+        seen: list[int] = []
+
+        def capture(config: Config, _options: CLIOptions) -> int:
+            """Record the cooldown the command layer resolved.
+
+            Args:
+                config: Configuration the command built.
+                _options: Unused.
+
+            Returns:
+                A successful exit code.
+            """
+            seen.append(config.cooldown_days)
+            return exit_codes.SUCCESS
+
+        with mock.patch.object(cli, "run_linter", capture):
+            CliRunner().invoke(
+                app,
+                [
+                    "lint",
+                    str(tmp_path),
+                    "--multi-repo",
+                    "--validation-method",
+                    "git",
+                    "--quiet",
+                ],
+            )
+
+        assert seen == [0]
+
+    def test_repo_depth_survives_the_bare_invocation(self) -> None:
+        """``--repo-depth`` consumes its value when ``lint`` is implied.
+
+        The preprocessor scans for the first positional token to decide
+        whether a subcommand was given. If ``--repo-depth`` were missing
+        from its set of value-taking options, a value that happens to
+        spell a subcommand would be mistaken for one and ``lint`` would
+        never be injected.
+        """
+        assert _preprocess_args_for_default_command(
+            ["--repo-depth", "2", "src/", "--multi-repo"]
+        ) == ["lint", "--repo-depth", "2", "src/", "--multi-repo"]
+        assert _preprocess_args_for_default_command(
+            ["--repo-depth", "lint", "src/"]
+        ) == ["lint", "--repo-depth", "lint", "src/"]
+
+
+class TestPerRepositoryOrgResolution:
+    """Which organisation each checkout resolves shorthand pins against.
+
+    ``GITHUB_REPOSITORY_OWNER`` names the repository a workflow was
+    launched for. Under Actions that is a sound answer for a single run
+    and a wrong one for every repository of a sweep bar one, so the
+    sweep clears it and each checkout falls back to its own remotes.
+    """
+
+    def test_the_environment_org_is_cleared_per_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """Every visit is told not to trust the environment.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        make_container(tmp_path, "one", "two")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        assert [
+            visit.config.allow_list.use_environment_org
+            for visit in recorder.visits
+        ] == [False, False]
+
+    def test_a_single_run_still_trusts_the_environment(self) -> None:
+        """The default is unchanged outside a sweep.
+
+        This is the guard against clearing the flag globally, which
+        would break the single-repository case the variable exists for.
+        """
+        assert Config().allow_list.use_environment_org is True
+
+    def test_the_root_repository_shortcut_keeps_the_environment(
+        self, tmp_path: Path
+    ) -> None:
+        """Pointing --multi-repo at a checkout is a single run.
+
+        The flag is documented as safe to leave in a wrapper script, so
+        it must not quietly cost that checkout the environment source.
+        Under Actions a checkout often has no useful remote, and
+        ``GITHUB_REPOSITORY_OWNER`` describes exactly this repository.
+
+        Args:
+            tmp_path: A directory that is itself a repository.
+        """
+        repository = make_repository(tmp_path / "solo")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), make_options(repository))
+
+        assert [visit.options.path for visit in recorder.visits] == [repository]
+        assert recorder.visits[0].config.allow_list.use_environment_org is True
+
+    def test_an_explicitly_disabled_environment_stays_disabled(
+        self, tmp_path: Path
+    ) -> None:
+        """The shortcut restores the configured value, not ``True``.
+
+        A configuration that turns the environment source off is
+        honoured by an ordinary single-repository run, so adding
+        ``--multi-repo`` in a wrapper script must not quietly turn it
+        back on.
+
+        Args:
+            tmp_path: A directory that is itself a repository.
+        """
+        repository = make_repository(tmp_path / "solo")
+        config = make_config(tmp_path)
+        config.allow_list.use_environment_org = False
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(config, make_options(repository))
+
+        assert recorder.visits[0].config.allow_list.use_environment_org is False
+
+
+class TestSweepRejectsIndividualFiles:
+    """``--files`` and ``--multi-repo`` ask for different things.
+
+    The scanner honours an absolute ``--files`` path whatever root it is
+    given, so a sweep would scan -- and under ``--update-allow-list``
+    rewrite -- the same file once per repository, attributing it to each
+    in turn. Refused rather than given an arbitrary meaning.
+    """
+
+    def test_the_combination_is_refused(self, tmp_path: Path) -> None:
+        """A sweep with named files stops before visiting anything.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        make_container(tmp_path, "one")
+        options = make_options(tmp_path).model_copy(
+            update={"files": ["/tmp/elsewhere/.github/workflows/ci.yaml"]}
+        )
+        recorder = RecordingRun()
+
+        with (
+            mock.patch.object(cli, "_run_one_repository", recorder),
+            pytest.raises(ConfigurationError, match="--files"),
+        ):
+            _run_multi_repo(make_config(tmp_path), options)
+
+        assert recorder.visits == []
+
+    def test_a_sweep_without_files_still_runs(self, tmp_path: Path) -> None:
+        """The guard is specific to ``--files`` being supplied.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        make_container(tmp_path, "one")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            code = _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path)
+            )
+
+        assert code == exit_codes.SUCCESS
+        assert len(recorder.visits) == 1
+
+
+class TestSilentFailures:
+    """A failure with nothing to say is still a failure.
+
+    Every consumer of ``RunOutcome.error`` tests it for truth: the
+    summary's failure count, the ``failed`` label and the JSON
+    document's ``error`` field. An exception carrying no message would
+    otherwise be read as no failure at all, and the repository would be
+    reported as having mere findings.
+    """
+
+    def test_an_empty_message_still_records_a_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """The exception class stands in for the missing message.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        repository = make_repository(tmp_path / "one")
+        recorder = RecordingRun({"one": RuntimeError()})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            outcome = _run_repository_in_sweep(
+                make_config(tmp_path),
+                make_options(tmp_path),
+                ValidationCache(make_config(tmp_path).cache),
+                repository,
+                silent=True,
+            )
+
+        assert outcome.error == "RuntimeError"
+        assert _sweep_status(outcome) == "[red]failed[/red]"
+
+    def test_a_message_is_preferred_when_there_is_one(
+        self, tmp_path: Path
+    ) -> None:
+        """The fallback must not displace a real description.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        repository = make_repository(tmp_path / "one")
+        recorder = RecordingRun({"one": RuntimeError("disk went away")})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            outcome = _run_repository_in_sweep(
+                make_config(tmp_path),
+                make_options(tmp_path),
+                ValidationCache(make_config(tmp_path).cache),
+                repository,
+                silent=True,
+            )
+
+        assert outcome.error == "disk went away"
+
+    def test_a_broken_dependabot_file_costs_only_its_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """Preparation must sit inside the failure boundary.
+
+        Resolving the cooldown reads the repository's own
+        ``dependabot.yml``, and a file that is not valid UTF-8 raises
+        past the resolver's narrow handling. Outside the boundary that
+        would abort the sweep, contradicting the promise that one bad
+        checkout costs only itself.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        make_container(tmp_path, "broken", "healthy")
+        github = tmp_path / "broken" / ".github"
+        github.mkdir()
+        (github / "dependabot.yml").write_bytes(b"\xff\xfe not utf-8")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            code = _run_multi_repo(
+                make_config(tmp_path), make_options(tmp_path)
+            )
+
+        # The healthy repository was still visited, and the broken one
+        # was recorded rather than allowed to stop the sweep.
+        assert [visit.options.path.name for visit in recorder.visits] == [
+            "healthy"
+        ]
+        assert code == exit_codes.RUNTIME_ERROR
+
+    def test_the_reason_reaches_the_console_too(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The user sees the same description the outcome carries.
+
+        A fallback that reached only the outcome would leave the live
+        line reading ``failed:`` with nothing after it.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures the live failure line.
+        """
+        repository = make_repository(tmp_path / "one")
+        recorder = RecordingRun({"one": RuntimeError()})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_repository_in_sweep(
+                make_config(tmp_path),
+                make_options(tmp_path, quiet=False),
+                ValidationCache(make_config(tmp_path).cache),
+                repository,
+                silent=False,
+            )
+
+        output = " ".join(strip_ansi(capsys.readouterr().out).split())
+        assert "failed: RuntimeError" in output
+
+
+class TestSweepJsonOutput:
+    """``--multi-repo --format json`` must stay machine-readable.
+
+    Printing each repository's payload as it completed would put several
+    top-level objects on standard output, which no JSON parser accepts,
+    and the sweep's own commentary would sit among them. Every test here
+    drives the sweep with ``quiet=False``, so the only thing that can be
+    keeping standard output clean is the JSON mode itself.
+    """
+
+    @staticmethod
+    def json_options(container: Path) -> CLIOptions:
+        """Build options for a talkative sweep in JSON mode.
+
+        Args:
+            container: Path the sweep treats as a container.
+
+        Returns:
+            Options with JSON output and console commentary enabled.
+        """
+        return CLIOptions(
+            path=container,
+            multi_repo=True,
+            quiet=False,
+            output_format="json",
+        )
+
+    def test_sweep_emits_one_parseable_document(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Two repositories yield one document, not two.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures standard output.
+        """
+        make_container(tmp_path, "alpha", "beta")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), self.json_options(tmp_path))
+
+        document = json.loads(capsys.readouterr().out)
+        assert [entry["repository"] for entry in document["repositories"]] == [
+            "alpha",
+            "beta",
+        ]
+        assert document["summary"]["repositories"] == 2
+
+    def test_each_repository_payload_is_carried_through(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A repository's own results reach the aggregate document.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures standard output.
+        """
+        make_container(tmp_path, "alpha")
+
+        def with_payload(
+            _config: Config,
+            _options: CLIOptions,
+            _cache: ValidationCache,
+            *,
+            collect_json: bool = False,
+        ) -> RunOutcome:
+            """Answer with a payload, as a collecting run would.
+
+            Args:
+                _config: Unused.
+                _options: Unused.
+                _cache: Unused.
+                collect_json: Recorded on the payload, so the test can
+                    show the driver asked for collection.
+
+            Returns:
+                An outcome carrying a JSON payload.
+            """
+            return RunOutcome(
+                exit_code=exit_codes.SUCCESS,
+                json_payload={"collected": collect_json},
+            )
+
+        with mock.patch.object(cli, "_run_one_repository", with_payload):
+            _run_multi_repo(make_config(tmp_path), self.json_options(tmp_path))
+
+        document = json.loads(capsys.readouterr().out)
+        assert document["repositories"][0]["results"] == {"collected": True}
+
+    def test_otherwise_invisible_failures_are_named(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A non-zero code must have something in the document to explain it.
+
+        Neither a failed rewrite nor a failed auto-fix stage produces a
+        validation error, so a consumer reading only ``results`` would
+        find nothing at all.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures standard output.
+        """
+        make_container(tmp_path, "alpha")
+
+        def with_failures(
+            _config: Config,
+            _options: CLIOptions,
+            _cache: ValidationCache,
+            *,
+            collect_json: bool = False,  # noqa: ARG001 - matches the driver
+        ) -> RunOutcome:
+            """Answer with a run that failed invisibly.
+
+            Args:
+                _config: Unused.
+                _options: Unused.
+                _cache: Unused.
+                collect_json: Unused.
+
+            Returns:
+                An outcome carrying both invisible failure kinds.
+            """
+            return RunOutcome(
+                exit_code=exit_codes.DEFECTS_FOUND,
+                write_failures=2,
+                autofix_error="resolution exploded",
+                json_payload={},
+            )
+
+        with mock.patch.object(cli, "_run_one_repository", with_failures):
+            _run_multi_repo(make_config(tmp_path), self.json_options(tmp_path))
+
+        entry = json.loads(capsys.readouterr().out)["repositories"][0]
+        assert entry["write_failures"] == 2
+        assert entry["autofix_error"] == "resolution exploded"
+
+    def test_a_failure_is_named_in_the_document(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A repository that could not be scanned is reported as such.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures standard output.
+        """
+        make_container(tmp_path, "alpha", "beta")
+        recorder = RecordingRun({"beta": RuntimeError("boom")})
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), self.json_options(tmp_path))
+
+        document = json.loads(capsys.readouterr().out)
+        errors = {
+            entry["repository"]: entry["error"]
+            for entry in document["repositories"]
+        }
+        assert errors == {"alpha": None, "beta": "boom"}
+        assert document["summary"]["failed"] == 1
+
+    def test_an_empty_sweep_still_emits_a_document(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Finding nothing is a result, not an absence of output.
+
+        A consumer cannot otherwise tell an empty container from a run
+        that crashed before printing.
+
+        Args:
+            tmp_path: Empty container directory.
+            capsys: Captures standard output.
+        """
+        code = _run_multi_repo(
+            make_config(tmp_path), self.json_options(tmp_path)
+        )
+
+        document = json.loads(capsys.readouterr().out)
+        assert code == exit_codes.SUCCESS
+        assert document["repositories"] == []
+        assert document["summary"] == {
+            "repositories": 0,
+            "failed": 0,
+            "exit_code": exit_codes.SUCCESS,
+        }
+
+    def test_the_summary_table_is_not_printed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The closing table would corrupt the document.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures standard output.
+        """
+        make_container(tmp_path, "alpha")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), self.json_options(tmp_path))
+
+        output = capsys.readouterr().out
+        assert "Repository Summary" not in output
+        assert "Scanning 1 repositories" not in output
+
+    def test_a_real_run_does_not_corrupt_the_document(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Drives the real per-repository run, not a stand-in.
+
+        Every other test in this class replaces ``_run_one_repository``,
+        so none of them can see what an actual repository prints. A real
+        run opens a Rich progress display and reports "No workflows
+        found to validate" on standard output, both of which would sit
+        inside the aggregate document.
+
+        Repositories with no workflows are used deliberately: they reach
+        that message by the shortest path and need no network.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures standard output.
+        """
+        make_container(tmp_path, "one", "two")
+        # quiet=False is the point: the sweep must impose its own
+        # silence rather than inherit it from the caller.
+        options = CLIOptions(
+            path=tmp_path,
+            multi_repo=True,
+            quiet=False,
+            output_format="json",
+        )
+
+        code = _run_multi_repo(make_config(tmp_path), options)
+
+        document = json.loads(strip_ansi(capsys.readouterr().out))
+        assert code == exit_codes.SUCCESS
+        assert [entry["repository"] for entry in document["repositories"]] == [
+            "one",
+            "two",
+        ]
+
+    def test_the_sweep_imposes_silence_on_each_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """The effective silence reaches each repository's own options.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        make_container(tmp_path, "one")
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), self.json_options(tmp_path))
+
+        assert recorder.visits[0].options.quiet is True
+
+    def test_a_talkative_text_sweep_stays_talkative(
+        self, tmp_path: Path
+    ) -> None:
+        """Silence is not imposed when nothing asked for it.
+
+        This is the guard against quieting every sweep, which would cost
+        the text mode its per-repository output.
+
+        Args:
+            tmp_path: Container directory.
+        """
+        make_container(tmp_path, "one")
+        recorder = RecordingRun()
+        options = make_options(tmp_path, quiet=False)
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), options)
+
+        assert recorder.visits[0].options.quiet is False
+
+
+class TestSweepSummaryLabels:
+    """How the closing table names each repository."""
+
+    def test_grouped_repositories_stay_distinguishable(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Two repositories sharing a basename get separate rows.
+
+        ``--repo-depth 2`` supports grouped layouts, where rendering the
+        basename alone would print the same label twice and leave a
+        finding unattributable.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures the table.
+        """
+        _display_multi_repo_summary(
+            [
+                (
+                    tmp_path / "group-a" / "service",
+                    RunOutcome(exit_code=exit_codes.SUCCESS),
+                ),
+                (
+                    tmp_path / "group-b" / "service",
+                    RunOutcome(exit_code=exit_codes.SUCCESS),
+                ),
+            ],
+            tmp_path,
+        )
+
+        output = " ".join(strip_ansi(capsys.readouterr().out).split())
+        assert "group-a/service" in output
+        assert "group-b/service" in output
+
+    def test_the_root_repository_shortcut_keeps_its_basename(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Relative-to-itself would render as a bare dot.
+
+        Args:
+            tmp_path: The repository, which is also the sweep root.
+            capsys: Captures the table.
+        """
+        repository = make_repository(tmp_path / "solo")
+
+        _display_multi_repo_summary(
+            [(repository, RunOutcome(exit_code=exit_codes.SUCCESS))],
+            repository,
+        )
+
+        output = " ".join(strip_ansi(capsys.readouterr().out).split())
+        assert "solo" in output
+
+    def test_a_relative_root_repository_still_has_a_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``Path(".")`` has an empty basename.
+
+        A caller may name a repository by a relative path, and a blank
+        label would lose the attribution the helper exists to provide.
+
+        Args:
+            tmp_path: The repository, entered so ``.`` denotes it.
+            monkeypatch: Changes the working directory.
+        """
+        repository = make_repository(tmp_path / "solo")
+        monkeypatch.chdir(repository)
+
+        assert cli._repository_label(Path("."), Path(".")) == "solo"
+
+    def test_a_filesystem_root_checkout_still_has_a_label(self) -> None:
+        """The last resort is the path itself, never an empty string."""
+        assert cli._repository_label(Path("/"), Path("/")) == "/"
+
+    def test_the_live_heading_also_distinguishes_grouped_repositories(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The heading printed per repository must attribute too.
+
+        The closing table and the live commentary name the same thing,
+        so a layout the table can distinguish must not collapse in the
+        running output.
+
+        Args:
+            tmp_path: Container directory.
+            capsys: Captures the headings.
+        """
+        make_repository(tmp_path / "group-a" / "service")
+        make_repository(tmp_path / "group-b" / "service")
+        options = make_options(tmp_path, quiet=False).model_copy(
+            update={"repo_depth": 2}
+        )
+        recorder = RecordingRun()
+
+        with mock.patch.object(cli, "_run_one_repository", recorder):
+            _run_multi_repo(make_config(tmp_path), options)
+
+        output = " ".join(strip_ansi(capsys.readouterr().out).split())
+        # Anchored on the heading marker. The closing table names the
+        # same repositories, so an unanchored assertion passes on the
+        # table alone and says nothing about the heading.
+        assert "\u2500\u2500 group-a/service" in output
+        assert "\u2500\u2500 group-b/service" in output
+
+
+class TestUnreadableRoot:
+    """A sweep that examined nothing must not report success.
+
+    ``find_repositories`` raises when the root itself cannot be listed,
+    and the driver has to turn that into a runtime error rather than
+    taking the empty-container path, which exits zero. Skipping an
+    unreadable *descendant* stays right: the rest of the sweep is still
+    worth doing.
+    """
+
+    def test_an_unreadable_root_is_a_runtime_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exit code, not a successful empty sweep.
+
+        Args:
+            tmp_path: Container directory.
+            monkeypatch: Replaces discovery with an unreadable root.
+        """
+        monkeypatch.setattr(
+            cli,
+            "find_repositories",
+            mock.Mock(side_effect=PermissionError("Permission denied")),
+        )
+
+        code = _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        assert code == exit_codes.RUNTIME_ERROR
+
+    def test_an_empty_container_still_succeeds(self, tmp_path: Path) -> None:
+        """The guard against failing every empty sweep.
+
+        Args:
+            tmp_path: An empty, readable container.
+        """
+        code = _run_multi_repo(make_config(tmp_path), make_options(tmp_path))
+
+        assert code == exit_codes.SUCCESS

--- a/tests/test_run_outcome.py
+++ b/tests/test_run_outcome.py
@@ -1,0 +1,796 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for what a single repository's run reports to its caller.
+
+``RunOutcome`` is the seam between one repository's run and a sweep's
+aggregate reporting, so the fields it carries are the only thing the
+summary can describe. Two of them are easy to get subtly wrong in ways
+no exit code reveals:
+
+* ``error`` distinguishes a repository that *failed* from one that
+  merely had findings. Collapsing a failed scan to a bare exit code
+  made an unreadable checkout indistinguishable from a lint result --
+  reporting an unusable input as an absence of problems.
+* ``defects`` counts what the reader still has to deal with. Counting
+  calls the auto-fixer had already rewritten showed them as fixed and
+  outstanding at once, which reads as a contradiction.
+
+Neither is observable through ``_determine_exit_code``, which is
+covered separately, so both are pinned here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+
+from gha_workflow_linter import cli
+from gha_workflow_linter.auto_fix import AutoFixer
+from gha_workflow_linter.cache import ValidationCache
+from gha_workflow_linter.cli import (
+    _AutoFixOutcome,
+    _emit_results,
+    _repaired_locations,
+    _run_one_repository,
+    _ScanShortCircuit,
+    _ValidationOutcome,
+)
+from gha_workflow_linter.models import (
+    ActionCall,
+    ActionCallType,
+    CacheConfig,
+    CLIOptions,
+    Config,
+    ReferenceType,
+    ValidationError,
+    ValidationResult,
+)
+from gha_workflow_linter.scanner import WorkflowScanner
+from gha_workflow_linter.validator import ActionCallValidator
+from tests.conftest import strip_ansi
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+#: File the synthetic validation errors are attributed to.
+WORKFLOW = Path(".github/workflows/build.yaml")
+
+#: The auto-fixer's own logger, whose level gates its live display.
+AUTO_FIX_LOGGER = "gha_workflow_linter.auto_fix"
+
+
+def make_validation_error(
+    line: int, *, comment: str | None = None
+) -> ValidationError:
+    """Build one validation error at a given line.
+
+    Args:
+        line: Line the offending call sits on. Repaired calls are
+            matched by ``(file, line)``, so distinct values keep them
+            distinct.
+        comment: Trailing comment on the call, used to mark a test
+            reference.
+
+    Returns:
+        A validation error against :data:`WORKFLOW`.
+    """
+    return ValidationError(
+        file_path=WORKFLOW,
+        action_call=ActionCall(
+            raw_line=f"      - uses: actions/checkout@v4  {comment or ''}",
+            line_number=line,
+            organization="actions",
+            repository="checkout",
+            reference="v4",
+            comment=comment,
+            call_type=ActionCallType.ACTION,
+            reference_type=ReferenceType.TAG,
+        ),
+        result=ValidationResult.INVALID_REFERENCE,
+        error_message="boom",
+    )
+
+
+def make_change(line: int, *, skipped: bool = False) -> dict[str, str]:
+    """Build one entry of the auto-fixer's per-file change list.
+
+    Args:
+        line: Line the fixer touched.
+        skipped: Whether the fixer deliberately left the line alone.
+
+    Returns:
+        A change entry shaped as ``AutoFixer`` produces it.
+    """
+    change = {
+        "old_line": "old",
+        "new_line": "new",
+        "line_number": str(line),
+    }
+    if skipped:
+        change["skipped"] = "true"
+    return change
+
+
+def make_autofix(
+    fixed_files: dict[Path, list[dict[str, str]]] | None = None,
+    write_failures: list[Path] | None = None,
+    stage_error: str | None = None,
+) -> _AutoFixOutcome:
+    """Build an auto-fix outcome carrying the given changes.
+
+    Args:
+        fixed_files: Changes per file, or none.
+        write_failures: Files whose rewrite could not be written.
+        stage_error: Why the stage failed outright, or None.
+
+    Returns:
+        An outcome the run can aggregate.
+    """
+    return _AutoFixOutcome(
+        fixed_files or {},
+        {"actions_moved": 0, "calls_updated": 0},
+        {},
+        write_failures or [],
+        stage_error,
+    )
+
+
+def make_validation(errors: list[ValidationError]) -> _ValidationOutcome:
+    """Build a validation outcome carrying the given errors.
+
+    Args:
+        errors: Validation errors the run found.
+
+    Returns:
+        A real outcome, so the types are exercised.
+    """
+    return _ValidationOutcome(
+        workflow_calls={},
+        validation_errors=errors,
+        validator=ActionCallValidator(Config()),
+        total_calls=len(errors),
+    )
+
+
+@pytest.fixture
+def quiet_run(tmp_path: Path) -> Iterator[ValidationCache]:
+    """Silence the reporting stages and supply a throwaway cache.
+
+    Reporting is covered elsewhere; what matters here is the outcome the
+    run returns, so the emitters are stubbed out and the cache is
+    written under ``tmp_path`` rather than the user's cache directory.
+
+    Args:
+        tmp_path: Test-scoped directory to hold the cache file.
+
+    Yields:
+        A cache safe to pass into a run.
+    """
+    with (
+        mock.patch.object(cli, "_emit_results", return_value=None),
+        mock.patch.object(cli, "_run_allow_list_stage", return_value=None),
+    ):
+        yield ValidationCache(CacheConfig(cache_dir=tmp_path / "cache"))
+
+
+def run(cache: ValidationCache, **options: Any) -> Any:
+    """Run one repository with the given options.
+
+    Args:
+        cache: Cache to pass into the run.
+        **options: Overrides for the CLI options.
+
+    Returns:
+        The outcome the run produced.
+    """
+    base: dict[str, Any] = {"path": Path.cwd(), "quiet": True}
+    base.update(options)
+    return _run_one_repository(Config(), CLIOptions(**base), cache)
+
+
+class TestScanFailureIsPreserved:
+    """A run that stopped early says why, when there was a why."""
+
+    def test_a_scan_failure_is_recorded_on_the_outcome(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """A failed scan is distinguishable from a lint result.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with mock.patch.object(
+            cli,
+            "_scan_and_validate",
+            return_value=_ScanShortCircuit(1, "Error scanning workflows: no"),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.exit_code == 1
+        assert outcome.error == "Error scanning workflows: no"
+
+    def test_an_empty_repository_is_not_a_failure(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """A repository with no workflows is a clean result.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with mock.patch.object(
+            cli, "_scan_and_validate", return_value=_ScanShortCircuit(0)
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.exit_code == 0
+        assert outcome.error is None
+
+
+class TestMessagelessFailures:
+    """A failure with nothing to say still says which failure it was.
+
+    ``str(RuntimeError())`` is empty, so a description built from it
+    alone reads as an absence of trouble -- the recurring hazard this
+    work keeps meeting. Every stage that records a reason uses the same
+    helper, so none of them can report a blank.
+    """
+
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            pytest.param(RuntimeError(), "RuntimeError", id="no-message"),
+            pytest.param(
+                RuntimeError("disk went away"),
+                "disk went away",
+                id="a-message-is-preferred",
+            ),
+            pytest.param(ValueError(""), "ValueError", id="empty-string"),
+        ],
+    )
+    def test_describe_exception(self, error: Exception, expected: str) -> None:
+        """Every failure gets a non-empty description.
+
+        Args:
+            error: The exception to describe.
+            expected: The description it must produce.
+        """
+        assert cli._describe_exception(error) == expected
+
+    @pytest.mark.parametrize(
+        "stage",
+        ["scan", "validate"],
+    )
+    def test_a_messageless_scan_failure_names_its_kind(
+        self,
+        quiet_run: ValidationCache,
+        stage: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The scan and validate handlers use the same fallback.
+
+        Driven through the real ``_scan_and_validate`` rather than a
+        stub, so the two handlers inside it are genuinely exercised.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+            stage: Which stage to make fail.
+            monkeypatch: Replaces the failing collaborator.
+        """
+
+        def explode(*_args: Any, **_kwargs: Any) -> None:
+            """Fail with an exception carrying no message.
+
+            Raises:
+                RuntimeError: Always, with no message.
+            """
+            raise RuntimeError
+
+        if stage == "scan":
+            monkeypatch.setattr(WorkflowScanner, "scan_directory", explode)
+            expected = "Error scanning workflows: RuntimeError"
+        else:
+            monkeypatch.setattr(
+                WorkflowScanner,
+                "scan_directory",
+                lambda *a, **k: {WORKFLOW: {1: object()}},
+            )
+            monkeypatch.setattr(
+                ActionCallValidator, "validate_action_calls", explode
+            )
+            expected = "Unexpected error validating action calls: RuntimeError"
+
+        outcome = run(quiet_run)
+
+        assert outcome.exit_code == 1
+        assert outcome.error == expected
+
+
+class TestRepairedLocations:
+    """Which calls the auto-fixer actually rewrote."""
+
+    def test_rewritten_lines_are_collected(self) -> None:
+        """Every non-skipped change contributes its line."""
+        autofix = make_autofix({WORKFLOW: [make_change(3), make_change(7)]})
+
+        assert _repaired_locations(autofix) == {(WORKFLOW, 3), (WORKFLOW, 7)}
+
+    def test_skipped_lines_are_excluded(self) -> None:
+        """A line the fixer left alone was not repaired."""
+        autofix = make_autofix(
+            {WORKFLOW: [make_change(3), make_change(7, skipped=True)]}
+        )
+
+        assert _repaired_locations(autofix) == {(WORKFLOW, 3)}
+
+    def test_nothing_fixed_yields_nothing(self) -> None:
+        """An empty run repairs no lines."""
+        assert _repaired_locations(make_autofix()) == set()
+
+
+class TestDefectsCount:
+    """What the summary reports as still needing attention."""
+
+    def test_a_repaired_call_is_not_still_a_defect(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """A call the fixer rewrote is no longer outstanding.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation(
+                    [make_validation_error(1), make_validation_error(2)]
+                ),
+            ),
+            mock.patch.object(
+                cli,
+                "_run_auto_fix_stage",
+                return_value=make_autofix({WORKFLOW: [make_change(1)]}),
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.defects == 1
+
+    def test_an_unrepaired_call_is_still_a_defect(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """Nothing rewritten leaves every error outstanding.
+
+        This is the guard against simply counting nothing.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation(
+                    [make_validation_error(1), make_validation_error(2)]
+                ),
+            ),
+            mock.patch.object(
+                cli, "_run_auto_fix_stage", return_value=make_autofix()
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.defects == 2
+
+    def test_a_skipped_call_is_still_a_defect(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """The fixer declining to act does not clear the finding.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation([make_validation_error(1)]),
+            ),
+            mock.patch.object(
+                cli,
+                "_run_auto_fix_stage",
+                return_value=make_autofix(
+                    {WORKFLOW: [make_change(1, skipped=True)]}
+                ),
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.defects == 1
+
+    def test_test_references_are_excluded(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """Test references are advisory by convention.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation(
+                    [
+                        make_validation_error(1),
+                        make_validation_error(2, comment="# testing"),
+                    ]
+                ),
+            ),
+            mock.patch.object(
+                cli, "_run_auto_fix_stage", return_value=make_autofix()
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.defects == 1
+
+
+class TestWriteFailuresReachTheOutcome:
+    """A failed rewrite must survive into what the sweep reports.
+
+    Recording the failure on the fixer achieves nothing if the outcome
+    the summary reads never learns of it.
+    """
+
+    def test_a_failed_rewrite_is_counted(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """The count reaches ``RunOutcome``.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation([]),
+            ),
+            mock.patch.object(
+                cli,
+                "_run_auto_fix_stage",
+                return_value=make_autofix(write_failures=[WORKFLOW]),
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.write_failures == 1
+
+    def test_a_clean_run_counts_none(self, quiet_run: ValidationCache) -> None:
+        """The guard against counting a failure on every run.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation([]),
+            ),
+            mock.patch.object(
+                cli, "_run_auto_fix_stage", return_value=make_autofix()
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.write_failures == 0
+
+    def test_a_stage_failure_is_carried(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """A stage that failed outright reaches the outcome too.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation([]),
+            ),
+            mock.patch.object(
+                cli,
+                "_run_auto_fix_stage",
+                return_value=make_autofix(stage_error="resolution exploded"),
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.autofix_error == "resolution exploded"
+
+    def test_a_clean_run_carries_no_stage_failure(
+        self, quiet_run: ValidationCache
+    ) -> None:
+        """The guard against reporting a failure on every run.
+
+        Args:
+            quiet_run: Cache fixture, with reporting stubbed out.
+        """
+        with (
+            mock.patch.object(
+                cli,
+                "_scan_and_validate",
+                return_value=make_validation([]),
+            ),
+            mock.patch.object(
+                cli, "_run_auto_fix_stage", return_value=make_autofix()
+            ),
+        ):
+            outcome = run(quiet_run)
+
+        assert outcome.autofix_error is None
+
+
+class TestAutoFixerSilence:
+    """The auto-fixer's live display is a second route to standard output.
+
+    ``CLIOptions.quiet`` silences the scanner and the reporting stages,
+    but :class:`~gha_workflow_linter.auto_fix.AutoFixer` decided whether
+    to open its Rich ``Live`` display from the logger level alone. The
+    CLI sets that level, so the CLI was safe; a caller of ``run_linter``
+    never does, and would have found progress output inside the
+    aggregate JSON document.
+
+    The sweep's other JSON tests cannot see this, because they use
+    repositories with no workflows and the fixer never runs.
+    """
+
+    @staticmethod
+    def fixer(tmp_path: Path, *, quiet: bool) -> AutoFixer:
+        """Build an auto-fixer with the given silence.
+
+        A throwaway cache is supplied so the fixer does not prime the
+        user's real one.
+
+        Args:
+            tmp_path: Test-scoped directory to hold the cache file.
+            quiet: Whether the caller asked for silence.
+
+        Returns:
+            An auto-fixer, not entered.
+        """
+        config = Config(cache=CacheConfig(cache_dir=tmp_path / "cache"))
+        return AutoFixer(
+            config, cache=ValidationCache(config.cache), quiet=quiet
+        )
+
+    def test_a_quiet_caller_is_honoured_whatever_the_logger_says(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Explicit silence does not depend on logging configuration.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+            caplog: Sets the level a library caller would leave in place.
+        """
+        fixer = self.fixer(tmp_path, quiet=True)
+
+        with caplog.at_level(logging.WARNING, logger=AUTO_FIX_LOGGER):
+            assert fixer._show_live_updates() is False
+
+    def test_a_talkative_caller_still_follows_the_logger(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The logger level still suppresses the display as before.
+
+        This is the guard against silencing the fixer outright, which
+        would cost every ordinary run its progress display.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+            caplog: Sets the logger level.
+        """
+        fixer = self.fixer(tmp_path, quiet=False)
+
+        with caplog.at_level(logging.WARNING, logger=AUTO_FIX_LOGGER):
+            assert fixer._show_live_updates() is True
+
+        with caplog.at_level(logging.ERROR, logger=AUTO_FIX_LOGGER):
+            assert fixer._show_live_updates() is False
+
+    def test_the_sweep_passes_its_silence_to_the_fixer(
+        self, tmp_path: Path
+    ) -> None:
+        """A JSON sweep must reach the fixer, not stop at the scanner.
+
+        Only the constructor call is asserted. The stand-in cannot
+        satisfy the rest of the stage, but that failure is caught and
+        logged by design, so the assertion is unaffected.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = Config(cache=CacheConfig(cache_dir=tmp_path / "cache"))
+        options = CLIOptions(path=tmp_path, quiet=True, output_format="json")
+
+        with mock.patch.object(cli, "AutoFixer") as fixer_class:
+            cli._run_auto_fix_stage(
+                config,
+                options,
+                ValidationCache(config.cache),
+                make_validation([make_validation_error(1)]),
+            )
+
+        assert fixer_class.call_args.kwargs["quiet"] is True
+
+    def test_json_output_silences_the_fixer_for_a_single_run(
+        self, tmp_path: Path
+    ) -> None:
+        """A programmatic single-repository JSON run gets no coercion.
+
+        The command layer forces quiet for JSON output, but a caller of
+        ``run_linter`` gets none of that, so the fixer's live display
+        would open on standard output ahead of the document. The sweep
+        already derives its own silence; the single-repository path has
+        to as well.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = Config(cache=CacheConfig(cache_dir=tmp_path / "cache"))
+        options = CLIOptions(path=tmp_path, quiet=False, output_format="json")
+
+        with mock.patch.object(cli, "AutoFixer") as fixer_class:
+            cli._run_auto_fix_stage(
+                config,
+                options,
+                ValidationCache(config.cache),
+                make_validation([make_validation_error(1)]),
+            )
+
+        assert fixer_class.call_args.kwargs["quiet"] is True
+
+    def test_a_text_run_is_not_silenced(self, tmp_path: Path) -> None:
+        """The guard against silencing the fixer for everyone.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = Config(cache=CacheConfig(cache_dir=tmp_path / "cache"))
+        options = CLIOptions(path=tmp_path, quiet=False)
+
+        with mock.patch.object(cli, "AutoFixer") as fixer_class:
+            cli._run_auto_fix_stage(
+                config,
+                options,
+                ValidationCache(config.cache),
+                make_validation([make_validation_error(1)]),
+            )
+
+        assert fixer_class.call_args.kwargs["quiet"] is False
+
+    def test_json_output_silences_every_display_in_the_stage(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The fixer is not the only thing that writes to stdout.
+
+        The applied-changes listing and the stage-failure notice print
+        from this stage too, so silencing the fixer alone still leaves
+        commentary ahead of the JSON document.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+            capsys: Captures standard output.
+        """
+        config = Config(cache=CacheConfig(cache_dir=tmp_path / "cache"))
+        options = CLIOptions(path=tmp_path, quiet=False, output_format="json")
+
+        # A stand-in the stage cannot use, so it takes the failure path
+        # and would print its notice.
+        with mock.patch.object(cli, "AutoFixer"):
+            outcome = cli._run_auto_fix_stage(
+                config,
+                options,
+                ValidationCache(config.cache),
+                make_validation([make_validation_error(1)]),
+            )
+
+        assert outcome.stage_error is not None
+        assert capsys.readouterr().out == ""
+
+    def test_a_text_run_still_reports_a_stage_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The guard against silencing the notice for everyone.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+            capsys: Captures standard output.
+        """
+        config = Config(cache=CacheConfig(cache_dir=tmp_path / "cache"))
+        options = CLIOptions(path=tmp_path, quiet=False)
+
+        with mock.patch.object(cli, "AutoFixer"):
+            cli._run_auto_fix_stage(
+                config,
+                options,
+                ValidationCache(config.cache),
+                make_validation([make_validation_error(1)]),
+            )
+
+        assert "Auto-fix failed" in strip_ansi(capsys.readouterr().out)
+
+
+class TestEmitResultsCollection:
+    """Whether the JSON payload is printed or handed back.
+
+    The sweep depends on being able to take a repository's payload
+    *without* it reaching standard output, since it assembles one
+    document of its own. If collecting still printed, every repository
+    would emit a top-level object and the aggregate document would be
+    unparsable no matter how carefully the sweep built it.
+    """
+
+    @staticmethod
+    def emit(*, collect_json: bool) -> dict[str, Any] | None:
+        """Run the emitter over an empty result set.
+
+        Args:
+            collect_json: Whether to collect the payload rather than
+                print it.
+
+        Returns:
+            Whatever the emitter returned.
+        """
+        scanner = mock.Mock()
+        scanner.get_scan_summary.return_value = {
+            "total_files": 0,
+            "total_calls": 0,
+        }
+        return _emit_results(
+            CLIOptions(path=Path.cwd(), quiet=True, output_format="json"),
+            scanner,
+            make_validation([]),
+            make_autofix(),
+            Config(),
+            None,
+            collect_json=collect_json,
+        )
+
+    def test_collecting_returns_the_payload_without_printing(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A collected payload never reaches standard output.
+
+        Args:
+            capsys: Captures standard output.
+        """
+        payload = self.emit(collect_json=True)
+
+        assert capsys.readouterr().out == ""
+        assert payload is not None
+        assert "scan_summary" in payload
+
+    def test_not_collecting_prints_the_document(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A single repository still prints its own results.
+
+        This is the guard against silencing the ordinary JSON mode.
+
+        Args:
+            capsys: Captures standard output.
+        """
+        payload = self.emit(collect_json=False)
+
+        assert payload is None
+        assert "scan_summary" in json.loads(capsys.readouterr().out)

--- a/tests/test_validator_cache_stats.py
+++ b/tests/test_validator_cache_stats.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for how a validator accounts for cache hits.
+
+A multi-repository sweep builds one
+:class:`~gha_workflow_linter.cache.ValidationCache` and shares it across
+every repository, which is the efficiency argument for building the mode
+into the tool. The cache's hit counter is cumulative, so a validator
+that reported it wholesale would credit each repository with every hit
+since the sweep began -- the second repository's JSON payload claiming
+the first repository's cache hits as its own.
+
+Each validator therefore records where the counter stood when its
+context was entered and reports the difference. The single-repository
+case is unaffected, since the counter starts at zero there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from gha_workflow_linter.cache import ValidationCache
+from gha_workflow_linter.models import (
+    ActionCall,
+    ActionCallType,
+    CacheConfig,
+    Config,
+    ReferenceType,
+    ValidationMethod,
+    ValidationResult,
+)
+from gha_workflow_linter.validator import ActionCallValidator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: A pinned call the cache can answer for without any network access.
+REPOSITORY = "actions/checkout"
+REFERENCE = "11bd71901bbe5b1630ceea73d27597364c9af683"
+
+
+def make_config(tmp_path: Path) -> Config:
+    """Build a configuration with a throwaway cache directory.
+
+    The Git validation method is chosen so that entering the validator's
+    context builds no network client.
+
+    Args:
+        tmp_path: Test-scoped directory to hold the cache file.
+
+    Returns:
+        A configuration safe to use without touching the user's cache.
+    """
+    return Config(
+        cache=CacheConfig(cache_dir=tmp_path / "cache"),
+        validation_method=ValidationMethod.GIT,
+    )
+
+
+def report_cache_hits(
+    config: Config, cache: ValidationCache, *, hits: int
+) -> int:
+    """Build a validator, cause some cache hits, and read its tally.
+
+    The baseline is taken when the context is entered and the merge
+    happens on exit, so the hits are simulated in between -- which is
+    where a real run's hits occur.
+
+    Args:
+        config: Configuration for the validator.
+        cache: Cache to share with it.
+        hits: How many cache hits to attribute to this validator.
+
+    Returns:
+        The cache hits the validator attributed to itself.
+    """
+
+    async def run() -> int:
+        """Enter the validator's context and cause hits inside it.
+
+        Returns:
+            The validator's reported cache hits.
+        """
+        validator = ActionCallValidator(config, cache=cache)
+        async with validator:
+            cache.stats.hits += hits
+        return validator.api_stats.cache_hits
+
+    return asyncio.run(run())
+
+
+class TestCacheHitAccounting:
+    """What a validator counts as its own cache hits."""
+
+    def test_a_fresh_cache_reports_its_own_hits(self, tmp_path: Path) -> None:
+        """The single-repository case is unchanged.
+
+        This is the guard against reporting nothing at all, which a
+        wrongly-taken baseline would produce.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+
+        assert report_cache_hits(config, cache, hits=3) == 3
+
+    def test_earlier_hits_are_not_claimed_by_a_later_validator(
+        self, tmp_path: Path
+    ) -> None:
+        """A sweep's second repository reports only what it caused.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+
+        # The first repository of a sweep.
+        assert report_cache_hits(config, cache, hits=5) == 5
+
+        # The second, sharing the same cache, which already holds five.
+        assert report_cache_hits(config, cache, hits=2) == 2
+
+    def test_a_repository_that_hits_nothing_reports_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """No hits of its own means none reported, not inherited ones.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+
+        report_cache_hits(config, cache, hits=9)
+
+        assert report_cache_hits(config, cache, hits=0) == 0
+
+    def test_the_shared_counter_is_left_intact(self, tmp_path: Path) -> None:
+        """Accounting reads the counter; it must not reset it.
+
+        Resetting between visits would be the other way to fix this, and
+        would cost the sweep its cumulative total.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+
+        report_cache_hits(config, cache, hits=4)
+        report_cache_hits(config, cache, hits=6)
+
+        assert cache.stats.hits == 10
+
+    def test_hits_before_entry_are_not_claimed(self, tmp_path: Path) -> None:
+        """The baseline is taken on entry, not at construction.
+
+        A validator may be built well before it runs, and the shared
+        cache keeps serving other work in between.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+        validator = ActionCallValidator(config, cache=cache)
+
+        # Someone else's hits, between construction and this run.
+        cache.stats.hits += 7
+
+        async def run() -> int:
+            """Enter the validator and cause two hits of its own.
+
+            Returns:
+                The validator's reported cache hits.
+            """
+            async with validator:
+                cache.stats.hits += 2
+            return validator.api_stats.cache_hits
+
+        assert asyncio.run(run()) == 2
+
+    def test_a_second_pass_does_not_recount_the_first(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-entering one validator reports each pass separately.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+        validator = ActionCallValidator(config, cache=cache)
+
+        async def run(hits: int) -> int:
+            """Enter the validator once and cause some hits.
+
+            Args:
+                hits: Hits to attribute to this pass.
+
+            Returns:
+                The validator's cumulative reported cache hits.
+            """
+            async with validator:
+                cache.stats.hits += hits
+            return validator.api_stats.cache_hits
+
+        assert asyncio.run(run(3)) == 3
+        # The second pass adds only its own two, not the first three
+        # again, so the running total is five rather than eight.
+        assert asyncio.run(run(2)) == 5
+
+
+class TestRealValidationPath:
+    """The tally a genuine validation run produces.
+
+    The tests above drive the counter directly, which pins the
+    arithmetic but cannot see a second merge somewhere else in the run.
+    One existed: the Git backend's statistics logging merged the cache
+    tally as well, so a real run counted every hit twice. These tests
+    validate a call the cache can already answer, so the run is
+    self-contained and the reported figure has a known correct value.
+    """
+
+    @staticmethod
+    def seed(cache: ValidationCache) -> None:
+        """Record a validation result the cache can serve from memory.
+
+        Args:
+            cache: Cache to populate.
+        """
+        cache.put(
+            REPOSITORY,
+            REFERENCE,
+            ValidationResult.VALID,
+            api_call_type="test",
+            validation_method=ValidationMethod.GIT,
+        )
+
+    @staticmethod
+    def action_calls() -> dict[Path, dict[int, ActionCall]]:
+        """Build one cached action call for the validator to check.
+
+        Returns:
+            A single call, keyed as the scanner would key it.
+        """
+        from pathlib import Path as _Path
+
+        return {
+            _Path(".github/workflows/build.yaml"): {
+                1: ActionCall(
+                    raw_line=(
+                        f"      - uses: {REPOSITORY}@{REFERENCE}  # v4.2.2"
+                    ),
+                    line_number=1,
+                    organization="actions",
+                    repository="checkout",
+                    reference=REFERENCE,
+                    comment="# v4.2.2",
+                    call_type=ActionCallType.ACTION,
+                    reference_type=ReferenceType.COMMIT_SHA,
+                )
+            }
+        }
+
+    def validate(self, config: Config, cache: ValidationCache) -> int:
+        """Validate one cached call and report the resulting tally.
+
+        Args:
+            config: Configuration for the validator.
+            cache: Cache holding the answer.
+
+        Returns:
+            The cache hits the validator attributed to itself.
+        """
+
+        async def run() -> int:
+            """Run a validation inside the validator's context.
+
+            Returns:
+                The validator's reported cache hits.
+            """
+            validator = ActionCallValidator(config, cache=cache)
+            async with validator:
+                await validator.validate_action_calls_async(self.action_calls())
+            return validator.api_stats.cache_hits
+
+        return asyncio.run(run())
+
+    def test_one_cached_call_is_counted_once(self, tmp_path: Path) -> None:
+        """A single cache hit is reported as one, not two.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+        self.seed(cache)
+
+        assert self.validate(config, cache) == 1
+
+    def test_a_later_repository_counts_only_its_own(
+        self, tmp_path: Path
+    ) -> None:
+        """Two validations over one cache report one hit each.
+
+        Args:
+            tmp_path: Supplies the cache directory.
+        """
+        config = make_config(tmp_path)
+        cache = ValidationCache(config.cache)
+        self.seed(cache)
+
+        assert self.validate(config, cache) == 1
+        assert self.validate(config, cache) == 1


### PR DESCRIPTION
## Summary

Phase 4, the last of the design in `docs/ALLOW_LIST_FEATURE.md` §11.

`--multi-repo` treats the given path as a container of git repositories and visits each in turn. `--repo-depth` controls how far below the path to look, defaulting to one level.

```bash
gha-workflow-linter lint ~/Repositories --multi-repo --verify-allow-list
gha-workflow-linter lint ~/Repositories --multi-repo --update-allow-list
```

Rebased onto `main` at `00c27c8` now that #320 and #321 have merged, so this is a standalone single commit.

## It also answers a gap #300 opened

Scanning now stops at repository boundaries, so pointing the linter at a directory that merely *contains* repositories finds nothing — every child is a boundary. That is correct for a single run, and this is the sanctioned way to cover many: each repository is visited as its own root, so its findings, workflow organisation and cooldown all belong to it.

## Why build it in rather than loop in a shell

**The cache is built once and shared**, so repositories pinning the same allow-list host share a single latest-release lookup. Measured on a cold cache with three repositories naming one host:

```
Latest-release cache hits: 0, 1 to resolve     <- first repository
Latest-release cache hits: 1, 0 to resolve
Latest-release cache hits: 1, 0 to resolve
```

Twenty repositories cost one query rather than twenty.

**What cannot be shared is not.** Configuration is deep-copied per repository and the cooldown re-resolved from that repository's own `dependabot.yml`, because both belong to the repository rather than to the sweep. A test gives two repositories different cooldowns and asserts neither inherits the other's.

## Failures and exit codes

Repositories are visited one at a time — the intra-repository parallelism already saturates the API budget, and one at a time keeps the progress output legible and attributes a failure to the repository that caused it.

A repository that fails is recorded and the sweep continues. A `ConfigurationError` is the deliberate exception and stops the run, since a bad setting applies to every repository and repeating it once per checkout helps nobody.

The aggregate exit code is the most significant across the sweep, so the §8 precedence (`4 > 3 > 5 > 1 > 0`) holds over the whole estate rather than only within one repository.

## Output

```
                        Repository Summary
┏━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Repository      ┃ Pins ┃ Stale ┃ Fixed ┃ Defects ┃ Status     ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━┩
│ group-a/service │    0 │     0 │     0 │       0 │ unresolved │
│ repo-current    │    0 │     0 │     0 │       0 │ clean      │
│ repo-stale      │    1 │     0 │     1 │       0 │ updated    │
└─────────────────┴──────┴───────┴───────┴─────────┴────────────┘
```

**Stale** counts what still needs attention rather than what was found, since a pin the sweep rewrote is no longer stale and showing it as both stale and fixed reads as a contradiction. Allow-list rewrites count towards **updated**, having been tracked separately from the action-call fixer's tally.

---

# Review round 2

Copilot raised **seven** defects (two threads, five suppressed). All were legitimate on inspection, and writing a test for one of them found an **eighth**.

### 1. Discovery dropped a checkout named like a build directory

The skip list was consulted before the repository test, so a clone called `venv` or `node_modules` was omitted from a sweep entirely. The names now suppress descent alone.

### 2. A scan failure was indistinguishable from findings

`_scan_and_validate` collapsed to a bare `int`, leaving `RunOutcome.error` unset — so an unreadable checkout was labelled `findings` and left out of the "could not be scanned" count. This is the *reporting an unusable input as an absence of problems* failure mode the design sets out to avoid.

It now returns a `_ScanShortCircuit` carrying the reason. "No workflows found" deliberately carries `error=None`, because a repository without workflows is a clean result rather than one that failed.

### 3. Repaired calls were still counted as defects

The tally counted validation errors the auto-fixer had already rewritten, showing one call as fixed and outstanding at once. A `_repaired_locations` helper now excludes them. Skipped entries stay counted — the fixer declining to act does not clear a finding.

### 4. `--multi-repo --format json` was not JSON

Each repository printed its own top-level object, which no parser accepts. The sweep now collects each payload into one document:

```json
{
  "repositories": [
    { "repository": "example-workflows", "exit_code": 3,
      "error": null, "results": { "scan_summary": {}, "allow_list": {} } }
  ],
  "summary": { "repositories": 1, "failed": 0, "exit_code": 3 }
}
```

An empty container still emits a document, so a consumer can tell it from a crash.

`output_json_results` would have become dead code under the obvious refactor, so it stays as the single-repo emitter and the new `build_json_results` serves aggregation. Both have a live caller.

### 5. **Not raised in review** — the log handler corrupted JSON output

Writing the test for #4 exposed it: `RichHandler` was bound to the **stdout** console, so any log record corrupted the document — a certainty in a sweep, which logs an error for every repository it survives. `err_console` already existed carrying a docstring saying diagnostics belong on stderr; it simply was not used for logging.

This changes behaviour beyond multi-repo mode. Six existing tests asserted diagnostics appear in `result.stdout`; they now assert on `result.stderr`, which pins the contract more precisely than before.

### 6. Cooldown-shifted cache entries crossed repositories

The most serious of the batch. The persistent latest-version cache is keyed on the repository alone and records no release policy, so a repository with a 3-day cooldown could publish a release that a 7-day repository was not yet entitled to — and the reverse order could suppress a valid update.

Pre-existing (the on-disk cache already carried this between successive runs), but the sweep makes it systematic. Fixed by mirroring the reasoning already recorded on `AllowListResolver.cache_usable` rather than inventing a scheme. The session cache is untouched: one `AutoFixer` serves one repository and therefore one cooldown.

### 7. Grouped repositories were indistinguishable

`group-a/service` and `group-b/service` both rendered as `service`. Rows are now relative to the sweep root.

### 8. `clean` appeared beside a non-zero Stale column

Status came from the exit code alone, but allow-list findings stay advisory without `--verify-allow-list`, and defects survive `--no-fail-on-error`.

I went one step further than the review suggested: an **unresolved** check gains its own label rather than sharing `findings`. Its counts are empty for want of an answer rather than for want of a problem, and a row of zeros marked `findings` gives the reader no way to tell the two apart. Ordering follows the §8 exit-code precedence, so unresolved outranks work already carried out.

## Validation

**Thirteen mutations applied. No new assertion passed against broken code.**

| mutation | result |
| --- | --- |
| Consult the skip list before the repository test | ✗ 6 failures |
| Discard the scan failure reason | ✗ scan-failure test failed |
| Count repaired calls as defects | ✗ repaired-call test failed |
| Treat skipped changes as repaired | ✗ 2 failures |
| Print each repository's JSON as it goes | ✗ payload test failed |
| Collect *and* print | ✗ no-print test failed |
| Stop printing in single-repo JSON mode | ✗ print test failed |
| JSON mode does not silence commentary | ✗ 4 failures |
| Render basenames in the summary | ✗ grouped-label test failed |
| Trust the exit code alone for status | ✗ 3 failures |
| Give unresolved no label of its own | ✗ 2 failures |
| Let work carried out outrank unresolved | ✗ precedence test failed |
| Point the log handler back at stdout | ✗ 6 failures |

Two of those were informative rather than confirmatory. The per-repository-print mutation turned out **weak by construction** — the sweep tests mock the very function that would print — so a direct `_emit_results` test was added to close the gap. And the unresolved-label mutations confirm both that the label exists and that it is correctly ordered.

- **1472 tests** passing (from 1436), coverage 83.4%
- All **30** `prek` hooks pass, including the `ruff` / `mypy` / `basedpyright` bumps that arrived with #321
- Exercised end to end against real checkouts: JSON parses cleanly from a two-repository sweep, and a `--repo-depth 2` grouped layout renders both rows distinctly

## Also

The design document gains a status section: all six phases have shipped. It records the two kinds still deferred — `SHA_COMMENT_MISMATCH` and `OUTDATED_ACTION` — per the rule that nothing ships until something emits it.


---

# Review round 3

Four more, all the same shape as each other: **state belonging to one repository reaching another.** Two threads, two suppressed.

### 9. `GITHUB_REPOSITORY_OWNER` resolved every checkout to one organisation

§6.3 puts the environment variable above the git remotes because, in Actions, a checkout often has no useful remote. Sound for a *single* run, where the variable and the scanned repository describe the same thing — but in a sweep it is false for every repository bar one, so every checkout resolved its shorthand `@<sha>` pins against one organisation's `.github`.

`resolve_workflow_org` now takes `use_environment`, and `AllowListConfig` gains `use_environment_org` (default `True`, so single runs are unchanged). The sweep clears it per repository. An explicit `--allow-list-org` still outranks both.

Benign for our estate today — everything sits under `lfreleng-actions` and the sweep runs there too — but it would bite silently the moment a sweep covered a fork or a second organisation.

### 10. The Dependabot search walked past the repository root

`find_dependabot_config` ascended to the filesystem root, so a checkout with no configuration of its own inherited whatever directory contained it. A sweep container carrying a cooldown would have imposed it on every repository beneath, and a lone checkout would answer differently depending on where it was cloned.

The walk now stops at a repository root — checked *after* that directory's own file, so a repository's own configuration is still found. Worktree and submodule marker files count as boundaries too.

This is the same **no-repository-boundary-awareness** class as the `.worktrees/` scanning bug fixed in #300.

### 11. `--files` with `--multi-repo` scanned the same file once per repository

`_resolve_absolute_pattern` honours an absolute path with no reference to the scan root, so the combination would scan — and under `--update-allow-list` **rewrite** — one file once per discovered repository, counting it against each.

Refused rather than dispatched. The two options ask for different things: `--files` names exact paths (it exists for the pre-commit hook, which passes one repository's staged files), while `--multi-repo` says "find the repositories and visit each". Dispatching would invent a meaning and still leave the relative-path case ambiguous.

### 12. The README overstated the cache saving

`Twenty repositories cost one query rather than twenty` is true only without a cooldown. Both `AllowListResolver.cache_usable` and the `_persistent_cache_usable` added in round 2 bypass the cache while a cooldown applies, and each repository builds its own resolver — so twenty cooled repositories cost twenty lookups. The README now says so, and explains why correctness wins over the saving.

Worth noting my own round-2 fix aggravated this, though the allow-list half was already true before this PR.

## Validation

**Eight more mutations, twenty-one across all rounds. Nothing passed against broken code.**

| mutation | result |
| --- | --- |
| Consult the environment org unconditionally | ✗ 1 failure |
| Sweep leaves the environment org trusted | ✗ 1 failure |
| Gate `configured` on the same flag | ✗ 1 failure |
| Default `use_environment_org` to `False` | ✗ 1 failure |
| Dependabot walk ignores the repository boundary | ✗ 2 failures |
| Boundary checked *before* the directory's own file | ✗ 2 failures |
| Accept `--files` alongside `--multi-repo` | ✗ 1 failure |
| Refuse every sweep | ✗ 7 failures |

Four of those are inverse mutations, present because the obvious over-corrections would have passed the positive tests: disabling `--allow-list-org` along with the environment, turning the environment off everywhere, checking the repository boundary too early, and refusing every sweep rather than only those with `--files`.

- **1482 tests** passing, coverage 83.4%
- All **30** `prek` hooks pass
- Verified live: the `--files` combination exits `1` with an actionable message before visiting anything, and a container-level `dependabot.yml` no longer reaches a child checkout


---

# Review round 4

No new threads — but **five suppressed comments**, all legitimate. Four share one shape: *something belonging to one repository reaching another.*

### 13. The live heading still used basenames

Round 3 taught the closing table to distinguish `group-a/service` from `group-b/service`; the per-repository heading printed while the sweep runs did not, so the running output collapsed what the table separated. Both now go through one `_repository_label` helper, which keeps the basename for the root-repository shortcut rather than rendering it as a bare `.`.

### 14. The root-repository shortcut lost its environment organisation

My round-3 fix cleared `use_environment_org` for every repository in a sweep. But pointing `--multi-repo` at a checkout visits *that one repository* — the case the README documents as "safe to leave in a wrapper script" — and there `GITHUB_REPOSITORY_OWNER` describes exactly the right repository. Clearing it took away a source the ordinary single-repository case depends on, since a checkout under Actions often has no useful remote.

A self-inflicted regression from the previous round. The shortcut now keeps the environment source; genuine sweeps still clear it.

### 15. Advisory outdated actions were reported as `clean`

The same defect I fixed for allow-list findings in round 2, left standing for action calls. With the **defaults** (`auto_fix=True`, `update_actions=False`), `_has_outdated_actions` can be true while the exit code stays `0`, so a repository whose own output listed outdated calls was labelled `clean` in the summary. The count now reaches `RunOutcome` and the clean check consults it.

### 16. The shared cache also shared its hit counter

`validator.py` merged `shared_cache.stats.hits` wholesale into each validator's statistics. Since a sweep shares one cache, every repository after the first claimed its predecessors' cache hits as its own — a per-repository lie in the JSON payload's `validation_summary`.

Each validator now records where the counter stood when it was built and reports the difference. Resetting the counter between visits was the other option; it was rejected because it would cost the sweep its cumulative total, and there is a test pinning that the shared counter is left intact.

### 17. The cooldown cache bypass ignored prerelease eligibility

Round 2's `_persistent_cache_usable` considered only the cooldown. But `allow_prerelease` is equally part of the release policy, and the cache records neither: a prerelease-enabled run could cache a prerelease that a later default run consumed, or consume a stable-only entry and miss a newer prerelease.

Both `_persistent_cache_usable` and `AllowListResolver.cache_usable` now bypass under either condition. My round-2 fix was incomplete, and this is the third time this cache's policy-blindness has produced a defect — worth remembering if a third policy dimension ever appears.

## Validation

| mutation | result |
| --- | --- |
| Live heading uses the basename | ✗ 1 failure *(after the test was fixed — see below)* |
| Root-repository shortcut renders as `.` | ✗ 1 failure |
| Root-repository shortcut loses the environment org | ✗ 1 failure |
| Advisory outdated actions count as clean | ✗ 1 failure |
| Cache hits reported cumulatively | ✗ 2 failures |
| Counter reset between visits instead of delta | ✗ 1 failure |
| `_persistent_cache_usable` reverted to cooldown-only | ✗ 4 failures |
| ...forced `True` / `False` | ✗ 9 / 4 failures |
| `cache_usable` reverted to cooldown-only | ✗ 3 failures |

**One test passed against broken code and was rewritten.** The live-heading test asserted `"group-a/service" in output`, which the *closing table* also satisfies — so it said nothing about the heading it was written to check. It is now anchored on the heading marker (`── group-a/service`). Worth recording as the one place in this PR where mutation testing earned its keep by catching my own test rather than my own code.

- **1505 tests** passing, coverage 83.5%
- All **30** `prek` hooks pass

The prerelease coverage also extends `AllowListResolver.cache_usable`, whose prerelease dimension had no test at all before this round.


---

# Review round 5

Again no threads, **six suppressed comments**. One is a defect round 4 introduced — and which round 4's own test could not have caught.

### 18. The Git backend counted every cache hit twice

`_log_final_statistics` merged the cache tally into `api_stats` *as well as* the context exit, on the Git path. So a real Git run double-counted, and after round 4 it counted the cumulative total plus its own delta.

Worth being straight about this: **the double-count predates this PR** — both sites previously added the cumulative value — but round 4 touched one of them and did not notice the other. The tally is now merged in exactly one place (`__aexit__`), and the logging method reads it without mutating, which is what a logging method should do anyway.

Copilot's second sentence was the important one: *"exercise the real validation path in the regression test rather than incrementing the counter directly."* Round 4's tests drove `cache.stats.hits` by hand, which pins the arithmetic but is blind to a second merge elsewhere in the run. There is now a `TestRealValidationPath` class that validates a call the cache can already answer — self-contained, no network, 0.08s — and asserts the figure a genuine run reports.

Restoring the duplicate merge fails those two tests and none of the others. That is the whole argument for them.

### 19. A failure with no message was not counted as a failure

`str(RuntimeError())` is `""`, and every consumer of `RunOutcome.error` tests it for truth — the failure count, the `failed` label, the JSON `error` field. Such a repository was silently demoted to `findings`. The exception class name now stands in.

Another instance of the recurring theme in this PR: *an unusable result read as an absence of problems.*

### 20. `updated` could hide outstanding work

The status checked what had been *done* before what *remained*, so a partial remediation — some pins rewritten, others still stale, exit code 3 — was labelled `updated`, telling the reader nothing further was needed.

What remains is now tested first. `updated` means the outstanding work is finished; `findings` means it is not. Two new cases pin the distinction: partial remediation reports `findings`, complete remediation still reports `updated`.

### 21–23. Accuracy

The README and `_run_multi_repo`'s docstring both still promised "twenty repositories cost one query" without qualifying it by release policy — the round-4 prerelease guard made that wrong in a second way. And `AllowListResolver.resolve` logged `"Cooldown active"` as the reason for bypassing its cache even when prerelease eligibility had caused it, which would mislead anyone reading debug output.

## Validation

| mutation | result |
| --- | --- |
| Statistics logging merges the tally again *(the original bug)* | ✗ 2 failures, both in `TestRealValidationPath` |
| Empty exception message left empty | ✗ 1 failure |
| `updated` evaluated before what remains | ✗ 2 failures |

- **1512 tests** passing, coverage 83.5%
- All **30** `prek` hooks pass

**Two tests in this PR have now passed against broken code**, both caught by mutation rather than by review: the live-heading test reading the closing table, and the cache-tally tests reading the counter instead of a real run. The second one, once rewritten, immediately caught the double-count above. Worth recording as the strongest evidence that the mutation step is doing real work here rather than ceremony.


---

# Review round 6

Three, all small — the rounds are converging.

**24.** The root-repository shortcut re-enabled the environment organisation *unconditionally*, so a configuration that had deliberately turned it off was honoured by an ordinary single-repository run but silently overridden the moment a wrapper added `--multi-repo`. The shortcut now restores whatever was configured; a genuine sweep still forces it off.

**25.** Round 5's fallback for a message-less exception reached `RunOutcome` but not the log line or the console `failed:` line, both of which still interpolated the bare exception — so the user saw `failed:` with nothing after it. Computed once now, and used for every representation.

**26.** The README's status table still described `updated` as "the run rewrote something on disk", which round 5's precedence change made wrong: a partial remediation rewrites files and is deliberately labelled `findings`.

| mutation | result |
| --- | --- |
| Shortcut overrides an explicitly disabled setting | ✗ 1 failure |
| Console line interpolates the bare exception | ✗ 1 failure |

- **1514 tests** passing, coverage 83.5%
- All **30** `prek` hooks pass


---

# Review round 7

Four. Two of them residue from earlier rounds, in places those rounds' tests could not look.

### 27. The auto-fixer's display was a second route to standard output

The sharpest catch of the seven. `AutoFixer` gates its Rich `Live` display on `self.logger.getEffectiveLevel() < logging.ERROR`. The command layer sets that level, so the CLI was safe — but a caller of `run_linter` never does, and round 3 silenced only the stages consulting `CLIOptions.quiet`.

**Round 3's own test could not have found it.** That test used repositories with *no workflows*, chosen precisely because they reach the "No workflows found" message without needing the network — and that same choice guaranteed the fixer never ran. A structural gap, not an oversight.

`AutoFixer` now takes `quiet` (default `False`, so library behaviour is unchanged) and the predicate is extracted into `_show_live_updates()`, which was previously a local inside a long batch routine and reachable only by running the fixer.

### 28. Discovery followed symlinks without tracking identity

A container holding a checkout *and* a link to it reported the same working tree twice — under `--update-allow-list`, rewriting one tree once per name. A link pointing back into the searched tree recursed until the depth ran out.

Identity is now tracked by resolved path, with the *first* path reported so output still names what the caller asked about.

### 29. An aborted validation dropped its reason

`ValidationAbortedError` carries a generic `message` and a specific `reason`; `str(e)` joins them. The short-circuit recorded `e.message` alone, so JSON reported `Validation aborted: Unable to validate...` and omitted the network or authentication detail underneath.

### 30. The design document claimed a shared GitHub client

§11 said the sweep shares "one `ValidationCache`, one GitHub client". It shares the cache; it does **not** share the client — each repository opens its own, because the validator and auto-fixer each build one inside their own async context.

Rather than bolt on a late refactor, the document now records what shipped and why: what client sharing would save is *connection setup*, not API calls, and the calls are already saved by the shared cache. Left open as an optimisation if a sweep ever proves connection-bound. The efficiency claim that justifies the feature — one latest-release lookup rather than twenty — is implemented and unaffected.

## Validation

| mutation | result |
| --- | --- |
| Fixer display ignores the caller's silence | ✗ 1 failure |
| Stage does not pass `quiet` to the fixer | ✗ 1 failure |
| Drop the discovery identity tracking | ✗ 2 failures |
| Identify directories by parent rather than resolved path | ✗ 12 failures |

The last is the guard against over-identifying: a coarser identity would collapse genuinely separate checkouts, which is worse than the bug being fixed.

- **1520 tests** passing, coverage 83.5%
- All **30** `prek` hooks pass


---

# Review rounds 8 and 9

### Round 8 — three, one of them a regression round 7 introduced

**31. Identity tracking hid repositories inside the requested depth.** Round 7's symlink fix marked a directory "visited" by identity alone. A directory first reached through a *deep* symbolic link arrives with little budget left; recording it as merely seen then kept a shallower, better-funded route from exploring it — so a repository well within `--repo-depth` could vanish. That is a worse failure than the duplication being fixed.

The **budget** each identity was explored with is now recorded, and a larger one supersedes a smaller. Budgets strictly decrease and an identity is re-entered only with a strictly larger one, so it still terminates on a symlink loop. Repository reporting is deduplicated separately, so nothing is emitted twice.

`_children` now also **sorts**, making traversal deterministic — which matters because *which* of several names for one directory gets reported depends on which is reached first.

**32–33. The message-less exception fallback** existed at the sweep level but not in the scan or validation handlers. All three now share one `_describe_exception` helper.

### Round 9 — one

**34.** `_repository_label` took the basename of the path as given. A caller naming a repository `Path(".")` has no basename, so the live heading, the summary row and the JSON `repository` field were all blank. It resolves first now, with the path itself as the last resort for a checkout at the filesystem root.

## A CI failure worth recording

Round 7 failed Python Tests on **all five** versions. The cause was **my test, not the code**: `test_a_symlink_to_a_checkout_is_not_a_second_repository` asserted which of two names a symlinked repository is reported under, and that depended on `iterdir()` order — creation order on macOS, different on Linux. It passed locally for a reason unrelated to correctness.

Round 8 fixed it at both levels: sorted traversal makes the order deterministic everywhere, and the assertion no longer cares which name wins:

```python
assert len(found) == 1
assert found[0].resolve() == repository.resolve()
```

A separate 3.12 failure on `a356cea` was **not** a test failure — the job aborted 19 seconds in during runner setup (`The operation was aborted due to timeout`, with a harden-runner cache contention warning). Re-running that job passed.

## Validation

| mutation | result |
| --- | --- |
| Identity marked visited without its budget | ✗ 1 failure |
| Repositories not deduplicated by identity | ✗ 1 failure |
| Empty exception message left empty everywhere | ✗ 6 failures |
| Root label from the unresolved basename | ✗ 2 failures |
| No fallback for a filesystem-root checkout | ✗ 1 failure |

- **1528 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass
- All **24** CI checks green on the preceding commit

---

## Where this landed

Nine review rounds, thirty-four defects. The shape of them is worth stating, because it is not what I expected going in: **one** was in the feature's core logic. The rest were almost entirely two recurring failure modes —

- *an unusable result read as an absence of problems* (a failed scan reported as findings, a message-less exception read as no failure, an unresolvable check reported as clean, an incomplete check sharing a label with a complete one); and
- *state belonging to one repository reaching another* (the workflow organisation, the Dependabot cooldown, the release-policy cache, the cache-hit counter, the label, the effective silence).

Both are properties of turning a single-repository tool into one that visits many, and neither is visible from inside a single run. Three of the defects were introduced by fixes for earlier ones, and two were found only because a test was mutated and did not fail.


---

# Review round 10

Two, and the first is the worst instance of a pattern that has run through this whole review.

### 35. A rewrite that failed to write was reported as success

Under `--update-actions`, a stale call is *planned* into `fixes_by_file` rather than recorded in `stale_actions_summary`. If the rewrite then fails, the file is dropped from the applied fixes and appears in neither. There is no validation error for a pin that was merely out of date, so nothing else in the run notices.

The result: `outdated == 0`, `files_changed == 0`, `defects == 0`, status **`clean`**, exit **`0`** — for a run that did none of the work it was asked to do.

`AutoFixer` now records the files it could not write, `_AutoFixOutcome` and `RunOutcome` carry them, the status treats them as outstanding, and `_determine_exit_code` fails the run. That last part is a **deliberate behaviour change beyond the sweep**: a single-repository `--update-actions` run that could not write also stops claiming success. Worth a second opinion, though the alternative is a CI job that silently does nothing.

### 36. Per-repository preparation sat outside the failure boundary

Resolving a repository's cooldown reads its own `dependabot.yml`, and a file that is not valid UTF-8 raises past the resolver's handling of `OSError` and `yaml.YAMLError`. Because that happened *before* the `try`, it aborted the entire sweep — contradicting the feature's central promise that one bad checkout costs only itself. Preparation now sits inside the same boundary, with `ConfigurationError` still re-raised.

The mutation for this reproduces the exact `UnicodeDecodeError`, and the test asserts the healthy repository is still visited.

## Validation

| mutation | result |
| --- | --- |
| Do not record write failures | ✗ 1 failure |
| Failed rewrite still exits successfully | ✗ 2 failures |
| Failed rewrite is not an outstanding finding | ✗ 1 failure |
| Count never reaches `RunOutcome` | ✗ 1 failure *(see below)* |
| Preparation outside the failure boundary | ✗ 1 failure |

**The fourth did not bite on the first attempt.** Every test constructed `RunOutcome(write_failures=...)` directly, so nothing exercised the wiring from the fixer's outcome into the run's. That is the *third* time in this PR that mutation testing has caught a hole in my tests rather than in the code — the other two being the live-heading test reading the closing table, and the cache-tally tests reading the counter instead of a real run.

- **1538 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass


---

# Review round 11

Three, and the first is the same defect as round 10 seen **one level up**.

### 37. The command layer read the container's cooldown before dispatching

Round 10 moved per-repository preparation inside the sweep's failure boundary. But the command function resolves a cooldown *before* `run_linter` dispatches at all — against the container path. In a sweep that value is discarded in favour of each checkout's own, so it was read and announced for nothing, and an unreadable container file aborted the whole command before any per-repository boundary existed.

A sweep now defers the resolution entirely. `0` is safe as a template value since every repository overwrites it, and an explicit `--cooldown` still wins through the per-repository path.

### 38. The cache-hit baseline was taken at construction

Round 4's fix recorded the baseline in `__init__`. A validator entered twice therefore counted the first pass again on the second `__aexit__`, and hits made through the shared cache between construction and entry were misattributed. Taken on context entry now, so each pass reports only its own.

### 39. A stale duplicate

One thread was raised against `17a24e39` for a defect already fixed in `e8685ba6`. Replied and resolved.

## Validation

| mutation | result |
| --- | --- |
| Sweep still reads the container's cooldown | ✗ 1 failure |
| Skip the resolution for **everyone** | ✗ 1 failure *(see below)* |
| Baseline at construction rather than entry | ✗ 2 failures |

**The second did not bite at first, and this one is worth dwelling on.** Hardcoding `config.cooldown_days = 0` broke *nothing* in the entire suite: `test_cooldown.py` exercises the resolver thoroughly, but nothing ever asserted that the command layer calls it. A later simplification of my conditional would have silently disabled cooldowns for every single-repository user — a pre-existing gap, not one I introduced.

That test now exists, paired with its sweep counterpart.

- **1543 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass

Four times now, mutation testing has found a hole in the tests rather than in the code. Three were mine; this one predated the PR.


---

# Review round 12

Two suppressed comments, and the first is the same hole as round 10 seen one level further up.

### 40. A whole-stage auto-fix failure was invisible

`_run_auto_fix_stage` catches everything, logs a warning and returns an **all-empty** outcome — deliberately, so validation results still reach the reader. But that leaves nothing whatsoever to show the requested fixing never happened: no applied fixes, no stale calls, and no validation error for a pin that was merely out of date. With `--update-actions`, a failure in setup or version resolution meant a run that reported success having done none of the work.

The stage now records *why* it failed, and that reaches `RunOutcome`, the sweep status and the JSON document.

**Whether it fails the run depends on what was asked for**, and this needed a correction mid-fix. My first cut failed the exit code on *any* stage error — which broke four existing tests, correctly: `auto_fix` defaults to true, so that would fail every offline run. This codebase already has a principle for exactly this, in the allow-list check's *"a developer offline on a train must still be able to commit"*. So a stage failure stays advisory by default, and fails only under `--update-actions`, where the caller explicitly asked for work to be done.

Worth flagging for a human opinion, since it is a judgement call rather than a mechanical fix.

### 41. The aggregate JSON omitted both invisible failure kinds

Neither a failed rewrite nor a failed stage produces a validation error, so a consumer reading `results` alone found nothing to explain a non-zero exit code. The per-repository entry now carries `write_failures` and `autofix_error`.

## Validation

| mutation | result |
| --- | --- |
| Failed stage never fails an update run | ✗ 1 failure |
| Failed stage fails **every** run, offline included | ✗ 1 failure |
| Failed stage is not an outstanding finding | ✗ 1 failure |
| Invisible failures absent from the JSON | ✗ 1 failure |
| Stage error never reaches the outcome | ✗ 1 failure *(see below)* |

**The last did not bite at first — the fifth time in this PR.** Exactly as in round 10, every test constructed `RunOutcome(autofix_error=...)` directly, so nothing exercised the wiring from the stage's outcome into the run's. The same gap, in the same shape, one round later. `TestWriteFailuresReachTheOutcome` now covers both fields.

- **1550 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass

---

## Stopping here

Twelve rounds, forty-one defects. Later rounds found 2, 3 and 2 — narrowing in significance rather than converging to zero, and the remainder are increasingly about JSON field completeness and library-caller edge cases. Those are better tracked as issues against a merged feature than as further growth of a commit already spanning 24 files.

The pattern across all of it is worth recording, because it was not what I expected. **One** defect was in the feature's core logic. The rest were two recurring failure modes, both properties of turning a single-repository tool into one that visits many, and neither visible from inside a single run:

- **An unusable result read as an absence of problems** — a failed scan reported as findings, a message-less exception read as no failure, an unresolvable check reported as clean, a failed rewrite reported as success, a swallowed stage failure reported as nothing at all.
- **State belonging to one repository reaching another** — the workflow organisation, the Dependabot cooldown, the release-policy cache, the cache-hit counter, the label, the effective silence, the container's cooldown.

Four defects were introduced by fixes for earlier ones. Five were found only because a test was mutated and failed to fail — three of those being holes in my own tests, and one a gap that predated this PR entirely.


---

# Review round 13 — and stopping here

Six items: two threads and four suppressed. **Four fixed, two deferred to #323.**

### 42. `--files` was refused only after backend preflight

The check lived in `_run_multi_repo`, which `run_linter` reaches *after* the command has configured and preflighted the validation backend. That preflight makes network calls and can `sys.exit(0)` when rate-limited — so an invalid `--files --multi-repo` invocation could **exit successfully** without the error ever being reported.

One `_reject_files_with_multi_repo` helper now serves both the command (before preflight) and the sweep (for library callers reaching it directly). The test asserts no backend was configured, which is what actually pins the ordering.

### 43–45. Documentation accuracy

The README's aggregate-JSON example omitted `write_failures` and `autofix_error`, giving consumers an incomplete schema for fields that are always present. And two docstrings I wrote in round 4 still described the cache baseline as taken at construction, which round 11 changed to context entry — stale by my own hand, and contradicted by the tests directly below them.

### Deferred to #323 — a cached release can downgrade a pin

Both threads describe one hazard: a cached entry is the newest release *as of when it was cached*, and nothing checks whether it is newer than what the file already pins. If Dependabot, Renovate or a human advances a pin inside the cache TTL, the next `--update-actions` walks it **backwards**. For allow-list pins it is worse — a restored `LatestRelease` has no `commit_tags`, which is exactly the data classification uses to tell *behind* from *ahead*.

A downgrade is materially worse than a stale pin, so this is not a small finding. But it is **pre-existing**, and I verified that before deciding:

```python
# upstream/main, auto_fix_versions.py — no policy guard at all
cached_version = self._cache.get_latest_version(repo_key)
```

This PR *added* `_persistent_cache_usable` and the cooldown and prerelease bypasses; the default-policy staleness window is the residue. It affects ordinary single-repository runs on `main` today, independently of this feature, and fixing it properly means either verifying direction before applying or changing the cache format to retain ordering data.

#323 records the mechanism, both call sites, how the window opens in practice, three candidate approaches and acceptance criteria.

## Validation

| mutation | result |
| --- | --- |
| Rejection happens only inside the sweep, after preflight | ✗ 1 failure |
| Every sweep refused regardless of `--files` | ✗ 39 failures |

- **1551 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass

## Stopping here

Thirteen rounds, forty-five defects addressed and one deferred. Later rounds found 2, 2 and 4 — narrowing in significance rather than converging to zero, and increasingly about schema completeness, library-caller edge cases and my own stale prose. Those are better tracked against a merged feature than as further growth of a commit already spanning 24 files.

**The shape of the whole review is the part worth keeping.** One defect was in the feature's core logic. The rest were two recurring failure modes, both properties of turning a single-repository tool into one that visits many, and neither visible from inside a single run:

- **An unusable result read as an absence of problems** — a failed scan reported as findings; a message-less exception read as no failure; an unresolvable check reported as clean; a failed rewrite reported as success; a swallowed stage failure reported as nothing at all; and an invalid invocation retired as success because a rate limit got there first.
- **State belonging to one repository reaching another** — the workflow organisation, the Dependabot cooldown, the release-policy cache, the cache-hit counter, the row label, the effective silence, the container's cooldown.

Four defects were introduced by fixes for earlier ones. **Five were found only because a test was mutated and failed to fail** — three holes in my own tests, one a gap that predated this work entirely, and one that immediately caught a real double-count once rewritten. That step earned its place; without it, five of these would have shipped behind green tests.


---

# Review round 14

One thread, and it is the *same failure mode* for the fourteenth time — which is itself the finding.

### 46. An unreadable sweep root read as an empty container

`_children` skips a directory it cannot list, logging a warning. That is right for a **descendant**: one bad directory should not cost the rest of the sweep its results.

Applied to the **root**, it meant nothing was examined and nothing was reported. `find_repositories` returned `[]`, `_run_multi_repo` took the empty-container path, and the run exited `0` with `"repositories": []` — indistinguishable from a container that genuinely holds no repositories. Reachable both by an unreadable root passed to `run_linter()` and by one that becomes unreadable after CLI validation.

`_children` now delegates to a strict `_list_subdirectories`, and the root is listed through the strict one before descending; the driver maps the failure to `RUNTIME_ERROR`. The root is listed twice as a result, which is a fair price once per sweep for keeping the recursion in one shape rather than threading a `strict` flag through it.

| mutation | result |
| --- | --- |
| Root listing failure swallowed like any other | ✗ 1 failure |
| Descendants no longer skipped, every failure fatal | ✗ 1 failure |
| Driver does not handle an unreadable root | ✗ 1 failure |

The second guards the opposite error, and paired "still succeeds" tests at both levels stop this degrading into failing every empty sweep.

- **1555 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass

---

## Final tally

Fourteen rounds. **Forty-six defects fixed, one deferred to #323.**

The distribution is the part worth keeping, because it was not what I expected when I opened this. **One** defect was in the feature's core logic — the sweep loop itself was right almost immediately. Everything else was two failure modes, both inherent to turning a single-repository tool into one that visits many, and neither visible from inside a single run:

**An unusable result read as an absence of problems.** A failed scan reported as findings. A message-less exception read as no failure. An unresolvable check reported as clean. A failed rewrite reported as success. A swallowed stage failure reported as nothing at all. An invalid invocation retired as success because a rate limit got there first. An unreadable root reported as an empty container.

**State belonging to one repository reaching another.** The workflow organisation. The Dependabot cooldown. The release-policy cache. The cache-hit counter. The row label. The effective silence. The container's cooldown.

Four defects were introduced by fixes for earlier ones — each time by generalising a rule one step too far, and each caught by an inverse mutation asking whether the correction had gone too far rather than not far enough.

**Five were found only because a test was mutated and failed to fail**: three holes in my own tests, one gap that predated this work entirely, and one that immediately caught a real double-count once rewritten. Without that step, five of these would have shipped behind a green suite.


---

# Review round 15

No threads. Two suppressed comments, and both were **symmetry gaps** — a rule applied to one of a pair but not its sibling.

### 47. A failed allow-list update was swallowed

Exactly the defect fixed in round 10 for the action fixer, left standing on the allow-list side. `_run_allow_list_stage` catches everything and returns `None` whenever verification is off — which is right in advisory mode, but wrong when `--update-allow-list` explicitly asked for work. The outcome then carried no failure and no applied-fix count, so the repository was labelled `clean` and the run exited `0`, potentially after earlier files had already been rewritten.

A failed update now surfaces as an unresolved check, and `_determine_exit_code` fails on an unresolved result when *either* verification or updating was requested. Stale pins stay advisory without `--verify-allow-list`, as before.

### 48. The fixer's silence came from `--quiet` alone

Round 7 gave `AutoFixer` an explicit `quiet`, and round 3 taught the *sweep* to derive its own silence in JSON mode. The single-repository path did neither: `_run_auto_fix_stage` passed `options.quiet` straight through, and a programmatic caller gets none of the command layer's JSON coercion — so `CLIOptions(output_format="json", quiet=False)` would open the live display on standard output ahead of the document.

| mutation | result |
| --- | --- |
| Failed allow-list update returns `None` again | ✗ 2 failures |
| Update-only failure does not reach the exit code | ✗ 1 failure |
| Single-run JSON does not silence the fixer | ✗ 1 failure |
| Fixer silenced for every run | ✗ 1 failure |

- **1559 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass

---

## Closing

Fifteen rounds. **Forty-eight defects fixed, one deferred to #323.**

The last three rounds found 1, 2 and 2, and all of them were the same two things: the recurring failure modes below, or a fix applied to one side of a pair and not the other. That second category is now closed — the action fixer and the allow-list stage handle a swallowed failure the same way, and every path that writes to standard output derives its silence the same way.

**One** defect was in the feature's core logic. The rest divided between:

**An unusable result read as an absence of problems** — a failed scan reported as findings; a message-less exception read as no failure; an unresolvable check reported as clean; a failed rewrite reported as success; a swallowed stage failure reported as nothing at all; an invalid invocation retired as success because a rate limit got there first; an unreadable root reported as an empty container; a failed update reported as a clean repository.

**State belonging to one repository reaching another** — the workflow organisation, the Dependabot cooldown, the release-policy cache, the cache-hit counter, the row label, the effective silence, the container's cooldown.

Both are properties of turning a single-repository tool into one that visits many, and neither is visible from inside a single run. Four defects were introduced by fixes for earlier ones, each by generalising a rule one step too far, and each caught by an inverse mutation asking whether the correction had overshot.

**Five were found only because a test was mutated and failed to fail** — three holes in my own tests, one predating this work, and one that immediately caught a real double-count once rewritten. Without that step, five of these would have shipped behind a green suite.


---

# Review round 16

Two threads and one suppressed. **Two fixed, one deferred to #324.**

### 49. Only the fixer got the derived silence

Round 15 derived the JSON silence and handed it to `AutoFixer` — but the stage prints from two other places, the applied-changes listing and the failure notice, and both were still gated on `options.quiet` alone. The fixer went quiet and the stage kept talking. Derived once at the top of the stage now, and used for all three.

I fixed the thing that was named rather than the class it belonged to. *"Derive the effective silence once and use it for every display guard"* was the actual instruction, and it is now what the code does.

### 50. The strict root listing was discarded

Round 14's fix listed the sweep root strictly, then let the traversal list it *again* through the tolerant path — which I described at the time as "a fair price". It was not: if the root became unreadable between the two listings, the second would swallow the failure and discovery would return an empty list, reopening exactly the ambiguity the strict listing exists to close.

The listing is reused now, and a test pins that the root is read **exactly once** — the only assertion that distinguishes reuse from re-listing without simulating the race.

### Deferred to #324 — the preflight exits before any output contract is met

`check_rate_limit_and_exit_if_needed` calls `sys.exit(0)` when rate-limited, terminating inside preflight before the command dispatches. So a promised aggregate JSON document is never emitted, and validation after preflight never runs.

Not fixed here, and the reasoning is worth stating because the suggested fix does not work: moving sweep discovery ahead of preflight would surface an unreadable root, but a rate-limited JSON run would **still** emit nothing — the process is already gone. The real fix is that preflight must not terminate at all; rate-limiting should be a status the caller decides about, not a `sys.exit` inside the API client. That is a refactor of shared behaviour affecting every mode, and it predates this work.

#324 also notes that "rate-limited, therefore report success" is itself an instance of the pattern this review kept finding, and that it matters for the weekly sweep — which would otherwise report a clean estate on any Monday it happened to be rate-limited.

| mutation | result |
| --- | --- |
| Stage displays revert to the quiet flag alone | ✗ 1 failure |
| Root listed twice, second listing tolerant | ✗ 1 failure |

- **1562 tests** passing, coverage 83.6%
- All **30** `prek` hooks pass

---

## Where this ends

Sixteen rounds. **Fifty defects fixed, two deferred to #323 and #324** — both pre-existing, both broader than this feature, both verified against `main` before deferring rather than assumed.

One defect was in the feature's core logic. The rest were three shapes:

**An unusable result read as an absence of problems** — a failed scan reported as findings; a message-less exception read as no failure; an unresolvable check reported as clean; a failed rewrite reported as success; a swallowed stage failure reported as nothing; an invalid invocation retired as success because a rate limit got there first; an unreadable root reported as an empty container; a failed update reported as a clean repository.

**State belonging to one repository reaching another** — the workflow organisation, the Dependabot cooldown, the release-policy cache, the cache-hit counter, the row label, the effective silence, the container's cooldown.

**A rule applied to one of a pair but not its sibling** — the action fixer against the allow-list stage, one display guard against the other two, the strict listing against the tolerant one.

Four defects came from fixes for earlier ones, each by generalising a rule one step too far, and each caught by an inverse mutation asking whether the correction had overshot. **Six were found only because a test was mutated and failed to fail**, of which four were holes in my own tests and one predated this work entirely.
