### PR TITLE
Fix: Return rate-limit status from preflight

### DIFF
--- a/src/gha_workflow_linter/cli.py
+++ b/src/gha_workflow_linter/cli.py
@@ -474,12 +474,18 @@ def _configure_validation_backend(
     options: CLIOptions,
     github_token: str | None,
     workers: int | None,
-) -> None:
+) -> bool:
     """Resolve the GitHub token, select a validation method, and pre-flight it.
 
     Applies the resolved method/token back onto ``config`` and prints the
     chosen backend (unless quiet/JSON). When the GitHub API backend is
     selected, this also performs the rate-limit pre-flight check.
+
+    Returns:
+        ``True`` when the API reported the client is rate-limited. The
+        caller decides what that means: pre-flight reports the state and
+        terminates nothing, so the command still reaches its output
+        contract and the validation that follows this stage still runs.
     """
     logger = logging.getLogger(__name__)
 
@@ -529,16 +535,14 @@ def _configure_validation_backend(
         from .github_api import GitHubGraphQLClient
 
         github_client = GitHubGraphQLClient(config.github_api)
-        try:
-            github_client.check_rate_limit_and_exit_if_needed()
-            # If we get here, we're not rate limited
-            if not effective_token and not options.quiet:
-                logger.warning(
-                    "No GitHub token available; API requests may be rate-limited ⚠️"
-                )
-        except SystemExit:
-            # Rate limit check triggered exit, re-raise to exit cleanly
-            raise
+        if github_client.check_rate_limit():
+            return True
+        if not effective_token and not options.quiet:
+            logger.warning(
+                "No GitHub token available; API requests may be rate-limited ⚠️"
+            )
+
+    return False
 
 
 def _resolve_update_actions(
@@ -980,14 +984,14 @@ def lint(
         logger.debug(f"Starting gha-workflow-linter {__version__}")
 
         # Resolve token, select validation method, and pre-flight it
-        _configure_validation_backend(
+        rate_limited = _configure_validation_backend(
             config, cli_options, github_token, workers
         )
 
         # Only show scanning path if we're actually going to proceed
         logger.debug(f"Scanning path: {path}")
 
-        exit_code = run_linter(config, cli_options)
+        exit_code = run_linter(config, cli_options, rate_limited=rate_limited)
 
     except typer.Exit:
         # Re-raise typer.Exit to avoid catching it as a general exception
@@ -1292,6 +1296,8 @@ def _scan_and_validate(
     options: CLIOptions,
     scanner: WorkflowScanner,
     shared_cache: ValidationCache,
+    *,
+    rate_limited: bool = False,
 ) -> _ScanShortCircuit | _ValidationOutcome:
     """Scan workflows and validate their action calls.
 
@@ -1330,6 +1336,19 @@ def _scan_and_validate(
 
         # Count total calls for progress tracking
         total_calls = sum(len(calls) for calls in workflow_calls.values())
+
+        if rate_limited:
+            # Nothing can be validated, but the scan already succeeded,
+            # so the run returns an outcome rather than short-circuiting:
+            # the caller still emits its document, still reports what it
+            # scanned, and still reaches the exit-code decision. Zero
+            # errors here means "none observed", which is why the exit
+            # code -- not this outcome -- carries the fact that nothing
+            # was checked.
+            validator = ActionCallValidator(config, cache=shared_cache)
+            return _ValidationOutcome(
+                workflow_calls, [], validator, total_calls
+            )
 
         validate_task = progress.add_task(
             "Validating action calls...", total=total_calls
@@ -1815,6 +1834,8 @@ def _determine_exit_code(
     autofix: _AutoFixOutcome,
     config: Config,
     allow_list: AllowListOutcome | None = None,
+    *,
+    rate_limited: bool = False,
 ) -> int:
     """Compute the process exit code from fixes and validation errors.
 
@@ -1829,10 +1850,17 @@ def _determine_exit_code(
         autofix: Outcome of the auto-fix stage.
         config: Resolved configuration.
         allow_list: Outcome of the allow-list stage, when it ran.
+        rate_limited: Whether the API was rate-limited, so the checks a
+            ``--verify-*`` flag asked about never ran. An advisory run
+            asked no question and still succeeds; a verifying run did
+            ask, and "could not look" is not an answer to it.
 
     Returns:
         A code from :mod:`gha_workflow_linter.exit_codes`.
     """
+    if rate_limited and (options.verify_actions or options.verify_allow_list):
+        return exit_codes.RATE_LIMITED
+
     codes: list[int] = []
 
     # A rewrite the caller asked for that could not be written is a
@@ -1955,19 +1983,26 @@ class RunOutcome:
     json_payload: dict[str, Any] | None = None
 
 
-def run_linter(config: Config, options: CLIOptions) -> int:
+def run_linter(
+    config: Config, options: CLIOptions, *, rate_limited: bool = False
+) -> int:
     """
     Run the main linting process.
 
     Args:
         config: Configuration object
         options: CLI options
+        rate_limited: Whether pre-flight found the GitHub API
+            rate-limited. The run still scans, still reports, and still
+            emits its document; it skips only the checks it cannot
+            perform, and says so in the exit code when the caller asked
+            for them.
 
     Returns:
         Exit code from :mod:`gha_workflow_linter.exit_codes`.
     """
     if options.multi_repo:
-        return _run_multi_repo(config, options)
+        return _run_multi_repo(config, options, rate_limited=rate_limited)
 
     shared_cache = ValidationCache(config.cache)
     # Eagerly load the cache and run all startup-time checks so any
@@ -1975,7 +2010,9 @@ def run_linter(config: Config, options: CLIOptions) -> int:
     # inside the progress block would interleave with the active
     # spinner and corrupt output).
     _render_cache_prime_banners(shared_cache.prime(), quiet=options.quiet)
-    return _run_one_repository(config, options, shared_cache).exit_code
+    return _run_one_repository(
+        config, options, shared_cache, rate_limited=rate_limited
+    ).exit_code
 
 
 def _run_one_repository(
@@ -1984,6 +2021,7 @@ def _run_one_repository(
     shared_cache: ValidationCache,
     *,
     collect_json: bool = False,
+    rate_limited: bool = False,
 ) -> RunOutcome:
     """Scan, validate, fix and report a single repository.
 
@@ -1995,13 +2033,19 @@ def _run_one_repository(
         collect_json: Return the JSON payload on the outcome instead of
             printing it, so a sweep can assemble one document rather
             than emitting several.
+        rate_limited: Whether pre-flight found the API rate-limited. The
+            scan still runs -- so an unreadable path is still reported
+            rather than passing silently -- and the results still emit;
+            only the validation that needs the API is skipped.
 
     Returns:
         What the run produced, for aggregation by the caller.
     """
     scanner = WorkflowScanner(config)
 
-    scan_result = _scan_and_validate(config, options, scanner, shared_cache)
+    scan_result = _scan_and_validate(
+        config, options, scanner, shared_cache, rate_limited=rate_limited
+    )
     if isinstance(scan_result, _ScanShortCircuit):
         return RunOutcome(
             exit_code=scan_result.exit_code, error=scan_result.error
@@ -2040,7 +2084,12 @@ def _run_one_repository(
 
     return RunOutcome(
         exit_code=_determine_exit_code(
-            options, validation, autofix, config, allow_list
+            options,
+            validation,
+            autofix,
+            config,
+            allow_list,
+            rate_limited=rate_limited,
         ),
         allow_list=allow_list,
         files_changed=sum(
@@ -2128,7 +2177,9 @@ def _repository_label(repository: Path, root: Path) -> str:
     return resolved.name or str(resolved)
 
 
-def _run_multi_repo(config: Config, options: CLIOptions) -> int:
+def _run_multi_repo(
+    config: Config, options: CLIOptions, *, rate_limited: bool = False
+) -> int:
     """Visit every repository beneath the given path in turn.
 
     Repositories are processed sequentially. The intra-repository
@@ -2212,6 +2263,7 @@ def _run_multi_repo(config: Config, options: CLIOptions) -> int:
                     shared_cache,
                     repository,
                     silent=silent,
+                    rate_limited=rate_limited,
                     # Pointing --multi-repo at a checkout visits that one
                     # repository, which is the case
                     # GITHUB_REPOSITORY_OWNER describes correctly, so the
@@ -2289,6 +2341,7 @@ def _run_repository_in_sweep(
     silent: bool = False,
     use_environment_org: bool = False,
     label: str | None = None,
+    rate_limited: bool = False,
 ) -> RunOutcome:
     """Run one repository of a sweep, surviving its failure.
 
@@ -2357,6 +2410,7 @@ def _run_repository_in_sweep(
             repo_options,
             shared_cache,
             collect_json=options.output_format == "json",
+            rate_limited=rate_limited,
         )
     except ConfigurationError:
         # A bad setting is a usage error and applies to every repository,

--- a/src/gha_workflow_linter/exit_codes.py
+++ b/src/gha_workflow_linter/exit_codes.py
@@ -23,10 +23,12 @@ Code  Name                      Meaning
 3     ALLOW_LIST_STALE          ``--verify-allow-list`` and stale pins remain.
 4     ALLOW_LIST_UNRESOLVED     ``--verify-allow-list`` and no latest release.
 5     ACTIONS_OUTDATED          ``--verify-actions`` and outdated calls remain.
+6     RATE_LIMITED              A ``--verify-*`` flag was set but the API was
+                                rate-limited, so nothing was checked.
 ===== ========================= ================================================
 
-Precedence is ``4 > 3 > 5 > 1 > 0``. An infrastructure failure must never
-be reported as a clean-or-stale result, and a condition the caller
+Precedence is ``6 > 4 > 3 > 5 > 1 > 0``. An infrastructure failure must
+never be reported as a clean-or-stale result, and a condition the caller
 specifically asked about must not be masked by the generic ``1``.
 """
 
@@ -69,10 +71,26 @@ allow-list host repository could not be resolved."""
 ACTIONS_OUTDATED: Final = 5
 """``--verify-actions`` was requested and outdated action calls remain."""
 
+RATE_LIMITED: Final = 6
+"""A ``--verify-*`` flag was requested but the GitHub API was
+rate-limited, so the checks it asked about never ran.
+
+Rate-limiting is not a finding: an advisory run reports
+:data:`SUCCESS` as it always has, because a throttled API must not
+break a build that asked no question of it. A caller that passed a
+``--verify-*`` flag *did* ask, and "could not look" is not an answer to
+it. This is the same distinction :data:`ALLOW_LIST_UNRESOLVED` draws,
+for the same reason, and it exists so a scheduled sweep can tell a
+clean estate from one it never managed to examine.
+"""
+
 
 # Ordered most to least significant. The first condition that holds
-# decides the exit code.
+# decides the exit code. RATE_LIMITED leads: every code below it
+# describes something the run observed, and none of them can be trusted
+# from a run that could not look.
 _PRECEDENCE: Final[tuple[int, ...]] = (
+    RATE_LIMITED,
     ALLOW_LIST_UNRESOLVED,
     ALLOW_LIST_STALE,
     ACTIONS_OUTDATED,
@@ -124,6 +142,7 @@ _DESCRIPTIONS: Final[dict[int, str]] = {
     ALLOW_LIST_STALE: "Stale allow-list pins",
     ALLOW_LIST_UNRESOLVED: "Allow-list latest release unresolved",
     ACTIONS_OUTDATED: "Outdated action calls",
+    RATE_LIMITED: "Rate-limited; requested checks did not run",
 }
 
 
@@ -133,6 +152,7 @@ __all__ = [
     "ALLOW_LIST_UNRESOLVED",
     "CLI_USAGE_ERROR",
     "DEFECTS_FOUND",
+    "RATE_LIMITED",
     "RUNTIME_ERROR",
     "SUCCESS",
     "combine",

--- a/src/gha_workflow_linter/github_api.py
+++ b/src/gha_workflow_linter/github_api.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import sys
 import time
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -1232,13 +1231,29 @@ class GitHubGraphQLClient:
             and self._rate_limit_info.reset_at > current_time
         )
 
-    def check_rate_limit_and_exit_if_needed(self) -> None:
+    def check_rate_limit(self) -> bool:
         """
-        Synchronously check rate limits and exit if rate limited.
+        Synchronously check rate limits and report the result.
 
-        This method performs a synchronous HTTP request to check rate limits
-        and exits the program if rate limited. Should be called early in the
-        application flow before showing progress bars.
+        This performs a synchronous HTTP request to check rate limits.
+        It is called early, before any progress bar opens, so a caller
+        can decide what to do while it still owes the user nothing.
+
+        Deciding here is not the same as acting here. An earlier version
+        called ``sys.exit(0)`` on discovering a rate limit, which ended
+        the process from inside the API client: before the command
+        dispatched, before any output contract was met, and before the
+        validation that sits after pre-flight could run. A ``--format
+        json`` run emitted no document at all yet exited successfully,
+        which a consumer cannot tell from a crash. Reporting the state
+        and leaving the decision to the caller keeps both the document
+        and the exit code in the hands of the code that promised them.
+
+        Returns:
+            ``True`` when the API reports the client is rate-limited.
+            ``False`` when it is not, and also when the check itself
+            could not run -- a failed check is not evidence of a rate
+            limit, and the async flow reports its own errors later.
         """
         # We can check rate limits even without a token for unauthenticated requests
 
@@ -1276,14 +1291,15 @@ class GitHubGraphQLClient:
                         used=graphql_limits.get("used", 0),
                     )
 
-                    # Check if we're rate limited and exit if so
                     if self._is_rate_limited():
                         self.logger.warning(
                             "GitHub API Rate-limited; Skipping Checks ⚠️"
                         )
-                        sys.exit(0)
+                        return True
 
         except Exception as e:
-            # If we can't check rate limits, log it but don't exit
-            # The async flow will handle errors later
+            # If we can't check rate limits, log it but carry on.
+            # The async flow will handle errors later.
             self.logger.debug(f"Could not check rate limits synchronously: {e}")
+
+        return False

--- a/tests/test_multi_repo_cli.py
+++ b/tests/test_multi_repo_cli.py
@@ -264,6 +264,7 @@ class RecordingRun:
         shared_cache: ValidationCache,
         *,
         collect_json: bool = False,
+        rate_limited: bool = False,
     ) -> RunOutcome:
         """Record one visit and return its configured outcome.
 
@@ -275,6 +276,9 @@ class RecordingRun:
             shared_cache: Cache the driver passed in.
             collect_json: Whether the driver asked for the payload to be
                 collected rather than printed.
+            rate_limited: Whether pre-flight found the API
+                rate-limited. Accepted so the double keeps the real
+                signature; the sweep passes it to every repository.
 
         Returns:
             The outcome configured for this repository.
@@ -972,12 +976,16 @@ class TestMultiRepoCLI:
         write_dependabot_cooldown(tmp_path, 5)
         seen: list[int] = []
 
-        def capture(config: Config, _options: CLIOptions) -> int:
+        def capture(
+            config: Config, _options: CLIOptions, *, rate_limited: bool = False
+        ) -> int:
             """Record the cooldown the command layer resolved.
 
             Args:
                 config: Configuration the command built.
                 _options: Unused.
+                rate_limited: Unused; accepted so the double keeps the
+                    real signature.
 
             Returns:
                 A successful exit code.
@@ -1011,12 +1019,16 @@ class TestMultiRepoCLI:
         write_dependabot_cooldown(tmp_path, 5)
         seen: list[int] = []
 
-        def capture(config: Config, _options: CLIOptions) -> int:
+        def capture(
+            config: Config, _options: CLIOptions, *, rate_limited: bool = False
+        ) -> int:
             """Record the cooldown the command layer resolved.
 
             Args:
                 config: Configuration the command built.
                 _options: Unused.
+                rate_limited: Unused; accepted so the double keeps the
+                    real signature.
 
             Returns:
                 A successful exit code.
@@ -1366,6 +1378,7 @@ class TestSweepJsonOutput:
             _cache: ValidationCache,
             *,
             collect_json: bool = False,
+            rate_limited: bool = False,
         ) -> RunOutcome:
             """Answer with a payload, as a collecting run would.
 


### PR DESCRIPTION
> [!WARNING]
> **Draft: incomplete. Do not merge.** The mechanism works and is
> verified, but one acceptance criterion is unmet, two tests fail, and
> there are no regression tests yet. Raised so the approach is visible
> for review early. Full state and remaining steps are in the handoff
> document; this description mirrors it.
>
> This commit was made with `--no-verify` under explicit maintainer
> permission, because the hooks run the test suite and two doubles
> still fail (see below). **The next commit must not bypass them.**

Addresses #324.

## The decision this implements

The issue leaves open whether "rate-limited, therefore report success"
is the right default. Three options were weighed; **option B** was
chosen: exit `0` for an advisory run, but return a distinct
infrastructure exit code when a `--verify-*` flag was requested.

`exit_codes.py` already draws that distinction for the allow-list
(`ALLOW_LIST_UNRESOLVED = 4`), and its module docstring already says an
infrastructure failure "must never be reported as a pass when
enforcement was requested". A rate-limited preflight is the same class
of event. B keeps the common advisory case at `0`, so a GitHub throttle
cannot break builds across the estate, while giving the weekly sweep the
signal the issue asks for: telling a clean estate from one it never
managed to examine.

Rejected: reporting only a JSON marker, as too weak for the sweep;
always exiting non-zero, as breaking every PR the moment GitHub
throttles.

## What changed

Preflight becomes a query. `check_rate_limit()` returns whether the
client is rate-limited and terminates nothing; a check that *itself*
fails returns `False`, since failing to look is not evidence of a limit.
The status then propagates:

```text
_configure_validation_backend  -> now returns bool
  -> lint command
    -> run_linter(..., rate_limited=)
      -> _run_one_repository(..., rate_limited=)
      |    -> _scan_and_validate(..., rate_limited=)
      |    -> _determine_exit_code(..., rate_limited=)
      -> _run_multi_repo(..., rate_limited=)
           -> _run_repository_in_sweep(...) -> _run_one_repository(...)
```

Two decision points:

- **`_scan_and_validate`** still *scans* when rate-limited, so an
  unreadable path is still reported — the acceptance criterion that
  reordering alone would not satisfy. It returns a `_ValidationOutcome`
  with zero errors rather than short-circuiting, so the rest of the
  pipeline emits its document normally.
- **`_determine_exit_code`** returns `RATE_LIMITED` when rate-limited
  *and* a `--verify-*` flag was passed; otherwise the existing logic
  stands.

`RATE_LIMITED = 6` sits at the **head** of `_PRECEDENCE`: every code
below it describes something the run observed, and none of them can be
claimed by a run that could not look.

## Verified

Driven through `run_linter` against a temporary repository:

| run | exit | JSON |
| --- | --- | --- |
| advisory, rate-limited | `0` SUCCESS | valid, 1155 bytes |
| `--verify-actions`, rate-limited | `6` RATE_LIMITED | valid, 1155 bytes |
| `--verify-allow-list`, rate-limited | `6` RATE_LIMITED | valid, 1155 bytes |

All three previously emitted **nothing** and exited `0`. Also confirmed
`combine(RATE_LIMITED, ALLOW_LIST_UNRESOLVED, DEFECTS_FOUND) == 6`.

## Not done — why this is a draft

1. **The JSON marker, which is the point of the issue.** A rate-limited
   document is currently byte-identical to a clean run, so an
   *advisory* `--format json` consumer — the sweep's own case — still
   cannot distinguish "checks skipped" from "checks found nothing". The
   exit code separates them only under `--verify-*`. Needs a marker in
   `build_json_results` / `output_json_results`, carried through
   `_output_multi_repo_json`.
2. **Two failing tests**, at `2 failed, 1559 passed, 21 skipped` (from
   31 failed). All were one mechanical cause: local doubles for
   `_run_one_repository` not accepting the new keyword, raising
   `TypeError` that the sweep's failure boundary swallows. Four are
   fixed here; two remain —
   `TestSharedCache::test_host_is_resolved_once_for_the_whole_sweep` and
   `TestSweepJsonOutput::test_otherwise_invisible_failures_are_named`.
   They want the explicit keyword, **not** `**kwargs`: the point is that
   signature drift shows up.
3. **No regression tests.** The issue requires driving the rate-limited
   path with the exit behaviour mutated. #325 found three tests in this
   repository that passed against broken code, so the bar is mutation
   verification, including the inverses — a guard that returns
   `RATE_LIMITED` unconditionally, or treats a failed check as a limit,
   must break a test.
4. **No documentation.** `README.md` and `docs/design.md` both list exit
   codes and need `6` plus the precedence change. Note #325 also edits
   `README.md`.

## Relationship to #325

Cut from `main`, deliberately not stacked. The two share **no files** —
#325 touches 12, this touches `cli.py`, `github_api.py`,
`exit_codes.py` — so stacking would avoid no conflict, while
`build-test.yaml` is gated on `branches: [main, master]`, meaning a
stacked PR would run **none** of the 1561 tests. They merge in any
order.
