### PR TITLE
Fix: refuse to move a pin backwards from cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,22 @@ gha-workflow-linter lint --auto-fix --update-actions
 gha-workflow-linter lint --auto-fix --no-update-actions
 ```
 
+**Updates do not move a pin backwards.** A resolved "latest" release
+names the newest at the moment of discovery, and a cached one can be
+older still — so a pin something else has advanced in the meantime
+(Dependabot, Renovate, a colleague, an earlier run) can be newer than the
+target. The linter leaves such a call alone rather than rewriting it
+backwards and reporting the downgrade as a successful update. The same
+applies when repairing a broken pin: a reference that no longer resolves
+is not replaced by a release older than the one its comment claims.
+
+Establishing that needs a version to compare, which comes from the
+reference when that is a version tag, and otherwise from the version
+comment. A commit pin carrying neither states no version, so it takes
+the ordinary update path. An action that has moved to a new repository
+is likewise exempt, since two projects' version numbers are not
+comparable.
+
 **Skip Testing Actions**: By default, auto-fix skips actions with 'test' in
 their comments (case-insensitive). This is useful when you have experimental or
 testing branches that you don't want to update yet. Use `--fix-test-calls` to
@@ -469,12 +485,19 @@ Twenty repositories cost one query rather than twenty.
 
 That sharing stops under a non-default release policy. A cooldown
 targets an older release by design, and prerelease eligibility changes
-which releases count as candidates; the cache records no more than a
-tag and a SHA, so a cached answer cannot say which policy produced it.
-Rather than let one repository's policy leak into another's, the sweep
-repeats the lookup per repository — twenty such repositories cost
+which releases count as candidates; the cache records the target and
+the releases ranked behind it, but not which policy chose them, so a
+cached answer cannot say whether it means the same thing to the next
+reader. Rather than let one repository's policy leak into another's, the
+sweep repeats the lookup per repository — twenty such repositories cost
 twenty queries. Correctness wins over the saving here, and the saving
 returns as soon as the default policy applies.
+
+One host is also resolved afresh when a pin sits on a release the cached
+entry never saw — the entry names the newest release at the moment of
+writing, and anything else may have advanced the pin inside the cache
+TTL. Trusting it there would report a current pin as stale and rewrite it
+backwards. A pin the cached entry can place still costs nothing.
 
 Each repository still gets its own workflow organisation and its own
 Dependabot cooldown, since both belong to the repository rather than to

--- a/docs/ALLOW_LIST_FEATURE.md
+++ b/docs/ALLOW_LIST_FEATURE.md
@@ -1162,10 +1162,12 @@ Semantics:
   open as an optimisation if a sweep ever proves connection-bound.
 
   Note also that cache sharing is suspended under a non-default release
-  policy: a cooldown or prerelease eligibility makes a cached
-  `(tag, sha)` policy-dependent, and the cache records no policy, so
-  each repository resolves for itself rather than inheriting another's
-  answer.
+  policy: a cooldown or prerelease eligibility makes a cached target
+  policy-dependent, and the cache records no policy, so each repository
+  resolves for itself rather than inheriting another's answer. A single
+  host is likewise re-resolved when a pin names a commit the cached
+  entry cannot place, since an entry written before that release existed
+  would report a current pin as stale and rewrite it backwards.
 - **Per-repository state**: workflow org (§6.3) and Dependabot cooldown
   (`dependabot.resolve_cooldown`) are resolved per repository, because
   both are repository properties.

--- a/src/gha_workflow_linter/allow_list_check.py
+++ b/src/gha_workflow_linter/allow_list_check.py
@@ -496,10 +496,12 @@ def _pin_is_at_or_ahead(ref: str, latest: LatestRelease) -> bool:
     Returns:
         ``True`` when the pinned commit belongs to a known release whose
         version is greater than or equal to the target's. ``False`` when
-        it belongs to no known release, and whenever the target carries
-        no commit map -- a cache-restored record, which the resolver only
-        produces when no cooldown applied and the target really is the
-        newest release.
+        it belongs to no known release -- a genuinely unknown commit,
+        which keeps the ``STALE`` classification because its position
+        cannot be established. A cache-restored target carries its commit
+        map too, and the resolver re-resolves any host whose cached
+        target cannot place a pinned commit, so this does not silently
+        answer ``False`` for want of data.
     """
     pinned_tag = latest.tag_for_commit(ref)
     if pinned_tag is None:
@@ -672,6 +674,32 @@ def classify_pins(
     return findings
 
 
+def _pinned_commits(
+    pins: Sequence[AllowListPin],
+) -> dict[str, set[str]]:
+    """Group the commits pinned against each host repository.
+
+    The resolver needs these to decide whether a cached answer is still
+    sufficient: a cached target cannot place a commit published after it
+    was written, and treating such a pin as stale would rewrite it
+    backwards.
+
+    Args:
+        pins: The detected pins, in scan order.
+
+    Returns:
+        Host repository key to the lowercased commit SHAs pinned against
+        it. Pins that name no commit at all are omitted: an ``UNPINNED``
+        pin has no position to establish.
+    """
+    commits: dict[str, set[str]] = {}
+    for pin in pins:
+        ref = pin.spec.ref
+        if _SHA_RE.match(ref):
+            commits.setdefault(host_key(pin), set()).add(ref.lower())
+    return commits
+
+
 class AllowListChecker:
     """Scan, resolve and classify allow-list pins in one pass.
 
@@ -752,7 +780,7 @@ class AllowListChecker:
         # the resolver.
         repo_keys = list(dict.fromkeys(host_key(pin) for pin in pins))
         hosts = await AllowListResolver(self.config, self.cache).resolve(
-            repo_keys
+            repo_keys, _pinned_commits(pins)
         )
         unresolved = {
             repo_key: UNRESOLVED_REASON

--- a/src/gha_workflow_linter/allow_list_resolver.py
+++ b/src/gha_workflow_linter/allow_list_resolver.py
@@ -27,8 +27,12 @@ caller depends on rather than incidental implementation details:
   whether enforcement was requested.
 * **Each distinct host repository costs one lookup.** Twenty pins naming
   ``lfreleng-actions/.github`` resolve it once, and a repeated run within
-  the cache TTL resolves it zero times -- except while a cooldown is
-  active, when the cache is bypassed entirely. See :attr:`cache_usable`.
+  the cache TTL resolves it zero times -- except while a cooldown or
+  prerelease eligibility applies, when the cache is bypassed entirely
+  (see :attr:`cache_usable`), and except when a pin sits on a release the
+  cached entry never saw, when that one repository is resolved afresh
+  rather than risk recommending a downgrade (see
+  :meth:`AllowListResolver._cache_can_place`).
 """
 
 from __future__ import annotations
@@ -50,7 +54,7 @@ from .models import ValidationMethod
 from .paths import base_repository
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
     from .cache import ValidationCache
     from .models import Config
@@ -97,18 +101,15 @@ class AllowListResolver:
     def cache_usable(self) -> bool:
         """Whether persisted results may be used and written this run.
 
-        The cache stores ``(tag, sha)`` and nothing else, so it cannot
-        record which release policy produced an entry. Two settings make
-        up that policy.
+        The cache stores a target and the commit-to-tag map behind it,
+        but no record of the release policy that produced either. Two
+        settings make up that policy.
 
-        Under a **cooldown**, a restored
-        :class:`~gha_workflow_linter.latest_release.LatestRelease` has an
-        empty ``commit_tags`` and cannot say whether a pin is behind the
-        target or ahead of it. That is harmless without a cooldown --
-        the target is then the newest release, so nothing can be ahead of
-        it -- but under a cooldown the target is deliberately an *older*
-        release, and losing direction would turn a correct pin into a
-        recommendation to downgrade.
+        A **cooldown** deliberately selects an *older* release than the
+        newest in existence, so a cooldown-shifted entry read back by a
+        run with no cooldown would suppress a valid update, and a
+        default-policy entry read under a cooldown would offer a release
+        the caller is not yet entitled to.
 
         **Prerelease eligibility** changes which releases are candidates
         at all, so a prerelease-enabled run could cache a prerelease that
@@ -128,7 +129,9 @@ class AllowListResolver:
         )
 
     async def resolve(
-        self, repo_keys: Iterable[str]
+        self,
+        repo_keys: Iterable[str],
+        pinned: Mapping[str, Iterable[str]] | None = None,
     ) -> dict[str, LatestRelease | None]:
         """
         Resolve the latest release of each distinct host repository.
@@ -136,11 +139,17 @@ class AllowListResolver:
         Repository keys are de-duplicated first, so a host shared by many
         pins costs exactly one lookup. Cached repositories are answered
         without touching a backend at all, unless :attr:`cache_usable` is
-        ``False``.
+        ``False`` or the cached answer cannot place one of the commits
+        ``pinned`` names.
 
         Args:
             repo_keys: Host repository keys, ``owner/repo``. Duplicates
                 and empty entries are ignored.
+            pinned: Commits already pinned against each host repository.
+                Supplying them lets a cached answer be checked for
+                sufficiency before it is trusted; omitting them keeps the
+                cache unconditional, which is only safe for a caller that
+                will not rewrite anything.
 
         Returns:
             Dictionary mapping each distinct repository key to its latest
@@ -156,7 +165,9 @@ class AllowListResolver:
         pending: list[str] = []
         for repo_key in unique:
             cached = self._cached(repo_key) if cache_usable else None
-            if cached is not None:
+            if cached is not None and self._cache_can_place(
+                repo_key, cached, (pinned or {}).get(repo_key, ())
+            ):
                 results[repo_key] = cached
             else:
                 pending.append(repo_key)
@@ -184,6 +195,52 @@ class AllowListResolver:
 
         return results
 
+    def _cache_can_place(
+        self,
+        repo_key: str,
+        cached: LatestRelease,
+        pinned: Iterable[str],
+    ) -> bool:
+        """
+        Report whether a cached answer can place every pinned commit.
+
+        A cached entry is the newest release *as of the moment it was
+        written*, and it stays usable for the whole TTL. If anything else
+        advances a pin inside that window -- Dependabot, Renovate, a
+        human, or an earlier repository in the same sweep -- the pin ends
+        up on a release the cached entry never saw. The classifier then
+        finds a commit it cannot place, calls the pin stale, and
+        ``--update-allow-list`` rewrites it *backwards*.
+
+        A commit the entry can place is safe either way: it belongs to a
+        release the resolution ranked, so the classifier can compare
+        versions and decide direction for itself. Only an unplaceable
+        commit forces a live lookup, which makes this cheap in the case
+        that matters -- nothing to do -- and precise in the case that
+        does not.
+
+        Args:
+            repo_key: Host repository key, for the log line.
+            cached: The release restored from the cache.
+            pinned: Commit SHAs pinned against this host repository.
+
+        Returns:
+            ``True`` when every pinned commit is the cached target or
+            belongs to a release the cached entry recorded.
+        """
+        for commit_sha in pinned:
+            if commit_sha.strip().lower() == cached.commit_sha.strip().lower():
+                continue
+            if cached.tag_for_commit(commit_sha) is not None:
+                continue
+            self.logger.debug(
+                f"Cached latest release {cached.tag} of {repo_key} cannot "
+                f"place pinned commit {commit_sha[:8]}; resolving afresh "
+                f"rather than risk recommending a downgrade"
+            )
+            return False
+        return True
+
     def _cached(self, repo_key: str) -> LatestRelease | None:
         """
         Read a repository's latest release from the persistent cache.
@@ -193,26 +250,31 @@ class AllowListResolver:
 
         Returns:
             The cached release, or ``None`` on a miss, an expired entry,
-            or an unreadable cache. ``published_at`` is always ``None``
-            and ``commit_tags`` always empty: the cache stores only
-            ``(tag, sha)``. Neither is needed once a release has been
-            selected without a cooldown, and :attr:`cache_usable` keeps
-            this path out of the runs where they would be.
+            or an unreadable cache. ``published_at`` is always ``None``:
+            the cache does not persist it, and it is not needed once a
+            release has been selected without a cooldown.
+            ``commit_tags`` is restored, so the record can still place a
+            commit among the releases the original resolution ranked --
+            though not one published after it, which
+            :meth:`_cache_can_place` is there to catch.
         """
         try:
-            cached = self.cache.get_latest_version(repo_key)
+            entry = self.cache.get_latest_version_entry(repo_key)
         except Exception as e:
             self.logger.debug(f"Latest-version cache read failed: {e}")
             return None
 
-        if not cached:
+        if not entry:
             return None
 
-        tag, commit_sha = cached
-        if not tag or not commit_sha:
+        if not entry.latest_tag or not entry.latest_sha:
             return None
 
-        return LatestRelease(tag=tag, commit_sha=commit_sha)
+        return LatestRelease(
+            tag=entry.latest_tag,
+            commit_sha=entry.latest_sha,
+            commit_tags=dict(entry.commit_tags),
+        )
 
     def _store(
         self,
@@ -221,6 +283,11 @@ class AllowListResolver:
     ) -> None:
         """
         Persist freshly resolved releases so the next run costs nothing.
+
+        The commit-to-tag map is stored alongside the target, so a later
+        run can still place a pinned commit among the releases this one
+        ranked instead of assuming the stored target is the newer of the
+        two.
 
         Unresolved repositories are deliberately not cached: a transient
         outage must not be remembered as "this repository has no release"
@@ -238,7 +305,10 @@ class AllowListResolver:
                 if release is None:
                     continue
                 self.cache.put_latest_version(
-                    repo_key, release.tag, release.commit_sha
+                    repo_key,
+                    release.tag,
+                    release.commit_sha,
+                    release.commit_tags,
                 )
                 stored = True
             if stored:

--- a/src/gha_workflow_linter/auto_fix.py
+++ b/src/gha_workflow_linter/auto_fix.py
@@ -32,7 +32,7 @@ from .models import (
     ValidationResult,
 )
 from .patterns import ActionCallPatterns
-from .utils import has_test_comment
+from .utils import has_test_comment, pinned_version
 
 
 class AutoFixer(_VersionResolutionMixin):
@@ -611,97 +611,13 @@ class AutoFixer(_VersionResolutionMixin):
                 has_invalid_ref = (file_path, line_num) in invalid_ref_actions
 
                 if has_invalid_ref:
-                    # For invalid references, try to find a valid replacement
-                    # Priority: 1) version from comment (if valid), 2) latest version, 3) fallback reference
-                    valid_ref: str | None = None
-                    valid_sha: str | None = None
-
-                    # First, check if there's a version comment we can use
-                    if action_call.comment:
-                        comment_text = (
-                            action_call.comment.strip().lstrip("#").strip()
-                        )
-                        if ActionCallPatterns.VERSION_TAG_PATTERN.match(
-                            comment_text
-                        ):
-                            # Try to get SHA for the comment version
-                            if (base_repo_key, comment_text) in sha_map:
-                                valid_sha = sha_map[
-                                    (base_repo_key, comment_text)
-                                ]
-                                valid_ref = comment_text
-                            else:
-                                # Fallback to individual fetch
-                                sha_info = (
-                                    await self._get_commit_sha_for_reference(
-                                        base_repo_key, comment_text
-                                    )
-                                )
-                                if sha_info:
-                                    valid_sha = sha_info["sha"]
-                                    valid_ref = comment_text
-
-                    # If comment version didn't work, try latest version
-                    if not valid_ref:
-                        effective_lookup_repo = base_repo_key
-                        if effective_lookup_repo in latest_versions:
-                            target_ref, cached_sha = latest_versions[
-                                effective_lookup_repo
-                            ]
-                            valid_ref = target_ref
-                            valid_sha = cached_sha
-
-                            # Get SHA if not cached
-                            if not valid_sha:
-                                if (
-                                    effective_lookup_repo,
-                                    target_ref,
-                                ) in sha_map:
-                                    valid_sha = sha_map[
-                                        (effective_lookup_repo, target_ref)
-                                    ]
-                                else:
-                                    sha_info = await self._get_commit_sha_for_reference(
-                                        effective_lookup_repo, target_ref
-                                    )
-                                    valid_sha = (
-                                        sha_info["sha"] if sha_info else None
-                                    )
-
-                    # If still no valid ref, use fallback logic
-                    if not valid_ref:
-                        valid_ref = await self._find_valid_reference(
-                            base_repo_key, action_call.reference
-                        )
-
-                        if not valid_ref:
-                            valid_ref = await self._get_fallback_reference(
-                                base_repo_key, action_call.reference
-                            )
-
-                        if not valid_ref:
-                            # Last resort: use default branch
-                            repo_info = await self._get_repository_info(
-                                base_repo_key
-                            )
-                            valid_ref = (
-                                repo_info.get("default_branch", "main")
-                                if repo_info
-                                else "main"
-                            )
-
-                        if valid_ref and not valid_sha:
-                            if (base_repo_key, valid_ref) in sha_map:
-                                valid_sha = sha_map[(base_repo_key, valid_ref)]
-                            else:
-                                sha_info = (
-                                    await self._get_commit_sha_for_reference(
-                                        base_repo_key, valid_ref
-                                    )
-                                )
-                                valid_sha = (
-                                    sha_info["sha"] if sha_info else None
-                                )
+                    valid_ref, valid_sha = await self._repair_invalid_reference(
+                        action_call,
+                        base_repo_key,
+                        sha_map,
+                        latest_versions,
+                        repo_changed=repo_was_redirected,
+                    )
 
                     # Now build the fix if we have a valid reference
                     # When require_pinned_sha is False, we can fix with just the ref
@@ -877,6 +793,14 @@ class AutoFixer(_VersionResolutionMixin):
                                             Text(update_msg, style="dim")
                                         )
                         elif ref_changed or comment_changed or repo_changed:
+                            if self._moves_backwards(
+                                pinned_version(action_call, existing_comment),
+                                target_ref,
+                                base_repo_key,
+                                repo_changed=repo_changed,
+                            ):
+                                continue
+
                             fixed_line = self._build_fixed_line(
                                 action_call,
                                 final_ref,

--- a/src/gha_workflow_linter/auto_fix_versions.py
+++ b/src/gha_workflow_linter/auto_fix_versions.py
@@ -26,9 +26,12 @@ from .exceptions import GitError
 from .git_validator import _get_remote_tags
 from .models import ValidationMethod
 from .patterns import ActionCallPatterns
+from .utils import comment_text
+from .utils import version_or_none as _version_or_none
 from .version_utils import (
     _find_most_specific_version_tag,
     _get_version_specificity,
+    _is_downgrade,
     _parse_iso_datetime,
     _parse_version,
     _select_version_with_cooldown,
@@ -36,6 +39,8 @@ from .version_utils import (
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from .models import ActionCall
 
 
 class _VersionResolutionMixin(_ReferenceResolutionMixin):
@@ -85,6 +90,167 @@ class _VersionResolutionMixin(_ReferenceResolutionMixin):
         return (
             self.config.cooldown_days <= 0 and not self.config.allow_prerelease
         )
+
+    def _moves_backwards(
+        self,
+        current: str | None,
+        target_tag: str,
+        repo_key: str,
+        *,
+        repo_changed: bool,
+    ) -> bool:
+        """Report whether retargeting a call would move it backwards.
+
+        A resolved "latest" release names the newest at the moment of
+        discovery, and a cached one can be older still: nothing stops
+        Dependabot, Renovate, a colleague or an earlier run advancing a
+        pin inside the cache TTL. The update path treats any differing
+        target as a change to apply, so without this a run rewrites the
+        pin *backwards* and reports the downgrade as a successful update
+        -- reverting a supply-chain fix nobody asked to revert.
+
+        Args:
+            current: The version the call pins now, or ``None`` when it
+                names none. Callers decide which sources may answer;
+                the invalid-reference repair excludes the reference
+                itself, having already established that it is broken.
+            target_tag: The version the run proposes to move it to.
+            repo_key: Repository the call names, for the log line.
+            repo_changed: Whether the call is being moved to another
+                repository. Two projects' version numbers are not
+                comparable -- an action that has moved starts its new
+                home's numbering wherever that project happens to be --
+                so a redirect answers ``False`` outright. Required
+                rather than defaulted, because omitting it is exactly
+                the mistake it exists to prevent, and every call site
+                must state it.
+
+        Returns:
+            ``True`` only when the call provably pins a higher version
+            than the target within one repository. A call naming no
+            version establishes no direction and is left to the ordinary
+            update path.
+        """
+        if repo_changed or current is None:
+            return False
+        if not _is_downgrade(current, target_tag):
+            return False
+
+        self.logger.debug(
+            f"Refusing to move {repo_key} backwards from {current} to "
+            f"{target_tag}: the resolved latest release is older than "
+            f"the pinned one"
+        )
+        return True
+
+    async def _repair_invalid_reference(
+        self,
+        action_call: ActionCall,
+        repo_key: str,
+        sha_map: dict[tuple[str, str], str],
+        latest_versions: dict[str, tuple[str, str]],
+        *,
+        repo_changed: bool,
+    ) -> tuple[str | None, str | None]:
+        """Find a valid reference to replace an invalid one.
+
+        Three sources are consulted in order of fidelity to what the file
+        already says: the version its comment names, the repository's
+        latest release, then a salvaged reference or the default branch.
+
+        The last two are guarded, because both can name a *version*. The
+        comment reaches them only when the version it names could not be
+        resolved at all, which is as likely to mean a rate limit or an
+        outage as a deleted tag -- and the latest release may itself be a
+        cached answer older than the comment. Rewriting a call that
+        claims v5 down to v4 on that evidence would report a downgrade as
+        a repair. The reference is deliberately not consulted for the
+        comparison: it is the thing already established as broken.
+
+        Once something has been refused for going backwards, the repair
+        will accept **only a version at least as new**, and abandons the
+        call otherwise. The branch sources are not a neutral fallback
+        here: replacing a pin that claims v5 with a floating ``main``
+        loses the pin as well as the version, which is a worse outcome
+        than the broken reference it replaces. Leaving it alone is not
+        silent, since the call keeps its validation error.
+
+        Args:
+            action_call: The call carrying the invalid reference.
+            repo_key: Base repository the call names, after any redirect.
+            sha_map: References already resolved in this batch.
+            latest_versions: Latest ``(tag, sha)`` per repository.
+            repo_changed: Whether the call was redirected to another
+                repository, which exempts it from the comparison.
+
+        Returns:
+            The replacement reference and its commit SHA, either of which
+            may be ``None`` when nothing could be established or when
+            everything on offer was older than the version claimed.
+        """
+        # Only a clean version tag is ordering evidence. An arbitrary
+        # comment is not: '# 2026-08-19' would parse as version 2026 and
+        # veto every repair the call could possibly need.
+        claimed = _version_or_none(comment_text(action_call))
+        if claimed:
+            sha = await self._resolve_ref(repo_key, claimed, sha_map)
+            if sha:
+                return claimed, sha
+
+        refused = False
+        latest = latest_versions.get(repo_key)
+        if latest:
+            if not self._moves_backwards(
+                claimed, latest[0], repo_key, repo_changed=repo_changed
+            ):
+                tag, cached_sha = latest
+                return tag, cached_sha or await self._resolve_ref(
+                    repo_key, tag, sha_map
+                )
+            refused = True
+
+        salvaged = await self._find_valid_reference(
+            repo_key, action_call.reference
+        )
+        if salvaged and self._moves_backwards(
+            claimed, salvaged, repo_key, repo_changed=repo_changed
+        ):
+            return None, None
+        if refused and not _version_or_none(salvaged):
+            return None, None
+
+        salvaged = salvaged or await self._get_fallback_reference(
+            repo_key, action_call.reference
+        )
+        if not salvaged:
+            # Last resort: use default branch
+            repo_info = await self._get_repository_info(repo_key)
+            salvaged = (
+                repo_info.get("default_branch", "main") if repo_info else "main"
+            )
+
+        return salvaged, await self._resolve_ref(repo_key, salvaged, sha_map)
+
+    async def _resolve_ref(
+        self,
+        repo_key: str,
+        ref: str,
+        sha_map: dict[tuple[str, str], str],
+    ) -> str | None:
+        """Resolve one reference to a commit, preferring the batch.
+
+        Args:
+            repo_key: Repository the reference belongs to.
+            ref: The reference to resolve.
+            sha_map: References already resolved in this batch.
+
+        Returns:
+            The commit SHA, or ``None`` when it could not be resolved.
+        """
+        if (repo_key, ref) in sha_map:
+            return sha_map[(repo_key, ref)]
+        sha_info = await self._get_commit_sha_for_reference(repo_key, ref)
+        return sha_info["sha"] if sha_info else None
 
     async def _get_latest_versions_batch(
         self, repo_keys: list[str]

--- a/src/gha_workflow_linter/cache.py
+++ b/src/gha_workflow_linter/cache.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -18,6 +18,9 @@ from .models import (  # noqa: TC001
     ValidationMethod,
     ValidationResult,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 # Re-export CacheConfig for backward compatibility
 __all__ = [
@@ -64,6 +67,17 @@ class LatestVersionEntry(BaseModel):
     latest_tag: str = Field(..., description="Latest release/tag name")
     latest_sha: str = Field(..., description="SHA for the latest tag")
     timestamp: float = Field(..., description="Unix timestamp when cached")
+    commit_tags: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Lowercased commit SHA to release tag, covering every release "
+            "the resolution considered and not only the selected one. "
+            "Retains the ordering information a bare (tag, sha) pair "
+            "cannot carry, so a restored entry can still say whether a "
+            "pinned commit is behind the cached target or ahead of it. "
+            "Empty for entries written by a caller that has no such map."
+        ),
+    )
 
     def is_expired(self, ttl_seconds: int) -> bool:
         """Check if the cache entry has expired."""
@@ -931,6 +945,28 @@ class ValidationCache:
         Returns:
             Tuple of (tag, sha) if cached and not expired, None otherwise
         """
+        entry = self.get_latest_version_entry(repository)
+        if entry is None:
+            return None
+        return (entry.latest_tag, entry.latest_sha)
+
+    def get_latest_version_entry(
+        self, repository: str
+    ) -> LatestVersionEntry | None:
+        """
+        Get the whole cached latest-version entry for a repository.
+
+        Callers that only need the target take :meth:`get_latest_version`.
+        This exists for the one that also needs
+        :attr:`LatestVersionEntry.commit_tags`, which is what tells a pin
+        that is *behind* the cached target from one that is *ahead* of it.
+
+        Args:
+            repository: Repository name (org/repo)
+
+        Returns:
+            The entry if cached and not expired, None otherwise.
+        """
         if not self.config.enabled:
             return None
 
@@ -949,12 +985,16 @@ class ValidationCache:
             self.logger.debug(
                 f"Cache hit for latest version: {repository} -> {version_entry.latest_tag}"
             )
-            return (version_entry.latest_tag, version_entry.latest_sha)
+            return version_entry
 
         return None
 
     def put_latest_version(
-        self, repository: str, latest_tag: str, latest_sha: str
+        self,
+        repository: str,
+        latest_tag: str,
+        latest_sha: str,
+        commit_tags: Mapping[str, str] | None = None,
     ) -> None:
         """
         Cache the latest version information for a repository.
@@ -963,6 +1003,11 @@ class ValidationCache:
             repository: Repository name (org/repo)
             latest_tag: Latest release/tag name
             latest_sha: SHA for the latest tag
+            commit_tags: Lowercased commit SHA to release tag for every
+                release the resolution considered. Supplying it lets a
+                later run place a pinned commit relative to the stored
+                target instead of assuming the target is newer; a caller
+                with no such map omits it.
         """
         if not self.config.enabled:
             return
@@ -974,6 +1019,7 @@ class ValidationCache:
             latest_tag=latest_tag,
             latest_sha=latest_sha,
             timestamp=time.time(),
+            commit_tags=dict(commit_tags or {}),
         )
 
         self._latest_versions[repository] = version_entry

--- a/src/gha_workflow_linter/latest_release.py
+++ b/src/gha_workflow_linter/latest_release.py
@@ -94,12 +94,14 @@ class LatestRelease:
             persist it.
         commit_tags: Reverse map of lowercased commit SHA to the tag of
             the policy-eligible release behind it, covering every release
-            the backend considered and not only the selected one. Empty
-            when the record was restored from the cache, which persists
-            only ``(tag, sha)``. Excluded from equality and ``repr``: it
-            is derived context about the repository, not part of the
-            identity of the release. Prefer :meth:`tag_for_commit` over
-            indexing it directly.
+            the backend considered and not only the selected one. A
+            record restored from the cache carries the map the original
+            resolution built, so it can place any commit that resolution
+            saw -- but not one published since. Empty when a caller
+            constructs a record without one. Excluded from equality and
+            ``repr``: it is derived context about the repository, not
+            part of the identity of the release. Prefer
+            :meth:`tag_for_commit` over indexing it directly.
     """
 
     tag: str
@@ -122,9 +124,9 @@ class LatestRelease:
 
         Returns:
             The tag of the release whose peeled commit is ``commit_sha``,
-            or ``None`` when the commit belongs to no eligible release --
-            including when :attr:`commit_tags` is empty because the record
-            came from the cache.
+            or ``None`` when the commit belongs to no release this record
+            covers -- including one published after a cached record was
+            written.
         """
         return self.commit_tags.get(commit_sha.strip().lower())
 

--- a/src/gha_workflow_linter/utils.py
+++ b/src/gha_workflow_linter/utils.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from .patterns import ActionCallPatterns
+
 if TYPE_CHECKING:
     from .models import ActionCall
 
@@ -43,3 +45,64 @@ def has_test_comment(action_call: ActionCall) -> bool:
     comment_text = action_call.comment.lstrip("#").strip()
     # Use word boundary to match 'test' at start of word (includes testing, tested, etc.)
     return bool(re.search(r"\btest", comment_text, re.IGNORECASE))
+
+
+def comment_text(action_call: ActionCall) -> str | None:
+    """Return an action call's comment without its marker or padding.
+
+    Args:
+        action_call: The call whose comment to read.
+
+    Returns:
+        The comment text, or ``None`` when the call carries none.
+    """
+    if not action_call.comment:
+        return None
+    return action_call.comment.strip().lstrip("#").strip()
+
+
+def version_or_none(text: str | None) -> str | None:
+    """Return the text when it names a clean version, otherwise ``None``.
+
+    Only a tag the version grammar accepts is usable as *ordering*
+    evidence. Anything else must not be parsed as one:
+    :func:`~gha_workflow_linter.version_utils._parse_version` discards a
+    ``-`` suffix, so a date comment such as ``2026-08-19`` would read as
+    version 2026 and outrank every real release.
+
+    Args:
+        text: A reference, comment or tag, or ``None``.
+
+    Returns:
+        The text unchanged when it is a clean version tag, else ``None``.
+    """
+    if text and ActionCallPatterns.VERSION_TAG_PATTERN.match(text):
+        return text
+    return None
+
+
+def pinned_version(action_call: ActionCall, comment: str | None) -> str | None:
+    """Determine which released version an action call currently pins.
+
+    Two sources answer, in order of authority:
+
+    * The reference itself, when it is a clean version tag. That is what
+      the workflow actually resolves at run time, so nothing outranks it.
+    * The version comment beside a SHA pin. A comment can lie, but the
+      auto-fixer diverts a *provably* wrong one to its mismatched-SHA
+      repair before asking this, so what arrives here is either verified
+      or unverifiable. Treating an unverifiable comment as the truth is
+      the fail-safe reading, given the answer is used to refuse a
+      rewrite: a missed update is a far smaller harm than a downgrade.
+
+    Args:
+        action_call: The call under consideration.
+        comment: Its version comment, already stripped of ``#`` and
+            surrounding whitespace, or ``None`` when it carries none.
+
+    Returns:
+        The version tag the call pins, or ``None`` when neither source
+        names one -- a branch, a floating ref, or a SHA with no version
+        comment.
+    """
+    return version_or_none(action_call.reference) or version_or_none(comment)

--- a/src/gha_workflow_linter/version_utils.py
+++ b/src/gha_workflow_linter/version_utils.py
@@ -42,6 +42,38 @@ def _parse_version(tag: str) -> tuple[int, int, int]:
     return (major, minor, patch)
 
 
+def _is_downgrade(current_tag: str, target_tag: str) -> bool:
+    """Report whether replacing one version tag with another goes backwards.
+
+    A resolved "latest" version is only ever the newest release *as of
+    the moment it was discovered*. A cached answer can therefore be older
+    than the version a file already pins, because Dependabot, Renovate, a
+    human or an earlier sweep can advance a pin inside the cache TTL. A
+    downgrade is materially worse than a stale pin -- it reverts a
+    supply-chain fix nobody asked to revert -- so callers use this to
+    refuse the rewrite rather than apply it.
+
+    Equality is deliberately not a downgrade: the same version may be
+    re-pinned to pick up a moved tag, and
+    :func:`_parse_version` ignores prerelease suffixes, so a comparison
+    it cannot separate must not block a legitimate rewrite.
+
+    Args:
+        current_tag: The version the file pins now.
+        target_tag: The version the run proposes to move it to.
+
+    Returns:
+        ``True`` only when ``current_tag`` is provably the higher
+        version. An unparsable tag on either side answers ``False``:
+        without two comparable versions there is no established
+        direction, and inventing one would block ordinary rewrites.
+    """
+    try:
+        return _parse_version(current_tag) > _parse_version(target_tag)
+    except ValueError:
+        return False
+
+
 def _get_version_specificity(tag: str) -> int:
     """
     Get the specificity level of a version tag.

--- a/tests/test_allow_list_check.py
+++ b/tests/test_allow_list_check.py
@@ -63,7 +63,7 @@ from gha_workflow_linter.models import (
 from gha_workflow_linter.version_utils import _parse_version
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
 FIXTURES = Path(__file__).parent / "fixtures" / "allow_list"
 
@@ -851,6 +851,7 @@ class _RecordingResolver:
     """Resolver double that records the keys it was asked for."""
 
     calls: list[list[str]] = []
+    pinned_calls: list[dict[str, set[str]]] = []
     hosts: dict[str, LatestRelease | None] = {}
 
     def __init__(self, config: Config, cache: ValidationCache) -> None:
@@ -864,18 +865,24 @@ class _RecordingResolver:
         self.cache = cache
 
     async def resolve(
-        self, repo_keys: Iterable[str]
+        self,
+        repo_keys: Iterable[str],
+        pinned: Mapping[str, Iterable[str]] | None = None,
     ) -> dict[str, LatestRelease | None]:
         """Record the request and answer from the configured mapping.
 
         Args:
             repo_keys: Host repository keys the checker asked for.
+            pinned: Commits pinned against each host repository.
 
         Returns:
             The configured latest release of each key.
         """
         keys = list(repo_keys)
         type(self).calls.append(keys)
+        type(self).pinned_calls.append(
+            {key: set(values) for key, values in (pinned or {}).items()}
+        )
         return {key: type(self).hosts.get(key) for key in keys}
 
 
@@ -900,6 +907,7 @@ async def run_check(
         The check outcome.
     """
     _RecordingResolver.calls = []
+    _RecordingResolver.pinned_calls = []
     _RecordingResolver.hosts = {HOST_REPO: LATEST} if hosts is None else hosts
     monkeypatch.setattr(
         allow_list_check, "AllowListResolver", _RecordingResolver
@@ -1302,7 +1310,7 @@ def _no_release_resolver() -> Any:
     """Return a resolve() stub reporting no release for every host."""
 
     async def _resolve(
-        _self: AllowListResolver, repo_keys: Any
+        _self: AllowListResolver, repo_keys: Any, _pinned: Any = None
     ) -> dict[str, Any]:
         return dict.fromkeys(repo_keys)
 

--- a/tests/test_cached_release_downgrade.py
+++ b/tests/test_cached_release_downgrade.py
@@ -1,0 +1,914 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""A cached release must never walk a pin backwards.
+
+Both caches serve an entry for the whole of its TTL, and both record the
+newest release *as of the moment the entry was written*. Nothing about
+that is wrong until something else advances a pin inside the window --
+Dependabot, Renovate, a human, or an earlier repository of a sweep. The
+cached answer is then older than the file, and an updater that treats
+"differs from the target" as "needs updating" rewrites the pin backwards
+and reports it as a successful update.
+
+These tests drive the real update paths with a real, pre-seeded cache,
+because the hazard lives in the join between the cache and the updater
+and neither half shows it alone.
+
+Every test has an inverse: a guard that refuses every rewrite would
+satisfy the positive cases while making the tool useless, so each is
+paired with a case that must still be applied.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+
+from gha_workflow_linter.allow_list_check import AllowListChecker
+from gha_workflow_linter.allow_list_resolver import AllowListResolver
+from gha_workflow_linter.auto_fix import AutoFixer
+from gha_workflow_linter.cache import ValidationCache
+from gha_workflow_linter.latest_release import LatestRelease
+from gha_workflow_linter.models import (
+    ActionCall,
+    AllowListFindingKind,
+    CacheConfig,
+    Config,
+    GitHubAPIConfig,
+    ReferenceType,
+    ValidationError,
+    ValidationMethod,
+    ValidationResult,
+)
+from gha_workflow_linter.utils import pinned_version
+from gha_workflow_linter.version_utils import _is_downgrade
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Distinct, well-formed commit SHAs standing in for three releases of
+#: one action. Only their identity matters, never their content.
+SHA_V4 = "a" * 40
+SHA_V5 = "b" * 40
+SHA_MOVED = "d" * 40
+
+#: A reference that resolves to nothing at all.
+BROKEN_SHA = "0" * 40
+
+#: The same, for the allow-list host repository.
+HOST = "lfreleng-actions/.github"
+SHA_HOST_V10 = "1" * 40
+SHA_HOST_V11 = "2" * 40
+SHA_HOST_V12 = "3" * 40
+
+
+class TestIsDowngrade:
+    """The shared direction predicate."""
+
+    def test_a_lower_target_is_a_downgrade(self) -> None:
+        assert _is_downgrade("v5.0.0", "v4.2.2") is True
+
+    def test_a_higher_target_is_not(self) -> None:
+        assert _is_downgrade("v4.2.2", "v5.0.0") is False
+
+    def test_the_same_version_is_not(self) -> None:
+        """A moved tag is re-pinned at the same version, and must be."""
+        assert _is_downgrade("v5.0.0", "v5.0.0") is False
+
+    def test_an_unparsable_tag_establishes_no_direction(self) -> None:
+        """Refusing on an unreadable tag would block ordinary rewrites."""
+        assert _is_downgrade("release-2026-01", "v4.2.2") is False
+        assert _is_downgrade("v4.2.2", "nightly") is False
+
+
+class TestPinnedVersion:
+    """Which version an action call is taken to be pinned at."""
+
+    @staticmethod
+    def _call(reference: str, comment: str | None) -> ActionCall:
+        return ActionCall(
+            organization="actions",
+            repository="checkout",
+            reference=reference,
+            reference_type=(
+                ReferenceType.COMMIT_SHA
+                if len(reference) == 40
+                else ReferenceType.TAG
+            ),
+            comment=comment,
+            raw_line=f"      - uses: actions/checkout@{reference}",
+            line_number=7,
+        )
+
+    def test_a_version_reference_outranks_the_comment(self) -> None:
+        """The reference is what the workflow actually resolves."""
+        call = self._call("v5.0.0", "v1.0.0")
+
+        assert pinned_version(call, "v1.0.0") == "v5.0.0"
+
+    def test_a_sha_pin_falls_back_to_its_comment(self) -> None:
+        call = self._call(SHA_V5, "v5.0.0")
+
+        assert pinned_version(call, "v5.0.0") == "v5.0.0"
+
+    def test_a_sha_pin_with_no_version_names_none(self) -> None:
+        """Without a version there is no direction to establish."""
+        call = self._call(SHA_V5, None)
+
+        assert pinned_version(call, None) is None
+        assert pinned_version(call, "renovate: pinned") is None
+
+
+def _fixer_config(tmp_path: Path) -> Config:
+    """Build a config whose cache lives under the test's directory."""
+    return Config(
+        parallel_workers=2,
+        require_pinned_sha=True,
+        auto_fix=True,
+        update_actions=True,
+        fix_test_calls=False,
+        validation_method=ValidationMethod.GITHUB_API,
+        cache=CacheConfig(enabled=True, cache_dir=tmp_path / "cache"),
+        github_api=GitHubAPIConfig(token="test-token"),
+    )
+
+
+def _seed_latest_version(
+    config: Config, tag: str, sha: str, repository: str = "actions/checkout"
+) -> None:
+    """Write a latest-version entry to disk, as a previous run would."""
+    cache = ValidationCache(config.cache)
+    cache.put_latest_version(repository, tag, sha)
+    cache.save()
+
+
+def _pinned_call(sha: str, comment: str) -> ActionCall:
+    """Build the SHA-pinned call a workflow line would produce."""
+    raw = f"      - uses: actions/checkout@{sha}  # {comment}"
+    return ActionCall(
+        organization="actions",
+        repository="checkout",
+        reference=sha,
+        reference_type=ReferenceType.COMMIT_SHA,
+        comment=comment,
+        raw_line=raw,
+        line_number=7,
+    )
+
+
+async def _run_fixer(
+    config: Config,
+    tmp_path: Path,
+    action_call: ActionCall,
+    *,
+    shas: dict[tuple[str, str], str],
+    check_for_updates: bool,
+    redirect_to: str | None = None,
+    invalid: bool = False,
+    salvage: str | None = None,
+) -> tuple[dict[Any, Any], dict[str, Any]]:
+    """Drive the real fixer, mocking only the network.
+
+    ``_get_latest_versions_batch`` is deliberately *not* mocked: it is
+    the function that consults the persistent cache, and the defect
+    under test lives in what it hands the update loop. Individual
+    reference resolution answers from ``shas`` too, so a reference
+    absent from it is genuinely unresolvable rather than accidentally
+    reaching the network. The salvage sources answer nothing, leaving
+    the default branch as the last resort.
+
+    Args:
+        config: Linter configuration.
+        tmp_path: Directory holding the workflow file.
+        action_call: The single call to consider.
+        shas: The reference-to-SHA answers to supply.
+        check_for_updates: Whether ``--update-actions`` was requested.
+        redirect_to: Repository the action has moved to, if any.
+        invalid: Whether the call carries an invalid reference.
+        salvage: Reference ``_find_valid_reference`` should offer, if
+            any. The remaining salvage sources answer nothing, leaving
+            the default branch as the last resort.
+
+    Returns:
+        The applied fixes and the outdated-action summary.
+    """
+    workflow = tmp_path / "ci.yaml"
+    workflow.write_text(
+        "---\nname: T\non: [push]\njobs:\n  b:\n    runs-on: ubuntu-latest\n"
+        f"    steps:\n{action_call.raw_line}\n"
+    )
+    errors = (
+        [
+            ValidationError(
+                file_path=workflow,
+                action_call=action_call,
+                result=ValidationResult.INVALID_REFERENCE,
+                error_message="Invalid reference",
+            )
+        ]
+        if invalid
+        else []
+    )
+
+    async def one_sha(repo_key: str, ref: str) -> dict[str, str] | None:
+        """Answer a single resolution from the same batch answers."""
+        sha = shas.get((repo_key, ref))
+        return {"sha": sha} if sha else None
+
+    with (
+        mock.patch.object(AutoFixer, "_get_shas_batch") as batch_shas,
+        mock.patch.object(AutoFixer, "_detect_repository_redirect") as redirect,
+        mock.patch.object(
+            AutoFixer, "_get_commit_sha_for_reference", side_effect=one_sha
+        ),
+        mock.patch.object(
+            AutoFixer, "_find_valid_reference", return_value=salvage
+        ),
+        mock.patch.object(
+            AutoFixer, "_get_fallback_reference", return_value=None
+        ),
+        mock.patch.object(AutoFixer, "_get_repository_info", return_value=None),
+    ):
+        batch_shas.return_value = shas
+        redirect.return_value = redirect_to
+
+        async with AutoFixer(config, base_path=tmp_path, quiet=True) as fixer:
+            applied, _, outdated = await fixer.fix_validation_errors(
+                errors,
+                {workflow: {7: action_call}},
+                check_for_updates=check_for_updates,
+            )
+
+    return applied, outdated
+
+
+class TestActionCallUpdater:
+    """``--update-actions`` against a cache older than the file."""
+
+    @pytest.mark.asyncio
+    async def test_a_cached_release_behind_the_pin_is_not_applied(
+        self, tmp_path: Path
+    ) -> None:
+        """The defect: v4 in the cache must not rewrite a v5 pin."""
+        config = _fixer_config(tmp_path)
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(SHA_V5, "v5.0.0"),
+            shas={("actions/checkout", "v5.0.0"): SHA_V5},
+            check_for_updates=True,
+        )
+
+        assert applied == {}
+
+    @pytest.mark.asyncio
+    async def test_a_cached_release_behind_the_pin_is_not_reported_stale(
+        self, tmp_path: Path
+    ) -> None:
+        """Without --update-actions the same pin is merely reported.
+
+        Reporting it as outdated would be the same false statement, one
+        step short of acting on it.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        _, outdated = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(SHA_V5, "v5.0.0"),
+            shas={("actions/checkout", "v5.0.0"): SHA_V5},
+            check_for_updates=False,
+        )
+
+        assert outdated == {}
+
+    @pytest.mark.asyncio
+    async def test_a_cached_release_ahead_of_the_pin_is_still_applied(
+        self, tmp_path: Path
+    ) -> None:
+        """The inverse: the guard must not refuse genuine updates."""
+        config = _fixer_config(tmp_path)
+        _seed_latest_version(config, "v5.0.0", SHA_V5)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(SHA_V4, "v4.2.2"),
+            shas={("actions/checkout", "v4.2.2"): SHA_V4},
+            check_for_updates=True,
+        )
+
+        assert SHA_V5 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+    @pytest.mark.asyncio
+    async def test_a_tag_pin_is_still_resolved_to_the_same_version_sha(
+        self, tmp_path: Path
+    ) -> None:
+        """Equality is not a downgrade, and must not block a rewrite.
+
+        Pinning a floating ``v5.0.0`` to that release's commit changes
+        the reference without changing the version. A guard that
+        refused everything not strictly newer would silently stop
+        ``--update-actions`` doing the one thing it exists for.
+        """
+        config = _fixer_config(tmp_path)
+        _seed_latest_version(config, "v5.0.0", SHA_V5)
+        raw = "      - uses: actions/checkout@v5.0.0"
+        tag_call = ActionCall(
+            organization="actions",
+            repository="checkout",
+            reference="v5.0.0",
+            reference_type=ReferenceType.TAG,
+            comment=None,
+            raw_line=raw,
+            line_number=7,
+        )
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            tag_call,
+            shas={("actions/checkout", "v5.0.0"): SHA_V5},
+            check_for_updates=True,
+        )
+
+        assert SHA_V5 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+    @pytest.mark.asyncio
+    async def test_a_redirect_is_applied_whatever_the_version_numbers(
+        self, tmp_path: Path
+    ) -> None:
+        """Two repositories' version numbers are not comparable.
+
+        An action that has moved starts its new home's numbering
+        wherever that project happens to be. Reading a lower number
+        there as a downgrade would leave the call pointing at the
+        abandoned repository.
+        """
+        config = _fixer_config(tmp_path)
+        _seed_latest_version(config, "v1.0.0", SHA_MOVED, "newowner/checkout")
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(SHA_V5, "v5.0.0"),
+            shas={},
+            check_for_updates=True,
+            redirect_to="newowner/checkout",
+        )
+
+        new_line = applied[tmp_path / "ci.yaml"][0]["new_line"]
+        assert "newowner/checkout" in new_line
+        assert SHA_MOVED in new_line
+
+    @pytest.mark.asyncio
+    async def test_a_pin_with_no_version_is_still_applied(
+        self, tmp_path: Path
+    ) -> None:
+        """No version means no direction, so the rewrite proceeds.
+
+        Refusing here would silently stop updating every pin carrying no
+        version comment.
+        """
+        config = _fixer_config(tmp_path)
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(SHA_V5, "pinned by hand"),
+            shas={},
+            check_for_updates=True,
+        )
+
+        assert SHA_V4 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+
+class TestInvalidReferenceRepair:
+    """The repair for a broken pin must not smuggle in a downgrade.
+
+    An invalid reference is repaired to the version its comment names
+    where that version resolves. It reaches the repository's latest
+    release only when it does *not* -- which is as likely to mean a rate
+    limit or an outage as a deleted tag, and the latest release may
+    itself be a cached answer older than the comment.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_older_latest_does_not_repair_a_newer_claim(
+        self, tmp_path: Path
+    ) -> None:
+        """A broken v5 pin is not repaired to a cached v4.
+
+        Repairing it would report a downgrade as a fix, on evidence
+        amounting to "v5.0.0 did not answer this time".
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v5.0.0"),
+            shas={},
+            check_for_updates=False,
+            invalid=True,
+        )
+
+        assert applied == {}
+
+    @pytest.mark.asyncio
+    async def test_a_newer_latest_still_repairs_a_broken_pin(
+        self, tmp_path: Path
+    ) -> None:
+        """The inverse: the fallback must still repair what it can.
+
+        Refusing here would leave every unresolvable pin broken, which
+        is the problem the fallback exists to solve.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v5.0.0", SHA_V5)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v4.2.2"),
+            shas={},
+            check_for_updates=False,
+            invalid=True,
+        )
+
+        assert SHA_V5 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+    @pytest.mark.asyncio
+    async def test_a_broken_version_reference_does_not_veto_its_own_repair(
+        self, tmp_path: Path
+    ) -> None:
+        """The broken reference is not evidence of where the pin sits.
+
+        A call naming a version tag that does not exist would otherwise
+        block every repair to a lower one, leaving it broken for good.
+        Only the comment answers here.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v5.0.0", SHA_V5)
+        raw = "      - uses: actions/checkout@v99.0.0"
+        broken_tag_call = ActionCall(
+            organization="actions",
+            repository="checkout",
+            reference="v99.0.0",
+            reference_type=ReferenceType.TAG,
+            comment=None,
+            raw_line=raw,
+            line_number=7,
+        )
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            broken_tag_call,
+            shas={},
+            check_for_updates=False,
+            invalid=True,
+        )
+
+        assert SHA_V5 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+    @pytest.mark.asyncio
+    async def test_a_redirect_repairs_whatever_the_version_numbers(
+        self, tmp_path: Path
+    ) -> None:
+        """A redirected repair compares nothing, as the update path does.
+
+        The comment names a version of the *old* project while the
+        latest release belongs to the new one, so the two numbers
+        describe different things. Comparing them would reject a new
+        home that happens to number lower and leave the call both
+        invalid and pointing at an abandoned repository.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v1.0.0", SHA_MOVED, "newowner/checkout")
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v5.0.0"),
+            shas={},
+            check_for_updates=False,
+            invalid=True,
+            redirect_to="newowner/checkout",
+        )
+
+        new_line = applied[tmp_path / "ci.yaml"][0]["new_line"]
+        assert "newowner/checkout" in new_line
+        assert SHA_MOVED in new_line
+
+    @pytest.mark.asyncio
+    async def test_a_salvaged_version_tag_is_guarded_too(
+        self, tmp_path: Path
+    ) -> None:
+        """The last source can name a version, so it is checked as well.
+
+        Salvage searches by prefix, so a broken ``@v4`` finds ``v4.2.2``
+        -- a plausible-looking repair that walks a call claiming v5
+        backwards, after the cached v4 target was correctly refused one
+        step earlier.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v5.0.0"),
+            shas={("actions/checkout", "v4.2.2"): SHA_V4},
+            check_for_updates=False,
+            invalid=True,
+            salvage="v4.2.2",
+        )
+
+        assert applied == {}
+
+    @pytest.mark.asyncio
+    async def test_a_refused_salvage_does_not_fall_back_to_a_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """A refused salvage stops the repair rather than floating it.
+
+        Continuing to the branch fallback would swap a version pin for a
+        moving reference, losing the pin as well as the version. The
+        call keeps its validation error, so nothing is swallowed.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v5.0.0"),
+            shas={
+                ("actions/checkout", "v4.2.2"): SHA_V4,
+                ("actions/checkout", "main"): SHA_MOVED,
+            },
+            check_for_updates=False,
+            invalid=True,
+            salvage="v4.2.2",
+        )
+
+        assert SHA_MOVED not in str(applied)
+
+    @pytest.mark.asyncio
+    async def test_a_salvaged_branch_is_not_read_as_a_version(
+        self, tmp_path: Path
+    ) -> None:
+        """The inverse: a branch establishes no direction, so it stands.
+
+        Refusing here would leave every broken pin with no version-tag
+        salvage unrepaired.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v5.0.0"),
+            shas={("actions/checkout", "main"): SHA_MOVED},
+            check_for_updates=False,
+            invalid=True,
+            salvage="main",
+        )
+
+        assert SHA_MOVED in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+    @pytest.mark.asyncio
+    async def test_a_refused_latest_does_not_fall_back_to_a_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Refusal carries forward, so a branch cannot slip in after it.
+
+        Salvage consults a cached ``main`` before it looks at tags, so a
+        repository with one would replace a pin claiming v5 with a
+        floating branch the moment the cached v4 target was refused --
+        losing the pin as well as the version.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v5.0.0"),
+            shas={("actions/checkout", "main"): SHA_MOVED},
+            check_for_updates=False,
+            invalid=True,
+            salvage="main",
+        )
+
+        assert applied == {}
+
+    @pytest.mark.asyncio
+    async def test_a_refused_latest_still_accepts_a_newer_salvage(
+        self, tmp_path: Path
+    ) -> None:
+        """The inverse: refusal narrows the repair, it does not end it.
+
+        A salvaged version at least as new as the claim is exactly the
+        repair the call needs, and refusing it would abandon a pin that
+        could have been fixed correctly.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v4.2.2", SHA_V4)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v5.0.0"),
+            shas={("actions/checkout", "v5.1.0"): SHA_V5},
+            check_for_updates=False,
+            invalid=True,
+            salvage="v5.1.0",
+        )
+
+        assert SHA_V5 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+    @pytest.mark.asyncio
+    async def test_a_comment_that_is_not_a_version_vetoes_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """Only a clean version tag counts as ordering evidence.
+
+        ``_parse_version`` discards a ``-`` suffix, so a date comment
+        would read as version 2026 and veto every repair the call could
+        possibly need.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v5.0.0", SHA_V5)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "2026-08-19"),
+            shas={},
+            check_for_updates=False,
+            invalid=True,
+        )
+
+        assert SHA_V5 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+    @pytest.mark.asyncio
+    async def test_a_resolvable_comment_version_still_wins(
+        self, tmp_path: Path
+    ) -> None:
+        """The comment outranks the latest release when it resolves.
+
+        Pinned here because the guard sits on the step below it: a
+        change that stopped consulting the comment would take the
+        guarded path for every broken pin.
+        """
+        config = _fixer_config(tmp_path)
+        config.update_actions = False
+        _seed_latest_version(config, "v5.0.0", SHA_V5)
+
+        applied, _ = await _run_fixer(
+            config,
+            tmp_path,
+            _pinned_call(BROKEN_SHA, "v4.2.2"),
+            shas={("actions/checkout", "v4.2.2"): SHA_V4},
+            check_for_updates=False,
+            invalid=True,
+        )
+
+        assert SHA_V4 in applied[tmp_path / "ci.yaml"][0]["new_line"]
+
+
+def _workflow_with_host_pin(tmp_path: Path, sha: str, comment: str) -> Path:
+    """Write a workflow whose allow-list pin names ``sha``."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True, exist_ok=True)
+    target = workflows / "ci.yaml"
+    target.write_text(
+        "---\n"
+        "name: T\n"
+        "on: [push]\n"
+        "jobs:\n"
+        "  b:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: lfreleng-actions/harden-runner-block-action@abc\n"
+        "        with:\n"
+        f"          config: '@{sha}'  # {comment}\n"
+    )
+    return target
+
+
+def _seed_host_release(
+    config: Config, tag: str, sha: str, commit_tags: dict[str, str]
+) -> None:
+    """Write a host repository's latest release to the on-disk cache."""
+    cache = ValidationCache(config.cache)
+    cache.put_latest_version(HOST, tag, sha, commit_tags)
+    cache.save()
+
+
+def _live_release() -> LatestRelease:
+    """The answer a live resolution would give: v0.12.0 is newest."""
+    return LatestRelease(
+        tag="v0.12.0",
+        commit_sha=SHA_HOST_V12,
+        commit_tags={
+            SHA_HOST_V12: "v0.12.0",
+            SHA_HOST_V11: "v0.11.0",
+            SHA_HOST_V10: "v0.10.0",
+        },
+    )
+
+
+def _check_with_recorded_resolution(
+    config: Config, target: Path, tmp_path: Path
+) -> tuple[Any, list[list[str]]]:
+    """Run the real checker, recording any live resolution it triggers.
+
+    Only ``_resolve_uncached`` is replaced -- the fail-soft boundary
+    around the backends -- so the cache read, the sufficiency test and
+    the classification are all the real thing.
+
+    Args:
+        config: Linter configuration.
+        target: The workflow file to check.
+        tmp_path: Repository root.
+
+    Returns:
+        The outcome and the repository keys resolved live.
+    """
+    resolved_live: list[list[str]] = []
+
+    async def _resolve_uncached(
+        _self: AllowListResolver, repo_keys: list[str]
+    ) -> dict[str, LatestRelease | None]:
+        resolved_live.append(list(repo_keys))
+        return dict.fromkeys(repo_keys, _live_release())
+
+    with mock.patch.object(
+        AllowListResolver, "_resolve_uncached", new=_resolve_uncached
+    ):
+        outcome = asyncio.run(
+            AllowListChecker(config, ValidationCache(config.cache)).check(
+                [target], tmp_path
+            )
+        )
+
+    return outcome, resolved_live
+
+
+class TestAllowListClassification:
+    """``--update-allow-list`` against a cache older than the file."""
+
+    @staticmethod
+    def _config(tmp_path: Path) -> Config:
+        config = Config(cache=CacheConfig(enabled=True, cache_dir=tmp_path))
+        config.allow_list.org = "lfreleng-actions"
+        return config
+
+    def test_a_pin_the_cached_target_cannot_place_is_resolved_afresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The defect: a v0.12 pin against a v0.11 cache entry.
+
+        v0.12.0 did not exist when the entry was written, so its commit
+        is absent from the stored map. Trusting the entry would classify
+        a current pin as stale and recommend a downgrade.
+        """
+        monkeypatch.delenv("GITHUB_REPOSITORY_OWNER", raising=False)
+        config = self._config(tmp_path)
+        _seed_host_release(
+            config,
+            "v0.11.0",
+            SHA_HOST_V11,
+            {SHA_HOST_V11: "v0.11.0", SHA_HOST_V10: "v0.10.0"},
+        )
+        target = _workflow_with_host_pin(tmp_path, SHA_HOST_V12, "v0.12.0")
+
+        outcome, resolved_live = _check_with_recorded_resolution(
+            config, target, tmp_path
+        )
+
+        assert resolved_live == [[HOST]]
+        assert outcome.findings == []
+
+    def test_a_pin_the_cached_target_can_place_costs_no_lookup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The inverse: a genuinely stale pin is still answered by cache.
+
+        v0.10.0 is in the stored map, so its position relative to the
+        cached target is established without a backend. Re-resolving
+        every differing pin would give the same answer at the cost of
+        the saving the cache exists for.
+        """
+        monkeypatch.delenv("GITHUB_REPOSITORY_OWNER", raising=False)
+        config = self._config(tmp_path)
+        _seed_host_release(
+            config,
+            "v0.11.0",
+            SHA_HOST_V11,
+            {SHA_HOST_V11: "v0.11.0", SHA_HOST_V10: "v0.10.0"},
+        )
+        target = _workflow_with_host_pin(tmp_path, SHA_HOST_V10, "v0.10.0")
+
+        outcome, resolved_live = _check_with_recorded_resolution(
+            config, target, tmp_path
+        )
+
+        assert resolved_live == []
+        assert [f.kind for f in outcome.findings] == [
+            AllowListFindingKind.STALE
+        ]
+        assert outcome.findings[0].target_version == "v0.11.0"
+
+
+class TestCacheRetainsOrderingData:
+    """The commit map must survive a round trip through the cache."""
+
+    def test_the_commit_map_round_trips(self, tmp_path: Path) -> None:
+        config = CacheConfig(enabled=True, cache_dir=tmp_path)
+        writer = ValidationCache(config)
+        writer.put_latest_version(
+            HOST, "v0.11.0", SHA_HOST_V11, {SHA_HOST_V10: "v0.10.0"}
+        )
+        writer.save()
+
+        entry = ValidationCache(config).get_latest_version_entry(HOST)
+
+        assert entry is not None
+        assert entry.commit_tags == {SHA_HOST_V10: "v0.10.0"}
+
+    def test_the_map_a_resolution_built_serves_the_next_run(
+        self, tmp_path: Path
+    ) -> None:
+        """A resolution must persist the map, not merely consume one.
+
+        Seeding the entry by hand passes whether or not the resolver
+        ever writes the map, so this drives a real resolution first and
+        reads the answer back through a second one.
+        """
+        config = Config(cache=CacheConfig(enabled=True, cache_dir=tmp_path))
+        calls: list[list[str]] = []
+
+        async def _resolve_uncached(
+            _self: AllowListResolver, repo_keys: list[str]
+        ) -> dict[str, LatestRelease | None]:
+            calls.append(list(repo_keys))
+            return dict.fromkeys(repo_keys, _live_release())
+
+        with mock.patch.object(
+            AllowListResolver, "_resolve_uncached", new=_resolve_uncached
+        ):
+            asyncio.run(
+                AllowListResolver(
+                    config, ValidationCache(config.cache)
+                ).resolve([HOST], {HOST: {SHA_HOST_V12}})
+            )
+            second = asyncio.run(
+                AllowListResolver(
+                    config, ValidationCache(config.cache)
+                ).resolve([HOST], {HOST: {SHA_HOST_V10}})
+            )
+
+        # One live resolution: the second run placed an older pin from
+        # the stored map alone.
+        assert calls == [[HOST]]
+        restored = second[HOST]
+        assert restored is not None
+        assert restored.tag_for_commit(SHA_HOST_V10) == "v0.10.0"
+
+    def test_an_entry_written_without_a_map_still_loads(
+        self, tmp_path: Path
+    ) -> None:
+        """Older on-disk entries carry no map and must not fail to load."""
+        config = CacheConfig(enabled=True, cache_dir=tmp_path)
+        writer = ValidationCache(config)
+        writer.put_latest_version(HOST, "v0.11.0", SHA_HOST_V11)
+        writer.save()
+
+        entry = ValidationCache(config).get_latest_version_entry(HOST)
+
+        assert entry is not None
+        assert entry.commit_tags == {}


### PR DESCRIPTION
## Summary

Closes #323.

A cached "latest release" entry names the newest release **at the moment of writing**, and stays usable for the whole TTL. Nothing stops something else advancing a pin inside that window — Dependabot, Renovate, a colleague, an earlier repository in the same sweep. The cached answer is then *older* than the file, both updaters read a differing target as work to do, and the run rewrites the pin **backwards** while reporting the downgrade as a successful update.

A downgrade reverts a supply-chain fix nobody asked to revert, which is materially worse than the stale pin it was trying to correct.

Pre-existing on `main`, independent of multi-repository mode, and branched from `main` rather than from #322 for that reason.

## The two halves needed different mechanisms

The issue offered three directions. Neither half takes only one, because the two paths know different things.

### Action calls — verify direction before applying (direction 1)

`_moves_backwards` refuses a rewrite when the call **provably** pins a higher version than the target. The version comes from the reference when it is a clean version tag (what the workflow actually resolves, so nothing outranks it), otherwise from the version comment.

Trusting an unverifiable comment here is deliberate. The fixer already diverts a *provably* wrong comment to its mismatched-SHA repair before this point, so what arrives is either verified or unverifiable — and since the answer is used solely to **refuse**, a missed update is a far smaller harm than a downgrade.

A redirected repository is exempt. Two projects' version numbers are not comparable: an action that has moved starts its new home's numbering wherever that project happens to be, and reading a lower number there as a downgrade would leave the call pointing at the abandoned repository. The exemption is a **required keyword** on `_moves_backwards` rather than a condition at each call site — see round 4.

The guard sits ahead of both outcomes of that branch, so a pin ahead of the target is not reported as outdated either. It is not outdated.

### Allow-list pins — retain ordering data, then re-resolve (directions 2 and 3)

Direction 1 does not transfer: the allow-list classifier establishes direction through the host repository's commit-to-tag map precisely so it never has to read the version comment, which §7.2 assumes can lie.

**Storing `commit_tags` alone is not enough**, and this is the part worth stating because it is the obvious fix and it does not work. The issue's own scenario has v0.12 published *after* the entry was written, so its commit cannot be in the stored map however faithfully the map is persisted.

So both, and they compose:

1. `LatestVersionEntry` retains the commit-to-tag map, so a restored record can place any commit the original resolution ranked.
2. `AllowListResolver._cache_can_place` re-resolves a host whose cached entry cannot place a pinned commit — the residue the map cannot cover.

The division of labour is the point. A pin **behind** the cached target is in the stored map, so it is still classified from cache at zero cost. Only a genuinely unplaceable commit — one ahead, or belonging to no ranked release — forces a lookup. Without (1), every stale pin anywhere would force one, and a twenty-repository sweep would pay twenty times for what the shared cache exists to save.

`cache_usable` keeps its cooldown and prerelease bypasses, but its docstring no longer rests on "a restored record has an empty `commit_tags`" — that is no longer true. The bypass stands on the cache recording no *policy*, which it still does not.

## Validation

**Seven mutations. Two found holes in the tests rather than in the code.**

| mutation | result |
| --- | --- |
| Drop the action-call direction guard *(the original bug)* | ✗ 2 failures |
| Drop the redirect exemption | ✗ 1 failure |
| `_is_downgrade` uses `>=`, refusing equal versions too | ✗ 2 failures |
| `_cache_can_place` always sufficient *(the original bug)* | ✗ 1 failure |
| `_cache_can_place` never sufficient | ✗ 1 failure |
| Checker never passes the pinned commits | ✗ 1 failure |
| Resolver never persists the commit map | ✗ **passed** — see below |

**The last one passed against broken code.** Every test seeded the cached entry by hand, so nothing exercised the wiring from a resolved release *into* the cache — the same shape of gap #322 hit five times. `test_the_map_a_resolution_built_serves_the_next_run` now drives a live resolution and reads the answer back through a second resolver, and fails under that mutation.

**One test also passed against broken code and was rewritten.** `test_a_moved_tag_at_the_same_version_is_still_applied` was meant to pin "equality is not a downgrade", but its data made `has_mismatched_sha` true, so it took an earlier branch and never reached the guard at all — the `>=` mutation left it green. It is replaced by `test_a_tag_pin_is_still_resolved_to_the_same_version_sha`, which exercises the real case at stake: `--update-actions` pinning a floating `v5.0.0` to that release's commit changes the reference without changing the version, and a guard rejecting anything not strictly newer would silently stop the fixer doing the one thing it exists for.

Four of the seven are inverse mutations, present because the obvious over-corrections would have passed the positive tests: refusing every cached answer, refusing equal versions, refusing across a redirect, and refusing a pin that names no version at all.

The regression tests drive the **real** update paths. `_get_latest_versions_batch` and the cache read are not mocked — only the network is — because the defect lives in the join between the cache and the updater and neither half shows it alone.

## Also

`--update-actions` gains a README paragraph, since "updates do not move a pin backwards" is user-visible behaviour, along with what establishes direction and when nothing does. The multi-repo caching section and design §11 both said the cache records no more than a tag and a SHA; it now records the releases ranked behind them too, and both say when a host is re-resolved despite a cache hit.

---

# Review rounds 2 to 5

Five defects beyond the original, spread over four rounds — and **every one of them is the same shape**: the rule applied to one path and not its sibling. They are grouped here rather than told round by round, because the pattern is the finding.

### The repair for a *broken* pin had none of the update path's protections

A pin whose reference does not resolve is repaired from three sources in order: the version its comment names, the repository's latest release, then a salvaged reference or the default branch. Each of the first four rounds found the guard missing from one more of them.

**Round 2 — no direction check at all.** The repair reaches the latest release only when the comment's version could not be resolved, which is as likely to mean a rate limit or an outage as a deleted tag; the latest release may itself be a cached answer older than the comment. A call claiming v5 was "repaired" down to a cached v4 and reported as fixed.

**Round 3 — the check did not exempt redirects.** `base_repo_key` is already the redirect *target* by that point, so a call moved from a repository at v5 to one whose latest release is v1 compared a version of the **old** project against one of the **new**, refused it, and left the call invalid *and* pointing at the abandoned repository. Introduced by round 2's fix.

**Round 4 — the salvage source bypassed the check.** `_find_valid_reference` returns any tag whose name *starts with* the invalid reference, so a broken `@v4` yields `v4.2.2` — reached **after** the cached v4 target had been correctly refused one step earlier, and rewritten to another v4 anyway.

**Round 5 — refusal did not carry forward.** Having refused the latest release, execution still fell through to a salvage that consults a cached `main` before it looks at tags. So a pin claiming v5 could be replaced by a floating branch, losing the pin *as well as* the version — precisely the outcome I had just written a docstring saying the design avoids. Refusal now narrows the repair to a version at least as new, and abandons the call otherwise. Leaving it alone is not silent: the call keeps its validation error and still fails the run.

**Round 5 also — the comment was unfiltered as ordering evidence.** `_parse_version` discards a `-` suffix, so a date comment such as `# 2026-08-19` read as version 2026 and vetoed every repair the call could possibly need. Only a tag the version grammar accepts is evidence now, through one `version_or_none` helper that `pinned_version` shares.

### Two structural changes, so these cannot recur

`repo_changed` is a **required keyword** on `_moves_backwards` rather than a condition repeated at three call sites. Rounds 3 and 4 were both omissions of it; with three sites the next was a matter of time. The exemption can no longer be forgotten, because it cannot be omitted.

And the whole invalid-reference repair moved out of `_process_action_calls_batch` into the version mixin. This began as a size-budget problem — `auto_fix.py` arrived at **1313 lines against an effective 1320** (aislop's `ceil(maxFileLoc × 1.1)`), round 1 landed at 1318, and round 2 simply could not fit — but it is the reason rounds 4 and 5 were tractable at all. The repair is now a testable unit of its own rather than 90 lines of nesting inside a 400-line loop, and `auto_fix.py` sits at **1232**.

### The README overstated the guarantee (round 2)

"Updates never move backwards" reads as unconditional, but direction needs a version on both sides and a commit pin with no version comment supplies none. `test_a_pin_with_no_version_is_still_applied` is deliberate — refusing there would silently stop updating every such pin — but the prose now says where the version comes from and when nothing does.

### Validation across the four rounds

| mutation | result |
| --- | --- |
| Repair ignores direction *(round 2's bug)* | ✗ 1 failure |
| Repair comparison trusts the broken reference | ✗ **passed** — see below |
| Repair refuses everything | ✗ 2 failures |
| Repair guard ignores the redirect *(round 3's bug)* | ✗ 1 failure |
| Repair guard exempts everything | ✗ 1 failure |
| Salvage bypasses the guard *(round 4's bug)* | ✗ 1 failure |
| Refused salvage falls through to a branch | ✗ 1 failure |
| A salvaged branch treated as a version | ✗ 1 failure |
| `_moves_backwards` ignores `repo_changed` | ✗ 2 failures |
| Refusal does not carry into salvage *(round 5's bug)* | ✗ 1 failure |
| Refusal abandons the call unconditionally | ✗ 1 failure |
| Comment unfiltered as ordering evidence *(round 5's bug)* | ✗ 1 failure |

**One more test passed against broken code**, the third in this PR. Reusing `pinned_version` (which prefers the reference) for the repair comparison broke nothing in the whole suite, because no test pinned a *version tag* that does not exist. `test_a_broken_version_reference_does_not_veto_its_own_repair` now does — the broken reference must not veto its own repair, or an invalid `@v99.0.0` stays broken permanently.

Half the mutations above are inverse: refusing every salvage, exempting every redirect, abandoning every refused call. Each of those over-corrections would have passed the positive tests while making the repair useless.

- **1591 tests** passing (from 1562), coverage 84.4%
- All **30** `prek` hooks pass; all **24** CI checks green on the preceding commit

## Where the defects landed

One defect in the feature as filed; five found in review, every one of them **a rule applied to one path and not its sibling** — the update path against the repair path, one repair source against the next, the refusal against what followed it. Two were created by the fix for the one before, which is why the last two changes make the omissions structurally impossible rather than merely correcting their latest instance.

**Three tests passed against broken code and were found only by mutation**: the cache-write wiring, the equality case that never reached the guard, and the broken-reference comparison. All three were holes in my tests rather than in the code, and all three are now closed.
